### PR TITLE
Use dune build to test projects, not opam install

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -85,7 +85,7 @@ let dockerfile { base; info; repo; variant} =
       run "%s opam exec -- dune build @doc" caches
     else
       copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
-      run "%s opam install -tv ." caches
+      run "opam exec -- dune build @install @runtest && rm -rf _build"
   in
   comment "syntax = docker/dockerfile:experimental@sha256:ee85655c57140bd20a5ebc3bb802e7410ee9ac47ca92b193ed0ab17485024fe5" @@
   from base @@


### PR DESCRIPTION
Since dune 2.2.0, it is no longer possible to opam install multi-project repositories with vendored dependencies. Instead, just check that dune can build the project locally. This is also faster.

See https://github.com/ocaml/dune/issues/3139

A very useful side-effect of this is that we now test projects in dev mode, with warnings-as-errors.