### PR TITLE
Constrain alcotest and dune versions to fix CI

### DIFF
--- a/ocaml-ci-api.opam
+++ b/ocaml-ci-api.opam
@@ -11,11 +11,9 @@ homepage: "https://github.com/ocurrent/ocaml-ci"
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 synopsis: "Cap'n Proto API for ocaml-ci"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "1.11" & < "2.2.0"}
   "current_rpc"
   "capnp" {>= "3.4.0"}
   "capnp-rpc-lwt"
   "dockerfile"
-  "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
 ]

--- a/ocaml-ci-client.opam
+++ b/ocaml-ci-client.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocurrent/ocaml-ci"
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 synopsis: "Command-line client for ocaml-ci"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "1.11" & < "2.2.0"}
   "current_rpc"
   "capnp-rpc-unix"
   "ocaml-ci-api"

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocurrent/ocaml-ci"
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 synopsis: "Test OCaml projects on GitHub"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "1.11" & < "2.2.0"}
   "current_git"
   "current_github"
   "current_docker"
@@ -21,4 +21,6 @@ depends: [
   "ocaml-ci-api"
   "conf-libev"
   "dockerfile" {>= "6.3.0"}
+  "alcotest" {< "1.0.0" & with-test}
+  "alcotest-lwt" {with-test}
 ]

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -11,7 +11,7 @@ homepage: "https://github.com/ocurrent/ocaml-ci"
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 synopsis: "Web-server frontend for ocaml-ci"
 depends: [
-  "dune" {>= "1.11"}
+  "dune" {>= "1.11" & < "2.2.0"}
   "current_rpc"
   "current_ansi"
   "prometheus-app"

--- a/test/dune
+++ b/test/dune
@@ -1,4 +1,5 @@
 (test
  (name test)
+ (package ocaml-ci-service)
  (libraries ocaml_ci alcotest alcotest-lwt ppx_deriving_yojson.runtime)
  (preprocess (pps ppx_deriving.eq ppx_deriving_yojson)))


### PR DESCRIPTION
Also, move alcotest to the ocaml-ci-service package, since that seems to be where the tests should be.

(this is intended as a quick fix until we figure out a proper solution in #108)