### PR TITLE
Custom build

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -113,7 +113,7 @@ module Examine = struct
   module Key = struct
     type t = Current_git.Commit.t
 
-    let digest t = Current_git.Commit.id t
+    let digest t = Current_git.Commit.hash t
   end
 
   module Value = Analysis

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -1,5 +1,5 @@
 module Analysis : sig
-  type t
+  type t [@@deriving yojson]
 
   val opam_files : t -> string list
   val is_duniverse : t -> bool

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -1,27 +1,88 @@
 open Current.Syntax
+open Lwt.Infix
+
+module Raw = Current_docker.Raw
+
+module Op = struct
+  type t = Builder.t
+
+  let id = "ci-build"
+
+  module Key = struct
+    type t = {
+      commit : Current_git.Commit.t;            (* The source code to build and test *)
+      repo : Current_github.Repo_id.t;          (* Used to choose a build cache *)
+      base : Raw.Image.t;                       (* The image with the OCaml compiler to use. *)
+      variant : string;                         (* Added as a comment in the Dockerfile *)
+      analysis : Analyse.Analysis.t;
+    }
+
+    let digest_analysis x =
+      let s = Analyse.Analysis.to_yojson x |> Yojson.Safe.to_string in
+      `String (Digest.string s |> Digest.to_hex)
+
+    let to_json { commit; analysis; base; variant; repo } =
+      `Assoc [
+        "commit", `String (Current_git.Commit.id commit);
+        "analysis", digest_analysis analysis;
+        "base", `String (Raw.Image.digest base);
+        "variant", `String variant;
+        "repo", `String (Fmt.to_to_string Current_github.Repo_id.pp repo);
+      ]
+
+    let digest t = Yojson.Safe.to_string (to_json t)
+  end
+
+  module Value = Current.Unit
+
+  let or_raise = function
+    | Ok () -> ()
+    | Error (`Msg m) -> raise (Failure m)
+
+  let build { Builder.docker_context; pool; build_timeout } job { Key.commit; base; analysis; variant; repo } =
+    let dockerfile =
+      let base = Raw.Image.hash base in
+      Dockerfile.string_of_t (
+        if Analyse.Analysis.is_duniverse analysis then
+          Duniverse_build.dockerfile ~base ~repo ~variant
+        else
+          Opam_build.dockerfile ~base ~info:analysis ~variant
+      )
+    in
+    Current.Job.log job "@[<v2>Using Dockerfile:@,%a@]" Fmt.lines dockerfile;
+    Current.Job.start ~timeout:build_timeout ~pool job ~level:Current.Level.Average >>= fun () ->
+    Current_git.with_checkout ~job commit @@ fun dir ->
+    Bos.OS.File.write Fpath.(dir / "Dockerfile") (dockerfile ^ "\n") |> or_raise;
+    let cmd = Raw.Cmd.docker ~docker_context @@ ["build"; "--"; Fpath.to_string dir] in
+    let pp_error_command f = Fmt.string f "Docker build" in
+    Current.Process.exec ~cancellable:true ~pp_error_command ~job cmd
+
+  let pp f { Key.repo; commit; variant; _ } =
+    Fmt.pf f "@[<v2>test %a %a on %s@]"
+      Current_github.Repo_id.pp repo
+      Current_git.Commit.pp commit
+      variant
+
+  let auto_cancel = true
+end
+
+module BC = Current_cache.Make(Op)
 
 let pull ~schedule platform =
   Current.component "docker pull" |>
   let> { Platform.builder; variant; label = _ } = platform in
   Builder.pull builder ("ocurrent/opam:" ^ variant) ~schedule
 
-let build ~repo ~analysis ~platform ~base source =
+let build ~repo ~analysis ~platform ~base commit =
   Current.component "build" |>
   let> { Platform.builder; variant; _ } = platform
   and> analysis = analysis
   and> base = base
-  and> source = source
+  and> commit = commit
   and> repo = repo in
-  let base = Current_docker.Raw.Image.hash base in
-  let dockerfile =
-    if Analyse.Analysis.is_duniverse analysis then
-      Duniverse_build.dockerfile ~base ~repo ~variant
-    else
-      Opam_build.dockerfile ~base ~info:analysis ~variant
-  in
-  Builder.build builder source ~dockerfile:(`Contents dockerfile)
+  BC.get builder { Op.Key.commit; analysis; repo; base; variant }
 
 let v ~platform ~schedule ~repo ~analysis source =
   let base = pull ~schedule platform in
-  let+ _ : Current_docker.Raw.Image.t = build ~analysis ~repo ~platform ~base source in
+  let+ () = build ~analysis ~repo ~platform ~base source in
   `Built

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -16,11 +16,8 @@ let build ~repo ~analysis ~platform ~base source =
   let dockerfile =
     if Analyse.Analysis.is_duniverse analysis then
       Duniverse_build.dockerfile ~base ~repo ~variant
-    else (
-      let opam_files = Analyse.Analysis.opam_files analysis in
-      if opam_files = [] then failwith "No opam files found!";
+    else
       Opam_build.dockerfile ~base ~info:analysis ~variant
-    )
   in
   Builder.build builder source ~dockerfile:(`Contents dockerfile)
 

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -66,13 +66,15 @@ let build_cache repo =
 
 let download_cache = "--mount=type=cache,target=/home/opam/.opam/download-cache,uid=1000"
 
-let dockerfile ~base ~repo ~variant =
+let dockerfile ~base ~repo ~variant ~for_user =
   let caches =
-    Printf.sprintf "%s %s" download_cache (build_cache repo)
+    if for_user then ""
+    else Printf.sprintf "%s %s" download_cache (build_cache repo)
   in
   let build_platform, install_platform = install_platform ~compiler:"4.09" in
   let open Dockerfile in
-  comment "syntax = docker/dockerfile:experimental@sha256:ee85655c57140bd20a5ebc3bb802e7410ee9ac47ca92b193ed0ab17485024fe5" @@
+  (if for_user then empty
+   else comment "syntax = docker/dockerfile:experimental@sha256:ee85655c57140bd20a5ebc3bb802e7410ee9ac47ca92b193ed0ab17485024fe5") @@
   build_platform @@
   from base @@
   install_platform @@

--- a/lib/duniverse_build.mli
+++ b/lib/duniverse_build.mli
@@ -1,1 +1,1 @@
-val dockerfile : base:string -> repo:Current_github.Repo_id.t -> variant:string -> Dockerfile.t
+val dockerfile : base:string -> repo:Current_github.Repo_id.t -> variant:string -> for_user:bool -> Dockerfile.t

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,1 +1,1 @@
-val dockerfile : base:string -> info:Analyse.Analysis.t -> variant:string -> Dockerfile.t
+val dockerfile : base:string -> info:Analyse.Analysis.t -> variant:string -> for_user:bool -> Dockerfile.t

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -63,9 +63,6 @@ let set_active_refs ~repo xs =
 let build_with_docker ~repo ~analysis source =
   Current.with_context analysis @@ fun () ->
   let lint_job = Ocaml_ci.Lint.v ~builder:lint_builder ~schedule:weekly ~analysis ~source in
-  (* At the moment, we know the set of platforms statically. However, we're pretending
-     it's dynamic here in anticipation of future changes where the set of platforms
-     to use comes from the analysis phase. *)
   let platforms =
     let+ analysis = Current.state ~hidden:true analysis in
     match analysis with


### PR DESCRIPTION
Instead of using the generic `Docker.build` from OCurrent, use our own version. This has several advantages:

1. The build log starts with a meaningful comment saying which project we're building and which commit, rather than a generic build command with the hash of the Dockerfile. We could put more useful stuff here later (such as a version of the Dockerfile that can run without BuildKit).

2. The Docker context is no longer part of the key, so if we reassign a platform to a new build host, we don't have to rebuild everything. We can more easily use a cluster.

3. The Dockerfile is generated during the build, not before. This avoids keeping Dockerfiles in memory for archived builds and means we can make changes to the generated files without having to rebuild everything (unless we want to).