### PR TITLE
Allow herachical statuses tree

### DIFF
--- a/api/common.ml
+++ b/api/common.ml
@@ -1,0 +1,1 @@
+let status_sep = ':'

--- a/api/common.mli
+++ b/api/common.mli
@@ -1,0 +1,2 @@
+val status_sep : char
+(** Hierarchical statuses separator *)

--- a/api/ocaml_ci_api.ml
+++ b/api/ocaml_ci_api.ml
@@ -1,2 +1,3 @@
 module Raw = Raw
 module Client = Client
+module Common = Common

--- a/web-ui/github.ml
+++ b/web-ui/github.ml
@@ -2,6 +2,7 @@ open Lwt.Infix
 
 module Capability = Capnp_rpc_lwt.Capability
 module Client = Ocaml_ci_api.Client
+module Common = Ocaml_ci_api.Common
 module Server = Cohttp_lwt_unix.Server
 module Response = Cohttp.Response.Make(Server.IO)
 module Transfer_IO = Cohttp__Transfer_io.Make(Server.IO)
@@ -70,20 +71,48 @@ let breadcrumbs steps page_title =
     List.rev steps
   )
 
+module StatusTree : sig
+  type key = string
+
+  type 'a tree =
+    | Leaf of 'a
+    | Branch of key * 'a t
+  and 'a t = 'a tree list
+
+  val add : key list -> 'a -> 'a t -> 'a t
+end = struct
+  type key = string
+
+  type 'a tree =
+    | Leaf of 'a
+    | Branch of key * 'a t
+  and 'a t = 'a tree list
+
+  let rec add k x ts = match k, ts with
+    | [], ts -> ts @ [Leaf x]
+    | k::ks, [] -> [Branch (k, add ks x [])]
+    | _::_, (Leaf _ as t)::ts -> t :: add k x ts
+    | k::ks, Branch (k', t)::ts when String.equal k k' -> Branch (k, add ks x t) :: ts
+    | _::_, (Branch _ as t)::ts -> t :: add k x ts
+end
+
 let statuses ss =
   let open Tyxml.Html in
-  let render_status (s, elms) =
-    let status_class_name =
-      match (s : Client.State.t) with
-      | NotStarted -> "not-started"
-      | Aborted -> "aborted"
-      | Failed m when Astring.String.is_prefix ~affix:"[SKIP]" m -> "skipped"
-      | Failed _ -> "failed"
-      | Passed -> "passed"
-      | Active -> "active"
-      | Undefined _ -> "undefined"
-    in
-    li ~a:[a_class [status_class_name]] elms
+  let rec render_status = function
+    | StatusTree.Leaf (s, elms) ->
+        let status_class_name =
+          match (s : Client.State.t) with
+          | NotStarted -> "not-started"
+          | Aborted -> "aborted"
+          | Failed m when Astring.String.is_prefix ~affix:"[SKIP]" m -> "skipped"
+          | Failed _ -> "failed"
+          | Passed -> "passed"
+          | Active -> "active"
+          | Undefined _ -> "undefined"
+        in
+        li ~a:[a_class [status_class_name]] elms
+    | StatusTree.Branch (b, ss) ->
+        li [txt b; ul ~a:[a_class ["statuses"]] (List.map render_status ss)]
   in
   ul ~a:[a_class ["statuses"]] (List.map render_status ss)
 
@@ -123,13 +152,20 @@ let link_github_refs ~owner ~name =
 
 let link_jobs ~owner ~name ~hash ?selected jobs =
   let open Tyxml.Html in
-  let render_job { Client.variant; outcome } =
+  let render_job trees { Client.variant; outcome } =
     let uri = job_url ~owner ~name ~hash variant in
-    let label = txt (Fmt.strf "%s (%a)" variant Client.State.pp outcome) in
-    let label = if selected = Some variant then b [label] else label in
-    outcome, [a ~a:[a_href uri] [label]]
+    match List.rev (String.split_on_char Common.status_sep variant) with
+    | [] -> assert false
+    | label_txt::k ->
+        let k = List.rev k in
+        let x =
+          let label = txt (Fmt.strf "%s (%a)" label_txt Client.State.pp outcome) in
+          let label = if selected = Some variant then b [label] else label in
+          outcome, [a ~a:[a_href uri] [label]]
+        in
+        StatusTree.add k x trees
   in
-  statuses (List.map render_job jobs)
+  statuses (List.fold_left render_job [] jobs)
 
 let short_hash = Astring.String.with_range ~len:6
 


### PR DESCRIPTION
In opam-ci, I found myself having the need for a hierarchical view for each packages being tested. This PR introduces a separator to variant name (currently `|` but it can be changed) which allows for a tree-like structure to emerge from the list of statuses.

Here is a screenshot of the result:
![screenshot](https://user-images.githubusercontent.com/2611789/75628868-d9977e80-5bd4-11ea-955d-4739a5702e9d.png)

This is going to be even more useful in the future once revdeps will be added to the opam-ci pipeline as without a hierarchical structure it quickly become really difficult to read.