### PR TITLE
Use the download cache when installing odoc

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -26,10 +26,10 @@ let fmt_dockerfile ~base ~info ~variant ~for_user =
   @@ run "opam exec -- dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)"
 
 let doc_dockerfile ~base ~info ~variant ~for_user =
+  let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
   let open Dockerfile in
   Opam_build.install_project_deps ~base ~info ~variant ~for_user
-  @@ run "opam depext odoc"
   (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
-  @@ run "opam install dune odoc>=1.5.0"
+  @@ run "%sopam depext -i dune odoc>=1.5.0" download_cache_prefix
   @@ run "ODOC_WARN_ERROR=true opam exec -- dune build @doc \
           || (echo \"dune build @doc failed\"; exit 2)"

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,3 +1,5 @@
+val download_cache : string
+
 val install_project_deps :
   base:string ->
   info:Analyse.Analysis.t ->

--- a/service/local.ml
+++ b/service/local.ml
@@ -2,6 +2,7 @@
 
 let () =
   Unix.putenv "DOCKER_BUILDKIT" "1";
+  Unix.putenv "PROGRESS_NO_TRUNC" "1";
   Logging.init ()
 
 let main config mode repo =


### PR DESCRIPTION
As well as being more efficient, this might prevent opam from being confused by suddenly losing its download cache.