### PR TITLE
Get OCaml compiler version from base image

### DIFF
--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -3,6 +3,9 @@ open Current.Syntax
 
 module Raw = Current_docker.Raw
 
+let docker_tag ~distro ~ocaml_version =
+  Printf.sprintf "%s-ocaml-%s" distro ocaml_version
+
 module Vars = struct
   type t = {
     arch : string;
@@ -10,6 +13,7 @@ module Vars = struct
     os_family : string;
     os_distribution : string;
     os_version : string;
+    ocaml_version : string;
   } [@@deriving yojson]
 
   let template = {|
@@ -28,6 +32,9 @@ module Vars = struct
     match of_yojson (Yojson.Safe.from_string s) with
     | Ok x -> x
     | Error e -> failwith e
+
+  let ocaml_major_version t =
+    Ocaml_version.with_just_major_and_minor (Ocaml_version.of_string_exn t.ocaml_version)
 end
 
 type t = {
@@ -40,6 +47,8 @@ type t = {
 
 let pp f t = Fmt.string f t.label
 let compare a b = compare a.label b.label
+
+let ( >>!= ) = Lwt_result.bind
 
 module Query = struct
   let id = "opam-vars"
@@ -60,19 +69,25 @@ module Query = struct
   let get_vars ~docker_context image =
     Raw.Cmd.docker ~docker_context ["run"; "-i"; image; "opam"; "config"; "expand"; Vars.template]
 
+  let get_ocaml_version ~docker_context image =
+    Raw.Cmd.docker ~docker_context ["run"; "-i"; image; "opam"; "exec"; "--"; "ocaml"; "-vnum"]
+
   let build No_context job { Key.docker_context; image } =
     Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
+    let cmd = get_ocaml_version ~docker_context image in
+    Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vnum ->
+    let ocaml_version = String.trim vnum in
     let cmd = get_vars ~docker_context image in
-    Current.Process.check_output ~cancellable:false ~job cmd >|= function
-    | Error _ as e -> e
-    | Ok vars ->
-      match Vars.of_yojson (Yojson.Safe.from_string vars) with
-      | Error msg ->
-        Current.Job.log job "Output was: %S" vars;
-        failwith msg
-      | Ok vars ->
-        Current.Job.log job "@[<v2>Result:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (Value.to_yojson vars);
-        Ok vars
+    Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vars ->
+    let json =
+      match Yojson.Safe.from_string vars with
+      | `Assoc items -> `Assoc (("ocaml_version", `String ocaml_version) :: items)
+      | json -> Fmt.failwith "Unexpected JSON: %a" Yojson.Safe.(pretty_print ~std:true) json
+    in
+    Current.Job.log job "@[<v2>Result:@,%a@]" Yojson.Safe.(pretty_print ~std:true) json;
+    match Vars.of_yojson json with
+    | Error msg -> Lwt_result.fail (`Msg msg)
+    | Ok vars -> Lwt_result.return vars
 
   let pp f key = Fmt.pf f "opam vars of %s" key.Key.image
 
@@ -88,7 +103,14 @@ let query builder image =
   let docker_context = builder.Builder.docker_context in
   QC.get Query.No_context { Query.Key.docker_context; image }
 
-let get ~label ~builder ~variant base =
+let get ~label ~builder ~distro ~ocaml_version base =
   let+ vars = query builder base
   and+ base = base in
+  let variant = docker_tag ~distro ~ocaml_version in
   { label; builder; variant; base; vars }
+
+let pull ~schedule ~builder ~distro ~ocaml_version =
+  Current.component "pull@,%s %s" distro ocaml_version |>
+  let> () = Current.return () in
+  let tag = docker_tag ~distro ~ocaml_version in
+  Builder.pull ~schedule builder @@ "ocurrent/opam:" ^ tag

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -8,13 +8,16 @@ module Vars : sig
     os_family : string;
     os_distribution : string;
     os_version : string;
+    ocaml_version : string;
   } [@@deriving yojson]
+
+  val ocaml_major_version : t -> Ocaml_version.t
 end
 
 type t = {
   label : string;
   builder : Builder.t;
-  variant : string;
+  variant : string;                     (* e.g. "debian-10-ocaml-4.08" *)
   base : Current_docker.Raw.Image.t;
   vars : Vars.t;
 }
@@ -25,7 +28,16 @@ val compare : t -> t -> int
 val get :
   label:string ->
   builder:Builder.t ->
-  variant:string ->
+  distro:string ->
+  ocaml_version:string ->
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
 (** [get ~label ~builder ~variant base] creates a [t] by getting the opam variables from [base]. *)
+
+val pull :
+  schedule:Current_cache.Schedule.t ->
+  builder:Builder.t ->
+  distro:string ->
+  ocaml_version:string ->
+  Current_docker.Raw.Image.t Current.t
+(** [pull ~schedule ~builder ~distro ~ocaml_version] pulls "ocurrent/opam:{distro}-ocaml-{version}" on [schedule]. *)

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -43,33 +43,34 @@ let default_compiler = "4.10"
 type platform = {
   label : string;
   builder : Ocaml_ci.Builder.t;
-  variant : string;
+  distro : string;
+  ocaml_version : string;
 }
 
 let platforms =
-  let v label builder variant = { label; builder; variant } in
+  let v label builder distro ocaml_version = { label; builder; distro; ocaml_version } in
   match profile with
   | `Production ->
     [
       (* Compiler versions:*)
-      v "4.10" Builders.amd4 "debian-10-ocaml-4.10";       (* Note: first item is also used as lint platform *)
-      v "4.09" Builders.amd3 "debian-10-ocaml-4.09";
-      v "4.08" Builders.amd1 "debian-10-ocaml-4.08";
-      v "4.07" Builders.amd2 "debian-10-ocaml-4.07";
-      v "4.06" Builders.amd2 "debian-10-ocaml-4.06";
-      v "4.05" Builders.amd3 "debian-10-ocaml-4.05";
-      v "4.04" Builders.amd3 "debian-10-ocaml-4.04";
-      v "4.03" Builders.amd2 "debian-10-ocaml-4.03";
-      v "4.02" Builders.amd2 "debian-10-ocaml-4.02";
+      v "4.10" Builders.amd4 "debian-10" "4.10";       (* Note: first item is also used as lint platform *)
+      v "4.09" Builders.amd3 "debian-10" "4.09";
+      v "4.08" Builders.amd1 "debian-10" "4.08";
+      v "4.07" Builders.amd2 "debian-10" "4.07";
+      v "4.06" Builders.amd2 "debian-10" "4.06";
+      v "4.05" Builders.amd3 "debian-10" "4.05";
+      v "4.04" Builders.amd3 "debian-10" "4.04";
+      v "4.03" Builders.amd2 "debian-10" "4.03";
+      v "4.02" Builders.amd2 "debian-10" "4.02";
       (* Distributions: *)
-      v "alpine"   Builders.amd1 @@ "alpine-3.11-ocaml-" ^ default_compiler;
-      v "ubuntu"   Builders.amd2 @@ "ubuntu-20.04-ocaml-" ^ default_compiler;
-      v "opensuse" Builders.amd2 @@ "opensuse-15.1-ocaml-" ^ default_compiler;
-      v "centos"   Builders.amd3 @@ "centos-8-ocaml-" ^ default_compiler;
-      v "fedora"   Builders.amd3 @@ "fedora-31-ocaml-" ^ default_compiler;
+      v "alpine"   Builders.amd1 "alpine-3.11"   default_compiler;
+      v "ubuntu"   Builders.amd2 "ubuntu-20.04"  default_compiler;
+      v "opensuse" Builders.amd2 "opensuse-15.1" default_compiler;
+      v "centos"   Builders.amd3 "centos-8"      default_compiler;
+      v "fedora"   Builders.amd3 "fedora-31"     default_compiler;
       (* oraclelinux doesn't work in opam 2 yet *)
     ]
   | `Dev ->
     [
-      v "4.10" Builders.local "debian-10-ocaml-4.10";
+      v "4.10" Builders.local "debian-10" "4.10";
     ]

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -7,16 +7,10 @@ module Docker = Current_docker.Default
 
 let daily = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) ()
 
-let pull builder variant =
-  Current.component "pull@,%s" variant |>
-  let> () = Current.return () in
-  let tag = "ocurrent/opam:" ^ variant in
-  Builder.pull ~schedule:daily builder tag
-
 let platforms =
-  let v { Conf.label; builder; variant } =
-    let base = pull builder variant in
-    Platform.get ~label ~builder ~variant base
+  let v { Conf.label; builder; distro; ocaml_version } =
+    let base = Platform.pull ~schedule:daily ~builder ~distro ~ocaml_version in
+    Platform.get ~label ~builder ~distro ~ocaml_version base
   in
   Current.list_seq (List.map v Conf.platforms)
 

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -1,12 +1,16 @@
-let debian_10_vars = { Ocaml_ci.Platform.Vars.
-                       os = "debian";
-                       arch = "x86_64";
-                       os_family = "debian";
-                       os_distribution = "debian";
-                       os_version = "10" }
+let debian_10_vars ocaml_version =
+  { Ocaml_ci.Platform.Vars.
+    os = "debian";
+    arch = "x86_64";
+    os_family = "debian";
+    os_distribution = "debian";
+    os_version = "10";
+    ocaml_version
+  }
+
 let v = [
-  "debian-10-ocaml-4.10", debian_10_vars;
-  "debian-10-ocaml-4.09", debian_10_vars;
-  "debian-10-ocaml-4.08", debian_10_vars;
-  "debian-10-ocaml-4.07", debian_10_vars;
+  "debian-10-ocaml-4.10", debian_10_vars "4.10";
+  "debian-10-ocaml-4.09", debian_10_vars "4.09";
+  "debian-10-ocaml-4.08", debian_10_vars "4.08";
+  "debian-10-ocaml-4.07", debian_10_vars "4.07";
 ]


### PR DESCRIPTION
This simplifies the compiler search for duniverse builds, and is useful for the solver branch too.