### PR TITLE
Fix support for duniverse projects

### DIFF
--- a/service/opam_build.ml
+++ b/service/opam_build.ml
@@ -25,7 +25,7 @@ let group_opam_files =
   ListLabels.fold_left ~init:[] ~f:(fun acc x ->
       let item = Fpath.v x in
       let dir = Fpath.parent item in
-      let pkg = (Filename.basename x |> Filename.chop_extension) ^ ".dev" in
+      let pkg = Filename.basename x |> Filename.chop_extension in
       match acc with
       | (prev_dir, prev_items, pkgs) :: rest when Fpath.equal dir prev_dir -> (prev_dir, x :: prev_items, pkg :: pkgs) :: rest
       | _ -> (dir, [x], [pkg]) :: acc

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -78,14 +78,14 @@ let build_with_docker ~repo ~analysis src =
   let lint_result = lint ~analysis ~src in
   [
     (* Compiler versions:*)
-    "4.02", build (module Conf.Builder_amd2) "debian-10-ocaml-4.02";
-    "4.03", build (module Conf.Builder_amd2) "debian-10-ocaml-4.03";
-    "4.04", build (module Conf.Builder_amd3) "debian-10-ocaml-4.04";
-    "4.05", build (module Conf.Builder_amd3) "debian-10-ocaml-4.05";
-    "4.06", build (module Conf.Builder_amd2) "debian-10-ocaml-4.06";
-    "4.07", build (module Conf.Builder_amd2) "debian-10-ocaml-4.07";
-    "4.08", build (module Conf.Builder_amd1) "debian-10-ocaml-4.08";
     "4.09", build (module Conf.Builder_amd3) "debian-10-ocaml-4.09";
+    "4.08", build (module Conf.Builder_amd1) "debian-10-ocaml-4.08";
+    "4.07", build (module Conf.Builder_amd2) "debian-10-ocaml-4.07";
+    "4.06", build (module Conf.Builder_amd2) "debian-10-ocaml-4.06";
+    "4.05", build (module Conf.Builder_amd3) "debian-10-ocaml-4.05";
+    "4.04", build (module Conf.Builder_amd3) "debian-10-ocaml-4.04";
+    "4.03", build (module Conf.Builder_amd2) "debian-10-ocaml-4.03";
+    "4.02", build (module Conf.Builder_amd2) "debian-10-ocaml-4.02";
     (* Distributions: *)
     "alpine", build (module Conf.Builder_amd1) @@ "alpine-3.10-ocaml-" ^ default_compiler;
     "ubuntu", build (module Conf.Builder_amd2) @@ "ubuntu-19.04-ocaml-" ^ default_compiler;


### PR DESCRIPTION
This enables duniverse projects (such as https://github.com/ocamllabs/duniverse, and soon https://github.com/realworldocaml/book) to work with ocaml-ci with zero configuration.  See the commits for an explanation of individual changes.