### PR TITLE
Always show the full command for each build steps in the logs

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -16,6 +16,7 @@ services:
     environment:
       - "CI_PROFILE=production"
       - "DOCKER_BUILDKIT=1"
+      - "PROGRESS_NO_TRUNC=1"
     ports:
       - '8102:9000'
     volumes:


### PR DESCRIPTION
Recently buildkit switched its output to use `PROGRESS_NO_TRUNC` by default to show the full command whether or not the line is more than 80 characters: https://github.com/moby/buildkit/pull/1435

However it would still be interesting to get this behaviour regardless of the version of docker installed.