### PR TITLE
Cache dockerfile generation

### DIFF
--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -20,5 +20,5 @@ depends: [
   "capnp-rpc-unix" {>= "0.5.0"}
   "ocaml-ci-api"
   "conf-libev"
-  "dockerfile"
+  "dockerfile" {>= "6.3.0"}
 ]


### PR DESCRIPTION
This isn't very clever, but it might help a bit. I tried using `lru` instead of this dumb system of wiping the cache when it gets too big, but for some reason that was much slower than having no cache at all!

Another option would be to replace the generic `Docker.build` with a custom build operation. Then we could generate the Dockerfile as part of the build step rather than on every evaluation of the pipeline.