### PR TITLE
Fix ocaml-migrate-parsetree conflicts

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -21,6 +21,7 @@
 (package
  (name ocaml-ci-service)
  (synopsis "Test OCaml projects on GitHub")
+ (conflicts (ocaml-migrate-parsetree (= "1.7.1")))
  (depends
   (dune (>= "1.11"))
   current_git
@@ -40,6 +41,7 @@
 (package
  (name ocaml-ci-web)
  (synopsis "Web-server frontend for ocaml-ci")
+ (conflicts (ocaml-migrate-parsetree (= "1.7.1")))
  (depends
   (dune (>= "1.11"))
   current_rpc


### PR DESCRIPTION
The opam files are now generated by dune.