### PR TITLE
Limit concurrent Git checkouts

### DIFF
--- a/service/local.ml
+++ b/service/local.ml
@@ -7,12 +7,11 @@ let () =
 let main config mode repo =
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine = Current.Engine.create ~config (Pipeline.local_test repo) in
-  let site = Current_web.Site.(v ~has_role:allow_all) ~name:"ocaml-ci-local" () in
-  let routes = Current_web.routes engine in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:"ocaml-ci-local" (Current_web.routes engine) in
   Logging.run begin
     Lwt.choose [
       Current.Engine.thread engine;
-      Current_web.run ~mode ~site routes;
+      Current_web.run ~mode site;
     ]
   end
 

--- a/service/main.ml
+++ b/service/main.ml
@@ -46,16 +46,16 @@ let main config mode app capnp_address github_auth =
     if github_auth = None then Current_web.Site.allow_all
     else has_role
   in
-  let site = Current_web.Site.v ?authn ~has_role ~secure_cookies:true ~name:"ocaml-ci" () in
   let routes =
     Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook) ::
     Routes.(s "login" /? nil @--> Current_github.Auth.login github_auth) ::
     Current_web.routes engine in
+  let site = Current_web.Site.v ?authn ~has_role ~secure_cookies:true ~name:"ocaml-ci" routes in
   Logging.run begin
     run_capnp ~engine capnp_address >>= fun () ->
     Lwt.choose [
       Current.Engine.thread engine;
-      Current_web.run ~mode ~site routes;
+      Current_web.run ~mode site;
     ]
   end
 


### PR DESCRIPTION
The service can become unresponsive if there are too many git checkout operations going on at once.