### PR TITLE
Allow collapsing orgs and repos in the pipeline display

### DIFF
--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -122,9 +122,9 @@ let local_test repo () =
   Current.of_output result
 
 let v ~app () =
-  Github.App.installations app |> Current.list_iter (module Github.Installation) @@ fun installation ->
+  Github.App.installations app |> Current.list_iter ~collapse_key:"org" (module Github.Installation) @@ fun installation ->
   let repos = Github.Installation.repositories installation in
-  repos |> Current.list_iter (module Github.Api.Repo) @@ fun repo ->
+  repos |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo) @@ fun repo ->
   let refs = Github.Api.Repo.ci_refs repo |> set_active_refs ~repo in
   refs |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in


### PR DESCRIPTION
Otherwise, it's too big to be useful.