### PR TITLE
Fix vendored ocamlformat dependencies installation

### DIFF
--- a/service/lint.ml
+++ b/service/lint.ml
@@ -3,25 +3,25 @@ module Docker = Conf.Builder_amd1
 
 let ocamlformat_dockerfile ~base ~ocamlformat_source =
   let open Dockerfile in
-  let copy_files =
-    copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
-  in
-  let install_ocamlformat_and_copy_files =
+  let install_ocamlformat =
     match ocamlformat_source with
     | Ocaml_ci.Analyse_ocamlformat.Vendored { path } ->
-      copy_files
-      @@ run "opam pin add -yn ocamlformat %S" path
+      let opam_file = Filename.concat path "ocamlformat.opam" in
+      copy ~chown:"opam" ~src:[ opam_file ] ~dst:opam_file ()
+      @@ run "opam pin add -k none -yn ocamlformat %S" path
+      (* Only the opam file is necessary to install the deps
+         [-k none] above ensures that opam doesn't try to make an installable package *)
       @@ run "opam depext ocamlformat"
       @@ run "opam install --deps-only -y ocamlformat"
     | Opam { version } ->
       run "opam depext ocamlformat=%s" version
       @@ run "opam install ocamlformat=%s" version
-      @@ copy_files
   in
   from (Docker.Image.hash base)
   @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
   @@ workdir "src"
-  @@ install_ocamlformat_and_copy_files
+  @@ install_ocamlformat
+  @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
 
 let v_fmt ~ocamlformat_source ~base ~src =
   let dockerfile =

--- a/service/lint.ml
+++ b/service/lint.ml
@@ -3,21 +3,25 @@ module Docker = Conf.Builder_amd1
 
 let ocamlformat_dockerfile ~base ~ocamlformat_source =
   let open Dockerfile in
-  let install_ocamlformat =
+  let copy_files =
+    copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
+  in
+  let install_ocamlformat_and_copy_files =
     match ocamlformat_source with
     | Ocaml_ci.Analyse_ocamlformat.Vendored { path } ->
-      run "opam pin add -yn ocamlformat %S" path
+      copy_files
+      @@ run "opam pin add -yn ocamlformat %S" path
       @@ run "opam depext ocamlformat"
       @@ run "opam install --deps-only -y ocamlformat"
     | Opam { version } ->
       run "opam depext ocamlformat=%s" version
       @@ run "opam install ocamlformat=%s" version
+      @@ copy_files
   in
   from (Docker.Image.hash base)
   @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
   @@ workdir "src"
-  @@ install_ocamlformat
-  @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
+  @@ install_ocamlformat_and_copy_files
 
 let v_fmt ~ocamlformat_source ~base ~src =
   let dockerfile =


### PR DESCRIPTION
Introduced in https://github.com/ocurrent/ocaml-ci/pull/78

We were trying to run `opam pin` on an empty directory, the dependencies of OCamlformat's last version would be installed instead.
