### PR TITLE
Collect opam variables from base images

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -5,10 +5,10 @@ module Analysis : sig
   val is_duniverse : t -> bool
   val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
-  val ocaml_versions : t -> string list
+  val variants : t -> string list
 
-  val of_dir : job:Current.Job.t -> Fpath.t -> (t, [ `Msg of string ]) result Lwt.t
+  val of_dir : job:Current.Job.t -> platforms:(string * Platform.Vars.t) list -> Fpath.t -> (t, [ `Msg of string ]) result Lwt.t
 end
 
-val examine : Current_git.Commit.t Current.t -> Analysis.t Current.t
-(** [examine src] returns a list of "*.opam" files in [src]. *)
+val examine : platforms:Platform.t list Current.t -> Current_git.Commit.t Current.t -> Analysis.t Current.t
+(** [examine ~platforms src] analyses the source code [src]. *)

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -3,12 +3,12 @@ module Spec : sig
 
   val opam :
     label:string ->
-    platform:Platform.t ->
+    variant:string ->
     analysis:Analyse.Analysis.t ->
     [ `Build | `Lint of [ `Doc | `Fmt ] ] ->
     t
 
-  val duniverse : label:string -> platform:Platform.t -> t
+  val duniverse : label:string -> variant:string -> t
 
   val pp : t Fmt.t
   val compare : t -> t -> int
@@ -18,7 +18,7 @@ end
 (** Build and test all the opam packages in a given build context on the given platform.
     [~repo] is the ID of the repository-under-test on GitHub. *)
 val v :
-  schedule:Current_cache.Schedule.t ->
+  platforms:Platform.t list Current.t ->
   repo:Current_github.Repo_id.t Current.t ->
   spec:Spec.t Current.t ->
   Current_git.Commit.t Current.t ->

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -1,8 +1,94 @@
+open Lwt.Infix
+open Current.Syntax
+
+module Raw = Current_docker.Raw
+
+module Vars = struct
+  type t = {
+    arch : string;
+    os : string;
+    os_family : string;
+    os_distribution : string;
+    os_version : string;
+  } [@@deriving yojson]
+
+  let template = {|
+    {
+      "arch": "%{arch}%",
+      "os": "%{os}%",
+      "os_family": "%{os-family}%",
+      "os_distribution": "%{os-distribution}%",
+      "os_version": "%{os-version}%"
+    }
+  |}
+
+  let marshal t = Yojson.Safe.to_string (to_yojson t)
+
+  let unmarshal s =
+    match of_yojson (Yojson.Safe.from_string s) with
+    | Ok x -> x
+    | Error e -> failwith e
+end
+
 type t = {
   label : string;
   builder : Builder.t;
   variant : string;
+  base : Current_docker.Raw.Image.t;
+  vars : Vars.t;
 }
 
 let pp f t = Fmt.string f t.label
 let compare a b = compare a.label b.label
+
+module Query = struct
+  let id = "opam-vars"
+
+  type t = No_context
+
+  module Key = struct
+    type t = {
+      docker_context : string option;
+      image : string;
+    } [@@deriving to_yojson]
+
+    let digest t = Yojson.Safe.to_string (to_yojson t)
+  end
+
+  module Value = Vars
+
+  let get_vars ~docker_context image =
+    Raw.Cmd.docker ~docker_context ["run"; "-i"; image; "opam"; "config"; "expand"; Vars.template]
+
+  let build No_context job { Key.docker_context; image } =
+    Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
+    let cmd = get_vars ~docker_context image in
+    Current.Process.check_output ~cancellable:false ~job cmd >|= function
+    | Error _ as e -> e
+    | Ok vars ->
+      match Vars.of_yojson (Yojson.Safe.from_string vars) with
+      | Error msg ->
+        Current.Job.log job "Output was: %S" vars;
+        failwith msg
+      | Ok vars ->
+        Current.Job.log job "@[<v2>Result:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (Value.to_yojson vars);
+        Ok vars
+
+  let pp f key = Fmt.pf f "opam vars of %s" key.Key.image
+
+  let auto_cancel = false
+end
+
+module QC = Current_cache.Make(Query)
+
+let query builder image =
+  Current.component "opam-vars" |>
+  let> image = image in
+  let image = Raw.Image.hash image in
+  let docker_context = builder.Builder.docker_context in
+  QC.get Query.No_context { Query.Key.docker_context; image }
+
+let get ~label ~builder ~variant base =
+  let+ vars = query builder base
+  and+ base = base in
+  { label; builder; variant; base; vars }

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -1,0 +1,31 @@
+(** A platform on which we wish to perform test builds. *)
+
+(** Opam variables. *)
+module Vars : sig
+  type t = {
+    arch : string;
+    os : string;
+    os_family : string;
+    os_distribution : string;
+    os_version : string;
+  } [@@deriving yojson]
+end
+
+type t = {
+  label : string;
+  builder : Builder.t;
+  variant : string;
+  base : Current_docker.Raw.Image.t;
+  vars : Vars.t;
+}
+
+val pp : t Fmt.t
+val compare : t -> t -> int
+
+val get :
+  label:string ->
+  builder:Builder.t ->
+  variant:string ->
+  Current_docker.Raw.Image.t Current.t ->
+  t Current.t
+(** [get ~label ~builder ~variant base] creates a [t] by getting the opam variables from [base]. *)

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -23,14 +23,10 @@ let dev_pool = Current.Pool.create ~label:"docker" 1
 (** Maximum time for one Docker build. *)
 let build_timeout = Duration.of_hour 1
 
-module Builder = struct
+module Builders = struct
   let v docker_context =
     let docker_context, pool =
-      match profile with
-      | `Production ->
-        Some docker_context, Current.Pool.create ~label:("docker-" ^ docker_context) 20
-      | `Dev ->
-        None, dev_pool
+      Some docker_context, Current.Pool.create ~label:("docker-" ^ docker_context) 20
     in
     { Ocaml_ci.Builder.docker_context; pool; build_timeout }
 
@@ -38,4 +34,42 @@ module Builder = struct
   let amd2 = v "laodoke"
   let amd3 = v "phoebe"
   let amd4 = v "m1-a"
+
+  let local = { Ocaml_ci.Builder.docker_context = None; pool = dev_pool; build_timeout }
 end
+
+let default_compiler = "4.10"
+
+type platform = {
+  label : string;
+  builder : Ocaml_ci.Builder.t;
+  variant : string;
+}
+
+let platforms =
+  let v label builder variant = { label; builder; variant } in
+  match profile with
+  | `Production ->
+    [
+      (* Compiler versions:*)
+      v "4.10" Builders.amd4 "debian-10-ocaml-4.10";       (* Note: first item is also used as lint platform *)
+      v "4.09" Builders.amd3 "debian-10-ocaml-4.09";
+      v "4.08" Builders.amd1 "debian-10-ocaml-4.08";
+      v "4.07" Builders.amd2 "debian-10-ocaml-4.07";
+      v "4.06" Builders.amd2 "debian-10-ocaml-4.06";
+      v "4.05" Builders.amd3 "debian-10-ocaml-4.05";
+      v "4.04" Builders.amd3 "debian-10-ocaml-4.04";
+      v "4.03" Builders.amd2 "debian-10-ocaml-4.03";
+      v "4.02" Builders.amd2 "debian-10-ocaml-4.02";
+      (* Distributions: *)
+      v "alpine"   Builders.amd1 @@ "alpine-3.11-ocaml-" ^ default_compiler;
+      v "ubuntu"   Builders.amd2 @@ "ubuntu-20.04-ocaml-" ^ default_compiler;
+      v "opensuse" Builders.amd2 @@ "opensuse-15.1-ocaml-" ^ default_compiler;
+      v "centos"   Builders.amd3 @@ "centos-8-ocaml-" ^ default_compiler;
+      v "fedora"   Builders.amd3 @@ "fedora-31-ocaml-" ^ default_compiler;
+      (* oraclelinux doesn't work in opam 2 yet *)
+    ]
+  | `Dev ->
+    [
+      v "4.10" Builders.local "debian-10-ocaml-4.10";
+    ]

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -18,8 +18,8 @@ module Analysis = struct
   }
   [@@deriving eq, yojson]
 
-  let of_dir ~job d =
-    of_dir ~job d
+  let of_dir ~job ~platforms d =
+    of_dir ~job ~platforms d
     |> Lwt_result.map (fun t ->
            {
              opam_files = opam_files t;
@@ -42,7 +42,7 @@ let expect_test name ~project ~expected =
           ~label ~config:(Current.Config.v ()) ()
       in
       let () = Gen_project.instantiate ~root project in
-      Analysis.of_dir ~job (Fpath.v root)
+      Analysis.of_dir ~job ~platforms:Test_platforms.v (Fpath.v root)
       >|= (function
             | Ok o -> o
             | Error (`Msg e) -> Alcotest.failf "Analysis stage failed: %s" e)

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -1,0 +1,12 @@
+let debian_10_vars = { Ocaml_ci.Platform.Vars.
+                       os = "debian";
+                       arch = "x86_64";
+                       os_family = "debian";
+                       os_distribution = "debian";
+                       os_version = "10" }
+let v = [
+  "debian-10-ocaml-4.10", debian_10_vars;
+  "debian-10-ocaml-4.09", debian_10_vars;
+  "debian-10-ocaml-4.08", debian_10_vars;
+  "debian-10-ocaml-4.07", debian_10_vars;
+]


### PR DESCRIPTION
Pull all the base images at the start and run opam in them to collect the OS variables. This will be useful in future to let the analyser know which platforms are available for building, so that it can choose package versions.

One minor result of this is that duniverse builds can now only use one of the existing platforms (and will build on that platform's machine).

To simplify testing, `Conf` now only defines one platform by default when testing locally.

(previous PR #154 got closed accidentally)