### PR TITLE
Enable download cache for lint jobs

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
-(lang dune 1.11)
+(lang dune 2.0)
 (name ocaml-ci)
-(using fmt 1.0)
+(formatting (enabled_for ocaml))
 
 (generate_opam_files true)
 

--- a/lib/analyse_ocamlformat.ml
+++ b/lib/analyse_ocamlformat.ml
@@ -5,6 +5,10 @@ type source =
   | Vendored of { path : string }
 [@@deriving yojson,eq]
 
+let pp_source f = function
+  | Opam { version } -> Fmt.pf f "version %s (from opam)" version
+  | Vendored { path } -> Fmt.pf f "vendored at %s" path
+
 let ocamlformat_version_from_string =
     let re =
       Re.(

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -3,6 +3,8 @@ type source =
   | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative to the project's root. *)
 [@@deriving yojson,eq]
 
+val pp_source : source Fmt.t
+
 val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> root:Fpath.t -> source option Lwt.t
 (** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,16 +1,14 @@
 val fmt_dockerfile :
   base:string ->
-  info:Analyse.Analysis.t ->
-  variant:string ->
+  ocamlformat_source:Analyse_ocamlformat.source option ->
   for_user:bool ->
   Dockerfile.t
 (** A Dockerfile that checks the formatting. *)
 
 val doc_dockerfile :
   base:string ->
-  info:Analyse.Analysis.t ->
+  opam_files:string list ->
   variant:string ->
   for_user:bool ->
   Dockerfile.t
 (** A Dockerfile that checks that the documentation in [./src/] builds without warnings. *)
-

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -2,9 +2,9 @@ val download_cache : string
 
 val install_project_deps :
   base:string ->
-  info:Analyse.Analysis.t ->
+  opam_files:string list ->
   variant:string ->
   for_user:bool ->
   Dockerfile.t
 
-val dockerfile : base:string -> info:Analyse.Analysis.t -> variant:string -> for_user:bool -> Dockerfile.t
+val dockerfile : base:string -> opam_files:string list -> variant:string -> for_user:bool -> Dockerfile.t


### PR DESCRIPTION
Also, store only the information we need in Build.Spec and show a summary in the build log.