### PR TITLE
Add OCaml 4.10 to the build matrix

### DIFF
--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -78,6 +78,7 @@ let build_with_docker ~repo ~analysis src =
   let lint_result = lint ~analysis ~src in
   [
     (* Compiler versions:*)
+    "4.10", build (module Conf.Builder_amd1) "debian-10-ocaml-4.10";
     "4.09", build (module Conf.Builder_amd3) "debian-10-ocaml-4.09";
     "4.08", build (module Conf.Builder_amd1) "debian-10-ocaml-4.08";
     "4.07", build (module Conf.Builder_amd2) "debian-10-ocaml-4.07";


### PR DESCRIPTION
In the effort to have the most packages available and tested on OCaml 4.10 at or before its release here is my proposal to add it to the build matrix of ocaml-ci. This is for instance needed for `mdx` and other packages (see https://github.com/realworldocaml/mdx/pull/204)