### PR TITLE
Support vendored ocamlformat

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -20,7 +20,7 @@ let ( >>!= ) = Lwt_result.bind
 
 module Analysis = struct
   type ocamlformat_version = Analyse_ocamlformat.version = Version of string | Vendored
-  [@@deriving yojson]
+  [@@deriving yojson,eq]
 
   type t = {
     is_duniverse : bool;

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -71,7 +71,7 @@ module Analysis = struct
     in
     (* [opam_files] are used to detect vendored OCamlformat but this only works
        with duniverse, as other opam files are filtered above. *)
-    Analyse_ocamlformat.get_ocamlformat_source job ~opam_files dir >>= fun ocamlformat_source ->
+    Analyse_ocamlformat.get_ocamlformat_source job ~opam_files ~root:dir >>= fun ocamlformat_source ->
     let r = { opam_files; is_duniverse; ocamlformat_source } in
     Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (to_yojson r);
     if opam_files = [] then Lwt_result.fail (`Msg "No opam files found!")

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -69,6 +69,8 @@ module Analysis = struct
             else None
         )
     in
+    (* [opam_files] are used to detect vendored OCamlformat but this only works
+       with duniverse, as other opam files are filtered above. *)
     Analyse_ocamlformat.get_ocamlformat_source job ~opam_files dir >>= fun ocamlformat_source ->
     let r = { opam_files; is_duniverse; ocamlformat_source } in
     Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (to_yojson r);

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -19,7 +19,9 @@ let is_toplevel path = not (String.contains path '/')
 let ( >>!= ) = Lwt_result.bind
 
 module Analysis = struct
-  type ocamlformat_version = Analyse_ocamlformat.version = Version of string | Vendored
+  type ocamlformat_version = Analyse_ocamlformat.version =
+    | Version of string
+    | Vendored of string
   [@@deriving yojson,eq]
 
   type t = {

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,12 +1,9 @@
 module Analysis : sig
-  type ocamlformat_version = Version of string | Vendored of string
-  [@@deriving yojson, eq]
-
   type t
 
   val opam_files : t -> string list
   val is_duniverse : t -> bool
-  val ocamlformat_version : t -> ocamlformat_version option
+  val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
   val of_dir : job:Current.Job.t -> Fpath.t -> (t, [ `Msg of string ]) result Lwt.t
 end

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,5 +1,5 @@
 module Analysis : sig
-  type ocamlformat_version = Version of string | Vendored
+  type ocamlformat_version = Version of string | Vendored of string
   [@@deriving yojson, eq]
 
   type t

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,9 +1,11 @@
 module Analysis : sig
+  type ocamlformat_version = Version of string | Vendored
+
   type t
 
   val opam_files : t -> string list
   val is_duniverse : t -> bool
-  val ocamlformat_version : t -> string option
+  val ocamlformat_version : t -> ocamlformat_version option
 
   val of_dir : job:Current.Job.t -> Fpath.t -> (t, [ `Msg of string ]) result Lwt.t
 end

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,5 +1,6 @@
 module Analysis : sig
   type ocamlformat_version = Version of string | Vendored
+  [@@deriving yojson, eq]
 
   type t
 

--- a/lib/analyse_ocamlformat.ml
+++ b/lib/analyse_ocamlformat.ml
@@ -47,7 +47,7 @@ let ocamlformat_version_from_file job path =
         Ok (Some v)
     | _ -> Error (`Msg "Unable to parse .ocamlformat file")
 
-let get_ocamlformat_source job ~opam_files root =
+let get_ocamlformat_source job ~opam_files ~root =
   let proj_is_ocamlformat p = String.equal (Filename.basename p) "ocamlformat.opam" in
   match List.find_opt proj_is_ocamlformat opam_files with
   | Some opam_file ->

--- a/lib/analyse_ocamlformat.ml
+++ b/lib/analyse_ocamlformat.ml
@@ -48,7 +48,7 @@ let ocamlformat_version_from_file job path =
     | _ -> Error (`Msg "Unable to parse .ocamlformat file")
 
 let get_ocamlformat_source job ~opam_files root =
-  let proj_is_ocamlformat p = Filename.basename p = "ocamlformat.opam" in
+  let proj_is_ocamlformat p = String.equal (Filename.basename p) "ocamlformat.opam" in
   match List.find_opt proj_is_ocamlformat opam_files with
   | Some opam_file ->
     let path = Filename.dirname opam_file in

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -4,5 +4,5 @@ type source =
 [@@deriving yojson,eq]
 
 val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> Fpath.t -> source option Lwt.t
-(** Detect the required version of ocamlformat or if it's vendored.
+(** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,6 +1,6 @@
 type source =
   | Opam of { version : string } (** Should install OCamlformat from Opam. *)
-  | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative from the project's root. *)
+  | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative to the project's root. *)
 [@@deriving yojson,eq]
 
 val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> Fpath.t -> source option Lwt.t

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,2 +1,3 @@
+type version = Version of string | Vendored
 
-val get_ocamlformat_version : Current.Job.t -> Fpath.t -> string option Lwt.t
+val get_ocamlformat_version : opam_files:string list -> Current.Job.t -> Fpath.t -> version option Lwt.t

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -4,4 +4,5 @@ type source =
 [@@deriving yojson,eq]
 
 val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> Fpath.t -> source option Lwt.t
-(** Detect the required version of ocamlformat or if it's vendored. *)
+(** Detect the required version of ocamlformat or if it's vendored.
+    Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -3,6 +3,6 @@ type source =
   | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative to the project's root. *)
 [@@deriving yojson,eq]
 
-val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> Fpath.t -> source option Lwt.t
+val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> root:Fpath.t -> source option Lwt.t
 (** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,3 +1,7 @@
-type version = Version of string | Vendored of string
+type source =
+  | Opam of { version : string } (** Should install OCamlformat from Opam. *)
+  | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative from the project's root. *)
+[@@deriving yojson,eq]
 
-val get_ocamlformat_version : opam_files:string list -> Current.Job.t -> Fpath.t -> version option Lwt.t
+val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> Fpath.t -> source option Lwt.t
+(** Detect the required version of ocamlformat or if it's vendored. *)

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,3 +1,3 @@
-type version = Version of string | Vendored
+type version = Version of string | Vendored of string
 
 val get_ocamlformat_version : opam_files:string list -> Current.Job.t -> Fpath.t -> version option Lwt.t

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -1,25 +1,20 @@
 open Current.Syntax
 module Docker = Conf.Builder_amd1
 
-type ocamlformat_version = [
-  | `Vendored of string
-  | `Version of string
-]
-
-let ocamlformat ~ocamlformat_version ~base ~src =
+let ocamlformat ~ocamlformat_source ~base ~src =
   let dockerfile =
     let open Dockerfile in
     let+ base = base
     and+ install_ocamlformat =
-      let+ ocamlformat_version = ocamlformat_version in
-      match ocamlformat_version with
-      | `Vendored path ->
+      let+ ocamlformat_source = ocamlformat_source in
+      match ocamlformat_source with
+      | Ocaml_ci.Analyse_ocamlformat.Vendored { path } ->
         run "opam pin add -yn ocamlformat %S" path
         @@ run "opam depext ocamlformat"
         @@ run "opam install --deps-only -y ocamlformat"
-      | `Version v ->
-        run "opam depext ocamlformat=%s" v
-        @@ run "opam install ocamlformat=%s" v
+      | Opam { version } ->
+        run "opam depext ocamlformat=%s" version
+        @@ run "opam install ocamlformat=%s" version
     in
     from (Docker.Image.hash base)
     @@ run "opam install dune" (* Not the dune version the project use *)

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -1,27 +1,28 @@
 open Current.Syntax
 module Docker = Conf.Builder_amd1
 
+let ocamlformat_dockerfile ~base ~ocamlformat_source =
+  let open Dockerfile in
+  let install_ocamlformat =
+    match ocamlformat_source with
+    | Ocaml_ci.Analyse_ocamlformat.Vendored { path } ->
+      run "opam pin add -yn ocamlformat %S" path
+      @@ run "opam depext ocamlformat"
+      @@ run "opam install --deps-only -y ocamlformat"
+    | Opam { version } ->
+      run "opam depext ocamlformat=%s" version
+      @@ run "opam install ocamlformat=%s" version
+  in
+  from (Docker.Image.hash base)
+  @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
+  @@ workdir "src"
+  @@ install_ocamlformat
+  @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
+
 let v_fmt ~ocamlformat_source ~base ~src =
   let dockerfile =
-    let open Dockerfile in
-    let+ base = base
-    and+ install_ocamlformat =
-      let+ ocamlformat_source = ocamlformat_source in
-      match ocamlformat_source with
-      | Ocaml_ci.Analyse_ocamlformat.Vendored { path } ->
-        run "opam pin add -yn ocamlformat %S" path
-        @@ run "opam depext ocamlformat"
-        @@ run "opam install --deps-only -y ocamlformat"
-      | Opam { version } ->
-        run "opam depext ocamlformat=%s" version
-        @@ run "opam install ocamlformat=%s" version
-    in
-    from (Docker.Image.hash base)
-    @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
-    @@ workdir "src"
-    @@ install_ocamlformat
-    @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
-  in
+    let+ base = base and+ ocamlformat_source = ocamlformat_source in
+    ocamlformat_dockerfile ~base ~ocamlformat_source in
   let img =
     Docker.build ~label:"OCamlformat" ~pool:Docker.pool ~pull:false ~dockerfile (`Git src)
   in

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -25,7 +25,7 @@ let ocamlformat ~ocamlformat_version ~base ~src =
     @@ run "opam install dune" (* Not the dune version the project use *)
     @@ workdir "src"
     @@ install_ocamlformat
-    @@ copy ~chown:"opam" ~src:["./"] ~dst:"./src" ()
+    @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
   in
   let img =
     Docker.build ~label:"OCamlformat" ~pool:Docker.pool ~pull:false ~dockerfile (`Git src)

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -1,7 +1,7 @@
 open Current.Syntax
 module Docker = Conf.Builder_amd1
 
-let ocamlformat ~ocamlformat_source ~base ~src =
+let v_fmt ~ocamlformat_source ~base ~src =
   let dockerfile =
     let open Dockerfile in
     let+ base = base

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -2,7 +2,7 @@ open Current.Syntax
 module Docker = Conf.Builder_amd1
 
 type ocamlformat_version = [
-  | `Vendored
+  | `Vendored of string
   | `Version of string
 ]
 
@@ -13,16 +13,19 @@ let ocamlformat ~ocamlformat_version ~base ~src =
     and+ install_ocamlformat =
       let+ ocamlformat_version = ocamlformat_version in
       match ocamlformat_version with
-      | `Vendored -> empty
+      | `Vendored path ->
+        run "opam pin add -yn ocamlformat %S" path
+        @@ run "opam depext ocamlformat"
+        @@ run "opam install --deps-only -y ocamlformat"
       | `Version v ->
         run "opam depext ocamlformat=%s" v
         @@ run "opam install ocamlformat=%s" v
     in
     from (Docker.Image.hash base)
     @@ run "opam install dune" (* Not the dune version the project use *)
+    @@ workdir "src"
     @@ install_ocamlformat
     @@ copy ~chown:"opam" ~src:["./"] ~dst:"./src" ()
-    @@ workdir "src"
   in
   let img =
     Docker.build ~label:"OCamlformat" ~pool:Docker.pool ~pull:false ~dockerfile (`Git src)

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -17,7 +17,7 @@ let ocamlformat ~ocamlformat_source ~base ~src =
         @@ run "opam install ocamlformat=%s" version
     in
     from (Docker.Image.hash base)
-    @@ run "opam install dune" (* Not the dune version the project use *)
+    @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
     @@ workdir "src"
     @@ install_ocamlformat
     @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -1,12 +1,7 @@
 module Docker = Conf.Builder_amd1
 
-type ocamlformat_version = [
-  | `Vendored of string (** OCamlformat is vendored, don't install it via opam *)
-  | `Version of string (** Which version of OCamlformat to use *)
-]
-
 val ocamlformat :
-  ocamlformat_version:ocamlformat_version Current.t ->
+  ocamlformat_source:Ocaml_ci.Analyse_ocamlformat.source Current.t ->
   base:Docker.Image.t Current.t ->
   src:Current_git.Commit.t Current.t ->
   unit Current.t

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -1,10 +1,11 @@
 module Docker = Conf.Builder_amd1
 
-val ocamlformat :
+val v_fmt :
   ocamlformat_source:Ocaml_ci.Analyse_ocamlformat.source Current.t ->
   base:Docker.Image.t Current.t ->
   src:Current_git.Commit.t Current.t ->
   unit Current.t
-(** [ocamlformat ~ocamlformat_source ~base ~src] runs an OCamlformat check
-    using Dune. [ocamlformat_source] tells if OCamlformat is vendored or should
-    be installed from Opam. The base image [base] should have OPAM installed. *)
+(** [v_fmt ~ocamlformat_source ~base ~src] ensures OCamlformat is installed and
+    runs "dune build @fmt". [ocamlformat_source] tells if OCamlformat is
+    vendored or should be installed from Opam.
+    The base image [base] should have OPAM installed. *)

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -1,7 +1,7 @@
 module Docker = Conf.Builder_amd1
 
 type ocamlformat_version = [
-  | `Vendored (** OCamlformat is vendored, don't install it via opam *)
+  | `Vendored of string (** OCamlformat is vendored, don't install it via opam *)
   | `Version of string (** Which version of OCamlformat to use *)
 ]
 

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -1,9 +1,14 @@
 module Docker = Conf.Builder_amd1
 
-val v_from_opam :
-  ocamlformat_version:string Current.t ->
+type ocamlformat_version = [
+  | `Vendored (** OCamlformat is vendored, don't install it via opam *)
+  | `Version of string (** Which version of OCamlformat to use *)
+]
+
+val ocamlformat :
+  ocamlformat_version:ocamlformat_version Current.t ->
   base:Docker.Image.t Current.t ->
   src:Current_git.Commit.t Current.t ->
   unit Current.t
-(** [v ~ocamlformat_version ~base ~src] runs a Dune linting check on [src] via
-    the base image [base] with OPAM installed. *)
+(** [ocamlformat ~ocamlformat_version ~base ~src] runs an OCamlformat check
+    using Dune. See [ocamlformat_version] for details. *)

--- a/service/lint.mli
+++ b/service/lint.mli
@@ -5,5 +5,6 @@ val ocamlformat :
   base:Docker.Image.t Current.t ->
   src:Current_git.Commit.t Current.t ->
   unit Current.t
-(** [ocamlformat ~ocamlformat_version ~base ~src] runs an OCamlformat check
-    using Dune. See [ocamlformat_version] for details. *)
+(** [ocamlformat ~ocamlformat_source ~base ~src] runs an OCamlformat check
+    using Dune. [ocamlformat_source] tells if OCamlformat is vendored or should
+    be installed from Opam. The base image [base] should have OPAM installed. *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -53,7 +53,7 @@ let lint ~analysis ~src =
       let ocamlformat_version =
         let+ v = ocamlformat_version in
         match v with
-        | Analyse.Analysis.Vendored -> `Vendored
+        | Analyse.Analysis.Vendored path -> `Vendored path
         | Version v -> `Version v
       in
       Lint.ocamlformat ~ocamlformat_version ~base ~src

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -50,7 +50,7 @@ let lint ~analysis ~src =
   analysis
   |> Current.map Analyse.Analysis.ocamlformat_source
   |> Current.option_map (fun ocamlformat_source ->
-      Lint.ocamlformat ~ocamlformat_source ~base ~src
+      Lint.v_fmt ~ocamlformat_source ~base ~src
     )
   |> Current.map (function
       | Some () -> `Checked

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -48,15 +48,9 @@ let lint ~analysis ~src =
     Conf.Builder_amd1.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
   in
   analysis
-  |> Current.map Analyse.Analysis.ocamlformat_version
-  |> Current.option_map (fun ocamlformat_version ->
-      let ocamlformat_version =
-        let+ v = ocamlformat_version in
-        match v with
-        | Analyse.Analysis.Vendored path -> `Vendored path
-        | Version v -> `Version v
-      in
-      Lint.ocamlformat ~ocamlformat_version ~base ~src
+  |> Current.map Analyse.Analysis.ocamlformat_source
+  |> Current.option_map (fun ocamlformat_source ->
+      Lint.ocamlformat ~ocamlformat_source ~base ~src
     )
   |> Current.map (function
       | Some () -> `Checked

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -44,13 +44,19 @@ let job_id x =
   Current.Analysis.job_id job
 
 let lint ~analysis ~src =
+  let base =
+    Conf.Builder_amd1.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
+  in
   analysis
   |> Current.map Analyse.Analysis.ocamlformat_version
   |> Current.option_map (fun ocamlformat_version ->
-      let base =
-        Conf.Builder_amd1.pull ~schedule:weekly "ocurrent/opam:alpine-3.10-ocaml-4.08"
+      let ocamlformat_version =
+        let+ v = ocamlformat_version in
+        match v with
+        | Analyse.Analysis.Vendored -> `Vendored
+        | Version v -> `Version v
       in
-      Lint.v_from_opam ~ocamlformat_version ~base ~src
+      Lint.ocamlformat ~ocamlformat_version ~base ~src
     )
   |> Current.map (function
       | Some () -> `Checked

--- a/test/gen_project.ml
+++ b/test/gen_project.ml
@@ -32,6 +32,8 @@ let ocamlformat ~version ppf =
 profile = conventional
   |} version
 
+let empty_file _ppf = ()
+
 (* Project generation logic *)
 
 type file = Folder of string * file list | File of string * contents

--- a/test/gen_project.mli
+++ b/test/gen_project.mli
@@ -10,5 +10,8 @@ val opam : contents
 val ocamlformat : version:string -> contents
 (** Contents of a [.ocamlformat] file with a particular version *)
 
+val empty_file : contents
+(** An empty file *)
+
 val instantiate : root:string -> file list -> unit
 (** Take a directory specification and persist it to disk *)


### PR DESCRIPTION
~~Rebased on top of https://github.com/ocurrent/ocaml-ci/pull/77~~

To avoid installing OCamlformat and having to parse its version from the `.ocamlformat` file.
Projects that have OCamlformat vendored (eg. OCamlformat itself) may not set a `version`.