### PR TITLE
Detect dune projects

### DIFF
--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -21,4 +21,5 @@ depends: [
   "ocaml-ci-api"
   "conf-libev"
   "dockerfile" {>= "6.3.0"}
+  "sexplib"
 ]

--- a/service/analyse.ml
+++ b/service/analyse.ml
@@ -103,9 +103,9 @@ module Examine = struct
           Ok (Some v)
       | _ -> Error (`Msg "Unable to parse .ocamlformat file")
 
-  let get_ocamlformat_version ~opam_files job root =
-    let proj_is_ocamlformat p = Filename.basename p = "ocamlformat.opam" in
-    if List.exists proj_is_ocamlformat opam_files then
+  let get_ocamlformat_version ~projects job root =
+    let proj_is_ocamlformat p = p.Value.project_name = Some "ocamlformat" in
+    if List.exists proj_is_ocamlformat projects then
       Lwt.return (Some Value.Vendored)
     else
       Fpath.(to_string (root / ".ocamlformat")) |> ocamlformat_version_from_file job
@@ -179,7 +179,7 @@ module Examine = struct
               Some path
         )
     in
-    get_ocamlformat_version ~opam_files job tmpdir >>= fun ocamlformat_version ->
+    get_ocamlformat_version ~projects job tmpdir >>= fun ocamlformat_version ->
     let r = { Value.opam_files; is_duniverse; ocamlformat_version; projects } in
     Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (Value.to_yojson r);
     if opam_files = [] then Lwt_result.fail (`Msg "No opam files found!")

--- a/service/analyse.mli
+++ b/service/analyse.mli
@@ -1,9 +1,11 @@
 module Analysis : sig
+  type ocamlformat_version = Version of string | Vendored
+
   type t
 
   val opam_files : t -> string list
   val is_duniverse : t -> bool
-  val ocamlformat_version : t -> string option
+  val ocamlformat_version : t -> ocamlformat_version option
 end
 
 val examine : Current_git.Commit.t Current.t -> Analysis.t Current.t

--- a/service/analyse.mli
+++ b/service/analyse.mli
@@ -1,11 +1,18 @@
 module Analysis : sig
   type ocamlformat_version = Version of string | Vendored
 
+  (** A project is a directory with a dune-project file in it *)
+  type project = {
+    project_path : string;
+    project_name : string option; (** The (name ..) field *)
+  }
+
   type t
 
   val opam_files : t -> string list
   val is_duniverse : t -> bool
   val ocamlformat_version : t -> ocamlformat_version option
+  val projects : t -> project list
 end
 
 val examine : Current_git.Commit.t Current.t -> Analysis.t Current.t

--- a/service/dune
+++ b/service/dune
@@ -15,5 +15,6 @@
             nocrypto.lwt
             ocaml_ci
             ocaml-ci-api
-            prometheus)
+            prometheus
+            sexplib)
  (preprocess (pps ppx_deriving_yojson)))

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -1,9 +1,14 @@
 module Docker = Conf.Builder_amd1
 
-val v_from_opam :
-  ocamlformat_version:string Current.t ->
+type ocamlformat_version = [
+  | `Vendored (** OCamlformat is vendored, don't install it via opam *)
+  | `Version of string (** Which version of OCamlformat to use *)
+]
+
+val ocamlformat :
+  ocamlformat_version:ocamlformat_version Current.t ->
   base:Docker.Image.t Current.t ->
   src:Current_git.Commit.t Current.t ->
   unit Current.t
-(** [v ~ocamlformat_version ~base ~src] runs a Dune linting check on [src] via
-    the base image [base] with OPAM installed. *)
+(** [ocamlformat ~ocamlformat_version ~base ~src] runs an OCamlformat check
+    using Dune. See [ocamlformat_version] for details. *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -44,13 +44,19 @@ let job_id x =
   Current.Analysis.job_id job
 
 let lint ~analysis ~src =
+  let base =
+    Conf.Builder_amd1.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
+  in
   analysis
   |> Current.map Analyse.Analysis.ocamlformat_version
   |> Current.option_map (fun ocamlformat_version ->
-      let base =
-        Conf.Builder_amd1.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
+      let ocamlformat_version =
+        let+ v = ocamlformat_version in
+        match v with
+        | Analyse.Analysis.Vendored -> `Vendored
+        | Version v -> `Version v
       in
-      Lint.v_from_opam ~ocamlformat_version ~base ~src
+      Lint.ocamlformat ~ocamlformat_version ~base ~src
     )
   |> Current.map (function
       | Some () -> `Checked


### PR DESCRIPTION
Hi !

This PR adds detection of `dune-project` files and parse them using Sexplib.

This is usefull in a follow-up PR to detect if OCamlformat is vendored, to avoid installing it from Opam or failing on the version check.

Sexplib was already an indirect dependency. I choose to parse `dune-project` files instead of just looking at `.opam` files because we may need other fields in the future (eg. dune's version for formatting).

Thanks !