### PR TITLE
Use new latching feature to pull base images daily

### DIFF
--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -20,6 +20,9 @@ depends: [
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
 build: [
   ["dune" "subst"] {pinned}
   [

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -20,6 +20,9 @@ depends: [
   "dockerfile"
   "ppx_deriving_yojson"
 ]
+conflicts: [
+  "ocaml-migrate-parsetree" {= "1.7.1"}
+]
 build: [
   ["dune" "subst"] {pinned}
   [


### PR DESCRIPTION
Docker pull jobs now latch the previous image while checking for updates, so there is now little cost to checking when no update is available. This means we can check for updates daily so that the CI will not lag the base image builder so much.