### PR TITLE
Add a stage to lint documentation errors

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -11,7 +11,7 @@ module Spec = struct
     `String (Digest.string s |> Digest.to_hex)
 
   type ty = [
-    | `Opam of [ `Build | `Lint ] * analysis
+    | `Opam of [ `Build | `Lint of [ `Fmt | `Doc ]] * analysis
     | `Duniverse
   ] [@@deriving to_yojson]
 
@@ -84,8 +84,8 @@ module Op = struct
       match ty with
       | `Opam (`Build, analysis) ->
         Opam_build.dockerfile ~base ~info:analysis ~variant
-      | `Opam (`Lint, analysis) ->
-        Lint.dockerfile ~base ~info:analysis ~variant
+      | `Opam (`Lint `Fmt, analysis) -> Lint.fmt_dockerfile ~base ~info:analysis ~variant
+      | `Opam (`Lint `Doc, analysis) -> Lint.doc_dockerfile ~base ~info:analysis ~variant
       | `Duniverse ->
         Duniverse_build.dockerfile ~base ~repo ~variant
     in
@@ -152,6 +152,6 @@ let v ~schedule ~repo ~spec source =
     match spec.ty with
     | `Duniverse
     | `Opam (`Build, _) -> `Built
-    | `Opam (`Lint, _) -> `Checked
+    | `Opam (`Lint _, _) -> `Checked
   in
   result, job_id

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -1,7 +1,13 @@
 module Spec : sig
   type t
 
-  val opam : label:string -> platform:Platform.t -> analysis:Analyse.Analysis.t -> [`Build | `Lint] -> t
+  val opam :
+    label:string ->
+    platform:Platform.t ->
+    analysis:Analyse.Analysis.t ->
+    [ `Build | `Lint of [ `Doc | `Fmt ] ] ->
+    t
+
   val duniverse : label:string -> platform:Platform.t -> t
 
   val pp : t Fmt.t

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,4 +1,16 @@
-val dockerfile : base:string -> info:Analyse.Analysis.t -> variant:string -> for_user:bool -> Dockerfile.t
-(** A Dockerfile that checks the formatting.
-    - Ensures OCamlformat is installed depending on {!Analysis.ocamlformat_source}.
-    - Checks formatting using "dune build @fmt". *)
+val fmt_dockerfile :
+  base:string ->
+  info:Analyse.Analysis.t ->
+  variant:string ->
+  for_user:bool ->
+  Dockerfile.t
+(** A Dockerfile that checks the formatting. *)
+
+val doc_dockerfile :
+  base:string ->
+  info:Analyse.Analysis.t ->
+  variant:string ->
+  for_user:bool ->
+  Dockerfile.t
+(** A Dockerfile that checks that the documentation in [./src/] builds without warnings. *)
+

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,1 +1,8 @@
+val install_project_deps :
+  base:string ->
+  info:Analyse.Analysis.t ->
+  variant:string ->
+  for_user:bool ->
+  Dockerfile.t
+
 val dockerfile : base:string -> info:Analyse.Analysis.t -> variant:string -> for_user:bool -> Dockerfile.t

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -87,9 +87,13 @@ let build_with_docker ~repo ~analysis source =
         platforms |> List.map (fun platform ->
             Build.Spec.opam ~label:platform.Platform.variant ~platform ~analysis `Build
           )
+      and lint =
+        [
+          Build.Spec.opam ~label:"(lint-fmt)" ~platform:lint_platform ~analysis (`Lint `Fmt);
+          Build.Spec.opam ~label:"(lint-doc)" ~platform:lint_platform ~analysis (`Lint `Doc);
+        ]
       in
-      let lint = Build.Spec.opam ~label:"(lint)" ~platform:lint_platform ~analysis `Lint in
-      lint :: builds
+      lint @ builds
   in
   let builds = specs |> Current.list_map (module Build.Spec) (fun spec ->
       let+ result = Build.v ~schedule:daily ~repo ~spec source


### PR DESCRIPTION
This resolves https://github.com/ocurrent/ocaml-ci/issues/94.

This stage follows the same structure as the existing `lint` step, but shares some logic with the Opam build steps in order to install the appropriate dependencies before building the documentation.