### PR TITLE
Add support for status badges using shields.io API

### DIFF
--- a/.ocamlformat-enable
+++ b/.ocamlformat-enable
@@ -1,3 +1,5 @@
+web-ui/badges.ml*
+
 test/test.ml*
 test/test_analyse.ml*
 test/gen_project.ml*

--- a/api/client.ml
+++ b/api/client.ml
@@ -115,13 +115,11 @@ module Commit = struct
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     >>= (Results.status_get
-         >> Raw.Reader.JobInfo.state_get
-         >> Raw.Reader.JobInfo.State.get
          >> function
            | NotStarted -> Ok (`Not_started)
            | Passed -> Ok (`Passed)
-           | Failed _ | Aborted -> Ok (`Failed)
-           | Active -> Ok (`Pending)
+           | Failed -> Ok (`Failed)
+           | Pending -> Ok (`Pending)
            | Undefined i -> Error (`Msg (Fmt.strf "client.states: undefined state %d" i))
         )
 end

--- a/api/client.mli
+++ b/api/client.mli
@@ -27,6 +27,9 @@ module Commit : sig
 
   val refs : t -> (git_ref list, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
   (** [refs t] is the list of Git references that have this commit as their head. *)
+
+  val status : t -> ([ `Not_started | `Pending | `Failed | `Passed ], [> `Capnp of Capnp_rpc.Error.t | `Msg of string]) Lwt_result.t
+  (** [status t] is the result of the most-recent 'summarise' step on this commit. *)
 end
 
 module Repo : sig

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -7,6 +7,13 @@ struct RefInfo {
   hash @1 :Text;
 }
 
+enum BuildStatus {
+  notStarted @0;
+  passed     @1;
+  failed     @2;
+  pending    @3;
+}
+
 struct JobInfo {
   variant @0 :Text;
   state :union {
@@ -35,7 +42,7 @@ interface Commit {
   refs @2 (hash :Text) -> (refs :List(Text));
   # Get the set of branches and PRs with this commit at their head.
 
-  status @3 () -> (status :JobInfo);
+  status @3 () -> (status :BuildStatus);
 }
 
 interface Repo {

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -34,6 +34,8 @@ interface Commit {
 
   refs @2 (hash :Text) -> (refs :List(Text));
   # Get the set of branches and PRs with this commit at their head.
+
+  status @3 () -> (status :JobInfo);
 }
 
 interface Repo {

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.11)
+(using fmt 1.0)

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -107,13 +107,13 @@ let get_job_ids t ~owner ~name ~hash =
 let get_status ~owner ~name ~hash =
   let t = Lazy.force db in
   let open Sqlite3.Data in
-  Db.query t.get_status [ TEXT owner; TEXT name; TEXT hash ]
+  Db.query_some t.get_status [ TEXT owner; TEXT name; TEXT hash ]
   |> function
-    | [ [ INT 0L ] ] -> `Pending
-    | [ [ INT 1L ] ] -> `Failed
-    | [ [ INT 2L ] ] -> `Passed
-    | [ [] ] -> `Not_started
-    | rows -> Fmt.failwith "get_status: invalid rows %a" Fmt.(list ~sep:cut Db.dump_row) rows
+    | Some [ INT 0L ] -> `Pending
+    | Some [ INT 1L ] -> `Failed
+    | Some [ INT 2L ] -> `Passed
+    | None -> `Not_started
+    | Some row -> Fmt.failwith "get_status: invalid rows %a" Db.dump_row row
 
 let record ~repo ~hash ~status jobs =
   let { Current_github.Repo_id.owner; name } = repo in

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -4,7 +4,12 @@
 
 type job_state = [`Not_started | `Active | `Failed of string | `Passed | `Aborted ] [@@deriving show]
 
-val record : repo:Current_github.Repo_id.t -> hash:string -> (string * Current.job_id option) list -> unit
+val record :
+  repo:Current_github.Repo_id.t ->
+  hash:string ->
+  status:[ `Pending | `Failed | `Passed ] ->
+  (string * Current.job_id option) list ->
+  unit
 (** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
 
 val is_known_owner : string -> bool
@@ -24,6 +29,13 @@ val get_jobs : owner:string -> name:string -> string -> (string * job_state) lis
 
 val get_job : owner:string -> name:string -> hash:string -> variant:string -> (string option, [> `No_such_variant]) result
 (** [get_job ~owner ~name ~variant] is the last known job ID for this combination. *)
+
+val get_status:
+  owner:string ->
+  name:string ->
+  hash:string ->
+  [ `Not_started | `Pending | `Failed | `Passed ]
+(** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
 
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -1,13 +1,16 @@
 (** The index is:
     - A map from active Git references to the Git commit at their heads.
+    - A map from project builds ([owner * name * hash)] triples) to statuses.
     - A (persisted) map from each Git commit hash to its last known OCurrent job ID. *)
 
 type job_state = [`Not_started | `Active | `Failed of string | `Passed | `Aborted ] [@@deriving show]
 
+type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
+
 val record :
   repo:Current_github.Repo_id.t ->
   hash:string ->
-  status:[ `Pending | `Failed | `Passed ] ->
+  status:build_status ->
   (string * Current.job_id option) list ->
   unit
 (** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
@@ -34,7 +37,7 @@ val get_status:
   owner:string ->
   name:string ->
   hash:string ->
-  [ `Not_started | `Pending | `Failed | `Passed ]
+  build_status
 (** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
 
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -60,15 +60,12 @@ let make_commit ~engine ~owner ~name hash =
       let open Commit.Status in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      let status = Results.status_init results in
-      let state = Raw.Builder.JobInfo.state_init status in
-      let module S = Raw.Builder.JobInfo.State in
       Index.get_status ~owner ~name ~hash
       |> (function
-          | `Not_started -> S.not_started_set state
-          | `Pending -> S.active_set state
-          | `Failed -> S.failed_set state "Summarise job failed"
-          | `Passed -> S.passed_set state
+          | `Not_started -> Results.status_set results NotStarted
+          | `Pending -> Results.status_set results Pending
+          | `Failed -> Results.status_set results Failed
+          | `Passed -> Results.status_set results  Passed
          );
       Service.return response
   end

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -169,14 +169,14 @@ let v ~app () =
                )
              |> Current.list_seq
   in
-  let summarise =
+  let summary =
     builds
     |> List.map (fun (variant, (build, _job)) -> variant, build)
     |> summarise
   in
   let status =
-    let+ summarise = summarise in
-    match summarise with
+    let+ summary = summary in
+    match summary with
     | Ok () -> `Passed
     | Error (`Active `Running) -> `Pending
     | Error (`Msg _) -> `Failed
@@ -190,7 +190,7 @@ let v ~app () =
     let hash = Current_github.Api.Commit.hash commit in
     Index.record ~repo ~hash ~status @@ ("(analysis)", analysis) :: jobs
   and set_github_status =
-    summarise
+    summary
     |> github_status_of_state ~head
     |> Github.Api.Commit.set_status head "ocaml-ci"
   in

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -169,19 +169,29 @@ let v ~app () =
                )
              |> Current.list_seq
   in
-  let index =
-    let+ commit = head
-    and+ analysis = job_id analysis
-    and+ jobs = jobs in
-    let repo = Current_github.Api.Commit.repo_id commit in
-    let hash = Current_github.Api.Commit.hash commit in
-    Index.record ~repo ~hash @@ ("(analysis)", analysis) :: jobs
-  in
-  let set_status =
+  let summarise =
     builds
     |> List.map (fun (variant, (build, _job)) -> variant, build)
     |> summarise
+  in
+  let status =
+    let+ summarise = summarise in
+    match summarise with
+    | Ok () -> `Passed
+    | Error (`Active `Running) -> `Pending
+    | Error (`Msg _) -> `Failed
+  in
+  let index =
+    let+ commit = head
+    and+ analysis = job_id analysis
+    and+ jobs = jobs
+    and+ status = status in
+    let repo = Current_github.Api.Commit.repo_id commit in
+    let hash = Current_github.Api.Commit.hash commit in
+    Index.record ~repo ~hash ~status @@ ("(analysis)", analysis) :: jobs
+  and set_github_status =
+    summarise
     |> github_status_of_state ~head
     |> Github.Api.Commit.set_status head "ocaml-ci"
   in
-  Current.all [index; set_status]
+  Current.all [index; set_github_status]

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,5 +1,3 @@
 let () =
-  Alcotest.run "ocaml-ci" [
-    ("index", Test_index.tests);
-    ("analyse", Test_analyse.tests)
-  ]
+  Alcotest.run "ocaml-ci"
+    [ ("index", Test_index.tests); ("analyse", Test_analyse.tests) ]

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -6,7 +6,7 @@ module Analysis = struct
   type ocamlformat_source = Ocaml_ci.Analyse_ocamlformat.source =
     | Opam of { version : string }
     | Vendored of { path : string }
-  [@@deriving yojson,eq]
+  [@@deriving yojson, eq]
 
   let set_equality = Alcotest.(equal (slist string String.compare))
 

--- a/test/test_analyse.mli
+++ b/test/test_analyse.mli
@@ -1,2 +1,1 @@
-
-val tests: unit Alcotest.test_case list
+val tests : unit Alcotest.test_case list

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -14,7 +14,7 @@ let test_simple () =
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
   Index.set_active_refs ~repo ["master", hash];
-  Index.record ~repo ~hash [ "analysis", Some "job1";
+  Index.record ~repo ~hash ~status:`Pending [ "analysis", Some "job1";
                              "alpine", None ];
   Alcotest.(check (list string)) "Owners" ["owner"] @@ Index.list_owners ();
   Alcotest.(check (list string)) "Repos" ["name"] @@ Index.list_repos owner;
@@ -22,10 +22,10 @@ let test_simple () =
   Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";
-  Index.record ~repo ~hash [ "analysis", Some "job1";
+  Index.record ~repo ~hash ~status:`Failed [ "analysis", Some "job1";
                              "alpine", Some "job2" ];
   Alcotest.(check jobs) "Jobs" ["alpine", `Failed "!"; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Index.record ~repo ~hash [ "analysis", Some "job1" ];
+  Index.record ~repo ~hash ~status:`Passed [ "analysis", Some "job1" ];
   Alcotest.(check jobs) "Jobs" ["analysis", `Passed] @@ Index.get_jobs ~owner ~name hash
 
 let tests = [

--- a/web-ui/badges.ml
+++ b/web-ui/badges.ml
@@ -1,0 +1,80 @@
+type schema = {
+  schema_version : int; [@key "schemaVersion"]  (** always: 1 *)
+  label : string;
+  message : string;
+  color : string option;  (** default: "lightgrey" *)
+  label_color : string option; [@key "labelColor"]  (** default: "grey" *)
+  is_error : bool option; [@key "isError"]  (** default: false *)
+  named_logo : string option; [@key "namedLogo"]  (** default: none *)
+  logo_svg : string option; [@key "logoSvg"]  (** default: none *)
+  logo_color : string option; [@key "logoColor"]  (** default: none *)
+  logo_width : string option; [@key "logoWidth"]  (** default: none *)
+  logo_position : string option; [@key "logoPosition"]  (** default: none *)
+  style : string option;  (** default: "flat" *)
+  cache_seconds : int option;  (** default: 300 *)
+}
+[@@deriving yojson]
+(** Extracted from https://shields.io/endpoint. *)
+
+let v ~label ~message ?color ?label_color ?is_error ?named_logo ?logo_svg
+    ?logo_color ?logo_width ?logo_position ?style ?cache_seconds () =
+  {
+    schema_version = 1;
+    label;
+    message;
+    color;
+    label_color;
+    is_error;
+    named_logo;
+    logo_svg;
+    logo_color;
+    logo_width;
+    logo_position;
+    style;
+    cache_seconds;
+  }
+
+let schema_of_status =
+  let v = v ~label:"ocaml-ci" in
+  function
+  | `Not_started -> v ~message:"unknown" ~color:"inactive" ()
+  | `Pending -> v ~message:"building" ~color:"yellow" ()
+  | `Failed -> v ~message:"failing" ~color:"critical" ()
+  | `Passed -> v ~message:"passing" ~color:"success" ()
+
+let ( let* ) = Lwt.Infix.( >>= )
+
+open Lwt.Infix
+module Capability = Capnp_rpc_lwt.Capability
+module Client = Ocaml_ci_api.Client
+module Server = Cohttp_lwt_unix.Server
+
+let normal_response = Lwt.map (fun x -> `Response x)
+
+let respond_error status body =
+  let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
+  Server.respond_error ~status ~headers ~body () |> normal_response
+
+let ( let*! ) x f =
+  x >>= function
+  | Error (`Capnp ex) ->
+      respond_error `Internal_server_error
+        (Fmt.to_to_string Capnp_rpc.Error.pp ex)
+  | Error (`Msg msg) -> respond_error `Internal_server_error msg
+  | Ok y -> f y
+
+let handle ~backend ~path =
+  let* ci = Backend.ci backend in
+  match path with
+  | [ org_name; repo_name; branch_name ] ->
+      let ref_name = Fmt.str "refs/heads/%s" branch_name in
+      Capability.with_ref (Client.CI.org ci org_name) @@ fun org ->
+      Capability.with_ref (Client.Org.repo org repo_name) @@ fun repo ->
+      Capability.with_ref (Client.Repo.commit_of_ref repo ref_name)
+      @@ fun commit ->
+      let*! status = Client.Commit.status commit in
+      let body =
+        status |> schema_of_status |> schema_to_yojson |> Yojson.Safe.to_string
+      in
+      Server.respond_string ~status:`OK ~body () |> normal_response
+  | _ -> Server.respond_not_found () |> normal_response

--- a/web-ui/badges.mli
+++ b/web-ui/badges.mli
@@ -1,0 +1,4 @@
+val handle :
+  backend:Backend.t ->
+  path:string list ->
+  Cohttp_lwt_unix.Server.response_action Lwt.t

--- a/web-ui/dune
+++ b/web-ui/dune
@@ -10,4 +10,7 @@
              tyxml
              prometheus-app.unix
              ocaml-ci-api
-             capnp-rpc-unix))
+             capnp-rpc-unix
+             yojson
+             ppx_deriving_yojson.runtime)
+(preprocess (pps ppx_deriving_yojson)))

--- a/web-ui/main.ml
+++ b/web-ui/main.ml
@@ -25,6 +25,8 @@ let handle_request ~backend _conn request _body =
     Style.get () |> normal_response
   | meth, ("github" :: path) ->
     Github.handle ~backend ~meth path
+  | `GET, ("badge" :: path) ->
+     Badges.handle ~backend ~path
   | _ ->
     Server.respond_not_found () |> normal_response
 


### PR DESCRIPTION
This resolves #91.

- Add a new database table for storing status information.
- Record this status information whenever a 'Summarise' stage completes.
- Expose statuses over the RPC API.
- Expose a new HTTP endpoint at `/badge/:org:/:repo:/:branch:` which returns a JSON response intended to be used with the [Shields.io endpoint API](https://shields.io/endpoint).