### PR TITLE
Lint project even if .ocamlformat is missing

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -2,38 +2,41 @@ open Current.Syntax
 
 module Make (Docker : S.DOCKER_CONTEXT) = struct
 
-  let ocamlformat_dockerfile ~base ~ocamlformat_source =
+  let install_ocamlformat =
     let open Dockerfile in
-    let install_ocamlformat =
-      match ocamlformat_source with
-      | Analyse_ocamlformat.Vendored { path } ->
-        let opam_file = Filename.concat path "ocamlformat.opam" in
-        copy ~chown:"opam" ~src:[ opam_file ] ~dst:opam_file ()
-        @@ run "opam pin add -k none -yn ocamlformat %S" path
-        (* Only the opam file is necessary to install the deps
-           [-k none] above ensures that opam doesn't try to make an installable package *)
-        @@ run "opam depext ocamlformat"
-        @@ run "opam install --deps-only -y ocamlformat"
-      | Opam { version } ->
-        run "opam depext ocamlformat=%s" version
-        @@ run "opam install ocamlformat=%s" version
-    in
+    function
+    | Analyse_ocamlformat.Vendored { path } ->
+      let opam_file = Filename.concat path "ocamlformat.opam" in
+      copy ~chown:"opam" ~src:[ opam_file ] ~dst:opam_file ()
+      @@ run "opam pin add -k none -yn ocamlformat %S" path
+      (* Only the opam file is necessary to install the deps
+          [-k none] above ensures that opam doesn't try to make an installable package *)
+      @@ run "opam depext ocamlformat"
+      @@ run "opam install --deps-only -y ocamlformat"
+    | Opam { version } ->
+      run "opam depext ocamlformat=%s" version
+      @@ run "opam install ocamlformat=%s" version
+
+  let fmt_dockerfile ~base ~ocamlformat_source =
+    let open Dockerfile in
     from (Docker.image_hash base)
     @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
     @@ workdir "src"
-    @@ install_ocamlformat
+    @@ (match ocamlformat_source with
+        | Some src -> install_ocamlformat src
+        | None -> empty)
     @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
 
-  (** An image with OCamlformat installed and the project ready to be formatted *)
-  let ocamlformat_base_image ~base ~ocamlformat_source ~source =
+  (** An image with formatting dependencies installed and the project ready to be formatted *)
+  let fmt_base_image ~base ~ocamlformat_source ~source =
     let dockerfile =
       let+ base = base and+ ocamlformat_source = ocamlformat_source in
-      ocamlformat_dockerfile ~base ~ocamlformat_source
+      fmt_dockerfile ~base ~ocamlformat_source
     in
-    Docker.build ~label:"OCamlformat" ~dockerfile source
+    Docker.build ~label:"fmt" ~dockerfile source
 
   let run_fmt ~img =
-    Docker.run ~label:"lint" img ~args:[ "sh"; "-c"; "dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)" ]
+    Docker.run ~label:"lint-fmt" img ~args:[ "sh"; "-c"; "dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)" ]
 
   let v ~schedule ~analysis ~source =
     let base =
@@ -41,13 +44,10 @@ module Make (Docker : S.DOCKER_CONTEXT) = struct
     in
     analysis
     |> Current.map Analyse.Analysis.ocamlformat_source
-    |> Current.option_map (fun ocamlformat_source ->
-        let img = ocamlformat_base_image ~base ~ocamlformat_source ~source in
+    |> (fun ocamlformat_source ->
+        let img = fmt_base_image ~base ~ocamlformat_source ~source in
         run_fmt ~img
       )
-    |> Current.map (function
-        | Some () -> `Checked
-        | None -> `Check_skipped
-      )
+    |> Current.map (fun () -> `Checked)
 
 end

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -4,7 +4,7 @@ module Make (Docker : S.DOCKER_CONTEXT) : sig
     schedule:Current_cache.Schedule.t ->
     analysis:Analyse.Analysis.t Current.t ->
     source:Docker.source ->
-    [> `Checked | `Check_skipped ] Current.t
+    [> `Checked ] Current.t
   (** [v ~analysis ~src] runs the linting step:
       - Ensures OCamlformat is installed depending on {!Analysis.ocamlformat_source}.
       - Checks formatting using "dune build @fmt".

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -100,7 +100,7 @@ let summarise results =
   |> Current.list_seq
   |> Current.map @@ fun results ->
   results |> List.fold_left (fun (ok, pending, err, skip) -> function
-      | _, Ok (`Checked | `Check_skipped) -> (ok, pending, err, skip)  (* Don't count lint checks *)
+      | _, Ok `Checked -> (ok, pending, err, skip)  (* Don't count lint checks *)
       | _, Ok `Built -> (ok + 1, pending, err, skip)
       | l, Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m -> (ok, pending, err, (m, l) :: skip)
       | l, Error `Msg m -> (ok, pending, (m, l) :: err, skip)


### PR DESCRIPTION
This resolves https://github.com/ocurrent/ocaml-ci/issues/107.

A simple solution that conditionally installs OCamlformat according to the result of the analysis phase.