### PR TITLE
Perform rebuilds in the background if the commit didn't change

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -12,20 +12,12 @@ module Op = struct
     type t = {
       commit : Current_git.Commit.t;            (* The source code to build and test *)
       repo : Current_github.Repo_id.t;          (* Used to choose a build cache *)
-      base : Raw.Image.t;                       (* The image with the OCaml compiler to use. *)
       variant : string;                         (* Added as a comment in the Dockerfile *)
-      analysis : Analyse.Analysis.t;
     }
 
-    let digest_analysis x =
-      let s = Analyse.Analysis.to_yojson x |> Yojson.Safe.to_string in
-      `String (Digest.string s |> Digest.to_hex)
-
-    let to_json { commit; analysis; base; variant; repo } =
+    let to_json { commit; variant; repo } =
       `Assoc [
         "commit", `String (Current_git.Commit.hash commit);
-        "analysis", digest_analysis analysis;
-        "base", `String (Raw.Image.digest base);
         "variant", `String variant;
         "repo", `String (Fmt.to_to_string Current_github.Repo_id.pp repo);
       ]
@@ -33,13 +25,33 @@ module Op = struct
     let digest t = Yojson.Safe.to_string (to_json t)
   end
 
-  module Value = Current.Unit
+  module Value = struct
+    type t = {
+      base : Raw.Image.t;                       (* The image with the OCaml compiler to use. *)
+      analysis : Analyse.Analysis.t;
+    }
+
+    let digest_analysis x =
+      let s = Analyse.Analysis.to_yojson x |> Yojson.Safe.to_string in
+      `String (Digest.string s |> Digest.to_hex)
+
+    let to_json { analysis; base } =
+      `Assoc [
+        "analysis", digest_analysis analysis;
+        "base", `String (Raw.Image.digest base);
+      ]
+
+    let digest t = Yojson.Safe.to_string (to_json t)
+  end
+
+  module Outcome = Current.Unit
 
   let or_raise = function
     | Ok () -> ()
     | Error (`Msg m) -> raise (Failure m)
 
-  let build { Builder.docker_context; pool; build_timeout } job { Key.commit; base; analysis; variant; repo } =
+  let run { Builder.docker_context; pool; build_timeout } job
+      { Key.commit; variant; repo } { Value.base; analysis } =
     let make_dockerfile =
       let base = Raw.Image.hash base in
       if Analyse.Analysis.is_duniverse analysis then
@@ -66,16 +78,17 @@ module Op = struct
     let pp_error_command f = Fmt.string f "Docker build" in
     Current.Process.exec ~cancellable:true ~pp_error_command ~job cmd
 
-  let pp f { Key.repo; commit; variant; _ } =
+  let pp f ({ Key.repo; commit; variant }, _) =
     Fmt.pf f "@[<v2>test %a %a on %s@]"
       Current_github.Repo_id.pp repo
       Current_git.Commit.pp commit
       variant
 
   let auto_cancel = true
+  let latched = true
 end
 
-module BC = Current_cache.Make(Op)
+module BC = Current_cache.Generic(Op)
 
 let pull ~schedule platform =
   Current.component "docker pull" |>
@@ -89,7 +102,7 @@ let build ~repo ~analysis ~platform ~base commit =
   and> base = base
   and> commit = commit
   and> repo = repo in
-  BC.get builder { Op.Key.commit; analysis; repo; base; variant }
+  BC.run builder { Op.Key.commit; repo; variant } { Op.Value.base; analysis}
 
 let v ~platform ~schedule ~repo ~analysis source =
   let base = pull ~schedule platform in

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -3,6 +3,35 @@ open Lwt.Infix
 
 module Raw = Current_docker.Raw
 
+module Spec = struct
+  type analysis = Analyse.Analysis.t
+
+  let analysis_to_yojson x =
+    let s = Analyse.Analysis.to_yojson x |> Yojson.Safe.to_string in
+    `String (Digest.string s |> Digest.to_hex)
+
+  type ty = [
+    | `Opam of [ `Build | `Lint ] * analysis
+    | `Duniverse
+  ] [@@deriving to_yojson]
+
+  type t = {
+    label : string;
+    platform : Platform.t;
+    ty : ty;
+  }
+
+  let opam ~label ~platform ~analysis op =
+    { label; platform; ty = `Opam (op, analysis) }
+
+  let duniverse ~label ~platform =
+    { label; platform; ty = `Duniverse }
+
+  let pp f t = Fmt.string f t.label
+  let compare a b = compare a.label b.label
+  let label t = t.label
+end
+
 module Op = struct
   type t = Builder.t
 
@@ -12,14 +41,14 @@ module Op = struct
     type t = {
       commit : Current_git.Commit.t;            (* The source code to build and test *)
       repo : Current_github.Repo_id.t;          (* Used to choose a build cache *)
-      variant : string;                         (* Added as a comment in the Dockerfile *)
+      label : string;                           (* A unique ID for this build within the commit *)
     }
 
-    let to_json { commit; variant; repo } =
+    let to_json { commit; label; repo } =
       `Assoc [
         "commit", `String (Current_git.Commit.hash commit);
-        "variant", `String variant;
         "repo", `String (Fmt.to_to_string Current_github.Repo_id.pp repo);
+        "label", `String label;
       ]
 
     let digest t = Yojson.Safe.to_string (to_json t)
@@ -27,18 +56,16 @@ module Op = struct
 
   module Value = struct
     type t = {
+      ty : Spec.ty;
       base : Raw.Image.t;                       (* The image with the OCaml compiler to use. *)
-      analysis : Analyse.Analysis.t;
+      variant : string;                         (* Added as a comment in the Dockerfile *)
     }
 
-    let digest_analysis x =
-      let s = Analyse.Analysis.to_yojson x |> Yojson.Safe.to_string in
-      `String (Digest.string s |> Digest.to_hex)
-
-    let to_json { analysis; base } =
+    let to_json { base; ty; variant } =
       `Assoc [
-        "analysis", digest_analysis analysis;
         "base", `String (Raw.Image.digest base);
+        "op", Spec.ty_to_yojson ty;
+        "variant", `String variant;
       ]
 
     let digest t = Yojson.Safe.to_string (to_json t)
@@ -51,13 +78,16 @@ module Op = struct
     | Error (`Msg m) -> raise (Failure m)
 
   let run { Builder.docker_context; pool; build_timeout } job
-      { Key.commit; variant; repo } { Value.base; analysis } =
+      { Key.commit; label = _; repo } { Value.base; variant; ty } =
     let make_dockerfile =
       let base = Raw.Image.hash base in
-      if Analyse.Analysis.is_duniverse analysis then
-        Duniverse_build.dockerfile ~base ~repo ~variant
-      else
+      match ty with
+      | `Opam (`Build, analysis) ->
         Opam_build.dockerfile ~base ~info:analysis ~variant
+      | `Opam (`Lint, analysis) ->
+        Lint.dockerfile ~base ~info:analysis ~variant
+      | `Duniverse ->
+        Duniverse_build.dockerfile ~base ~repo ~variant
     in
     Current.Job.write job
       (Fmt.strf "@.\
@@ -78,11 +108,11 @@ module Op = struct
     let pp_error_command f = Fmt.string f "Docker build" in
     Current.Process.exec ~cancellable:true ~pp_error_command ~job cmd
 
-  let pp f ({ Key.repo; commit; variant }, _) =
-    Fmt.pf f "@[<v2>test %a %a on %s@]"
+  let pp f ({ Key.repo; commit; label }, _) =
+    Fmt.pf f "@[<v2>test %a %a (%s)@]"
       Current_github.Repo_id.pp repo
       Current_git.Commit.pp commit
-      variant
+      label
 
   let auto_cancel = true
   let latched = true
@@ -90,21 +120,38 @@ end
 
 module BC = Current_cache.Generic(Op)
 
-let pull ~schedule platform =
+let pull ~schedule spec =
   Current.component "docker pull" |>
-  let> { Platform.builder; variant; label = _ } = platform in
+  let> { Spec.platform; _} = spec in
+  let { Platform.builder; variant; label = _ } = platform in
   Builder.pull builder ("ocurrent/opam:" ^ variant) ~schedule
 
-let build ~repo ~analysis ~platform ~base commit =
+let build ~spec ~repo ~base commit =
   Current.component "build" |>
-  let> { Platform.builder; variant; _ } = platform
-  and> analysis = analysis
+  let> { Spec.platform; ty; label } = spec
   and> base = base
   and> commit = commit
   and> repo = repo in
-  BC.run builder { Op.Key.commit; repo; variant } { Op.Value.base; analysis}
+  let { Platform.builder; variant; _ } = platform in
+  BC.run builder { Op.Key.commit; repo; label } { Op.Value.base; ty; variant }
 
-let v ~platform ~schedule ~repo ~analysis source =
-  let base = pull ~schedule platform in
-  let+ () = build ~analysis ~repo ~platform ~base source in
-  `Built
+let get_job_id x =
+  let+ md = Current.Analysis.metadata x in
+  match md with
+  | Some { Current.Metadata.job_id; _ } -> job_id
+  | None -> None
+
+let v ~schedule ~repo ~spec source =
+  let base = pull ~schedule spec in
+  let build = build ~spec ~repo ~base source in
+  let+ state = Current.state ~hidden:true build
+  and+ job_id = get_job_id build
+  and+ spec = spec in
+  let result =
+    state |> Result.map @@ fun () ->
+    match spec.ty with
+    | `Duniverse
+    | `Opam (`Build, _) -> `Built
+    | `Opam (`Lint, _) -> `Checked
+  in
+  result, job_id

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -1,9 +1,19 @@
+module Spec : sig
+  type t
+
+  val opam : label:string -> platform:Platform.t -> analysis:Analyse.Analysis.t -> [`Build | `Lint] -> t
+  val duniverse : label:string -> platform:Platform.t -> t
+
+  val pp : t Fmt.t
+  val compare : t -> t -> int
+  val label : t -> string
+end
+
 (** Build and test all the opam packages in a given build context on the given platform.
     [~repo] is the ID of the repository-under-test on GitHub. *)
 val v :
-  platform:Platform.t Current.t ->
   schedule:Current_cache.Schedule.t ->
   repo:Current_github.Repo_id.t Current.t ->
-  analysis:Analyse.Analysis.t Current.t ->
+  spec:Spec.t Current.t ->
   Current_git.Commit.t Current.t ->
-  [> `Built ] Current.t
+  ([> `Built | `Checked ] Current_term.Output.t * Current.job_id option) Current.t

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
   (name ocaml_ci)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries logs current current_docker current_github current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version))
+  (libraries logs current current_docker current_github current.term current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version))

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -1,7 +1,3 @@
-open Current.Syntax
-
-module Docker = Current_docker.Raw
-
 let install_ocamlformat =
   let open Dockerfile in
   function
@@ -18,41 +14,16 @@ let install_ocamlformat =
 
 let fmt_dockerfile ~base ~ocamlformat_source =
   let open Dockerfile in
-  from (Docker.Image.hash base)
+  from base
   @@ run "opam install dune" (* Not necessarily the dune version used by the project *)
   @@ workdir "src"
   @@ (match ocamlformat_source with
       | Some src -> install_ocamlformat src
       | None -> empty)
   @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
+  @@ run "opam exec -- dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)"
 
-(** An image with formatting dependencies installed and the project ready to be formatted *)
-let fmt_base_image ~builder ~base ~ocamlformat_source ~source =
-  Current.component "build-fmt-tools" |>
-  let> base = base
-  and> ocamlformat_source = ocamlformat_source
-  and> source = source
-  in
-  let dockerfile = `Contents (fmt_dockerfile ~base ~ocamlformat_source) in
-  Builder.build builder source ~dockerfile
-
-let run_fmt ~builder ~img =
-  Current.component "lint-fmt" |>
-  let> img = img in
-  Builder.run builder img
-    ~args:[ "sh"; "-c"; "dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)" ]
-
-let pull ~builder ~schedule tag =
-  Current.component "pull %s" tag |>
-  let> () = Current.return () in
-  Builder.pull builder tag ~schedule
-
-let v ~builder ~schedule ~analysis ~source =
-  let base = pull ~builder ~schedule "ocurrent/opam:alpine-3.10-ocaml-4.08" in
-  analysis
-  |> Current.map Analyse.Analysis.ocamlformat_source
-  |> (fun ocamlformat_source ->
-      let img = fmt_base_image ~builder ~base ~ocamlformat_source ~source in
-      run_fmt ~builder ~img
-    )
-  |> Current.map (fun () -> `Checked)
+let dockerfile ~base ~info ~variant ~for_user =
+  ignore (variant, for_user); (* (todo) *)
+  let ocamlformat_source = Analyse.Analysis.ocamlformat_source info in
+  fmt_dockerfile ~base ~ocamlformat_source

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,9 +1,4 @@
-val v :
-  builder:Builder.t ->
-  schedule:Current_cache.Schedule.t ->
-  analysis:Analyse.Analysis.t Current.t ->
-  source:Current_git.Commit.t Current.t ->
-  [> `Checked ] Current.t
-(** [v ~builder ~schedule ~analysis ~source] runs the linting step:
+val dockerfile : base:string -> info:Analyse.Analysis.t -> variant:string -> for_user:bool -> Dockerfile.t
+(** A Dockerfile that checks the formatting.
     - Ensures OCamlformat is installed depending on {!Analysis.ocamlformat_source}.
     - Checks formatting using "dune build @fmt". *)


### PR DESCRIPTION
Before, we would turn the GitHub status orange if any part of the key (commit, base image hash, analysis) changed. Now, we only consider the commit to be the key. Other changes rebuild but latch the previous build result until the operation is complete. For example, when the Docker base images update we don't mark the commits as pending while rebuilding.

This uses the new latching support in https://github.com/ocurrent/ocurrent/pull/179.

TODO:
- [x] Do the same for the lint job(s).