### PR TITLE
Fix calls to api with variants containing spaces

### DIFF
--- a/web-ui/main.ml
+++ b/web-ui/main.ml
@@ -16,6 +16,7 @@ let handle_request ~backend _conn request _body =
   let meth = Cohttp.Request.meth request in
   let uri = Cohttp.Request.uri request in
   let path = Uri.path uri in
+  let path = Uri.pct_decode path in
   Log.info (fun f -> f "HTTP %s %S" (Cohttp.Code.string_of_method meth) path);
   match meth, String.cuts ~sep:"/" ~empty:false path with
   | `GET, ([] | ["index.html"]) ->


### PR DESCRIPTION
When requesting a path containing spaces or special characters in the web-ui, those special characters were not decoded and thus were sent to the API in their `%<number>` form (e.g. `%20` for spaces).

This PR was tested successfully in opam-ci