### PR TITLE
Find opam files recursively again, but skip test directories

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -99,7 +99,7 @@ let dockerfile { base; info; repo; variant} =
   crunch_list (List.map (fun pkg ->
       run {|test "$(opam show -f depexts: %s)" = "$(printf "\n")" || opam depext -ty %s|} pkg pkg) pkgs
     ) @@
-  run "opam pin remove $(opam pin -s) -n" @@
+  (if Analyse.Analysis.is_duniverse info then run "opam pin remove $(opam pin -s) -n" else empty) @@
   build_cmd
 
 let cache = Hashtbl.create 10000


### PR DESCRIPTION
This partially reverts 108d1676c83 and 5f38279da9899.
This is needed to build ocaml-ci itself, at least.