### PR TITLE
Run solver in the analysis phase

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ocurrent"]
 	path = ocurrent
 	url = https://github.com/ocurrent/ocurrent.git
+[submodule "opam-0install-solver"]
+	path = opam-0install-solver
+	url = https://github.com/talex5/opam-0install-solver

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 6cab6a0d6a6919fb3b0e25e34297e1399c43d55d && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 754e9ef4ae5e6a6c43350796974e024b987cc8c0 && opam update
 COPY --chown=opam \
 	ocurrent/current_ansi.opam \
 	ocurrent/current_docker.opam \
@@ -12,6 +12,9 @@ COPY --chown=opam \
 	ocurrent/current_slack.opam \
 	ocurrent/current_web.opam \
 	/src/ocurrent/
+COPY --chown=opam \
+	opam-0install-solver/opam-0install.opam \
+	/src/opam-0install-solver/
 WORKDIR /src
 RUN opam pin add -yn current_ansi.dev "./ocurrent" && \
     opam pin add -yn current_docker.dev "./ocurrent" && \
@@ -21,7 +24,8 @@ RUN opam pin add -yn current_ansi.dev "./ocurrent" && \
     opam pin add -yn current.dev "./ocurrent" && \
     opam pin add -yn current_rpc.dev "./ocurrent" && \
     opam pin add -yn current_slack.dev "./ocurrent" && \
-    opam pin add -yn current_web.dev "./ocurrent"
+    opam pin add -yn current_web.dev "./ocurrent" && \
+    opam pin add -yn opam-0install.dev "./opam-0install-solver"
 COPY --chown=opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 RUN opam install -y --deps-only .
 ADD --chown=opam . .

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 58d97b2c265c368952a50355247bb28a8ab1f597 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 754e9ef4ae5e6a6c43350796974e024b987cc8c0 && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	ocurrent/current_ansi.opam \

--- a/api/dune
+++ b/api/dune
@@ -1,8 +1,9 @@
 (library
   (name ocaml_ci_api)
   (public_name ocaml-ci-api)
-  (libraries capnp-rpc-lwt current_rpc)
-  (flags (:standard -w -53-55)))
+  (libraries capnp-rpc-lwt current_rpc ppx_deriving_yojson.runtime)
+  (flags (:standard -w -53-55))
+  (preprocess (pps ppx_deriving.std ppx_deriving_yojson)))
 
 (rule
  (targets schema.ml schema.mli ocurrent.ml ocurrent.mli)

--- a/api/ocaml_ci_api.ml
+++ b/api/ocaml_ci_api.ml
@@ -1,3 +1,4 @@
 module Raw = Raw
 module Client = Client
 module Common = Common
+module Worker = Worker

--- a/api/worker.ml
+++ b/api/worker.ml
@@ -1,0 +1,42 @@
+(** Communication between ocaml-ci and the workers. *)
+
+(** Variables describing a build environment. *)
+module Vars = struct
+  type t = {
+    arch : string;
+    os : string;
+    os_family : string;
+    os_distribution : string;
+    os_version : string;
+    ocaml_version : string;
+  } [@@deriving yojson]
+end
+
+(** A set of packages for a single build. *)
+module Selection = struct
+  type t = {
+    id : string;                        (** The platform ID from the request. *)
+    packages : string list;             (** The selected packages ("name.version"). *)
+    commit : string;                    (** A commit in opam-repository to use. *)
+  } [@@deriving yojson, ord]
+end
+
+(** A request to select sets of packages for the builds. *)
+module Solve_request = struct
+  type t = {
+    opam_repository : string;                   (** Path of opam repository checkout. *)
+    root_pkgs : (string * string) list;         (** Name and contents of top-level opam files. *)
+    pinned_pkgs : (string * string) list;       (** Name and contents of other pinned opam files. *)
+    platforms : (string * Vars.t) list;         (** Possible build platforms, by ID. *)
+  } [@@deriving yojson]
+end
+
+(** The response from the solver. *)
+module Solve_response = struct
+  type ('a, 'b) result = ('a, 'b) Stdlib.result =
+    | Ok of 'a
+    | Error of 'b
+  [@@deriving yojson]
+
+  type t = (Selection.t list, [`Msg of string]) result [@@deriving yojson]
+end

--- a/dune
+++ b/dune
@@ -1,2 +1,2 @@
 (dirs :standard \ var)
-(vendored_dirs capnp-ocaml capnp-rpc ocurrent)
+(vendored_dirs capnp-ocaml capnp-rpc ocurrent opam-0install-solver)

--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,7 @@
   ocaml-ci-api
   conf-libev
   (dockerfile (>= 6.3.0))
+  opam-0install
   (ocaml-version (>= 2.4.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -5,11 +5,25 @@ module Analysis : sig
   val is_duniverse : t -> bool
   val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
-  val selections : t -> [ `Opam_build of string list | `Duniverse of string list ]
-  (** Get the variants selected for the builds. *)
+  val selections : t -> [
+      | `Opam_build of Ocaml_ci_api.Worker.Selection.t list
+      | `Duniverse of string list               (* Variants to build on *)
+    ]
 
-  val of_dir : job:Current.Job.t -> platforms:(string * Platform.Vars.t) list -> Fpath.t -> (t, [ `Msg of string ]) result Lwt.t
+  val of_dir :
+    solver:Lwt_process.command ->
+    job:Current.Job.t ->
+    platforms:(string * Ocaml_ci_api.Worker.Vars.t) list ->
+    opam_repository:Fpath.t ->
+    Fpath.t ->
+    (t, [ `Msg of string ]) result Lwt.t
 end
 
-val examine : platforms:Platform.t list Current.t -> Current_git.Commit.t Current.t -> Analysis.t Current.t
-(** [examine ~platforms src] analyses the source code [src]. *)
+val examine :
+  solver:Lwt_process.command ->
+  platforms:Platform.t list Current.t ->
+  opam_repository:Current_git.Commit.t Current.t ->
+  Current_git.Commit.t Current.t ->
+  Analysis.t Current.t
+(** [examine ~solver ~platforms ~opam_repository src] analyses the source code [src] and selects
+    package versions to test using [opam_repository]. *)

--- a/lib/analyse_ocamlformat.ml
+++ b/lib/analyse_ocamlformat.ml
@@ -3,7 +3,7 @@ open Lwt.Infix
 type source =
   | Opam of { version : string }
   | Vendored of { path : string }
-[@@deriving yojson,eq]
+[@@deriving yojson, eq, ord]
 
 let pp_source f = function
   | Opam { version } -> Fmt.pf f "version %s (from opam)" version

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,7 +1,7 @@
 type source =
   | Opam of { version : string } (** Should install OCamlformat from Opam. *)
   | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative to the project's root. *)
-[@@deriving yojson,eq]
+[@@deriving yojson, eq, ord]
 
 val pp_source : source Fmt.t
 

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -3,7 +3,7 @@ module Spec : sig
 
   val opam :
     label:string ->
-    variant:string ->
+    selection:Ocaml_ci_api.Worker.Selection.t ->
     analysis:Analyse.Analysis.t ->
     [ `Build | `Lint of [ `Doc | `Fmt ] ] ->
     t

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,5 @@
 (library
   (name ocaml_ci)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries logs current current_docker current_github current.term current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version))
+  (libraries logs current current_docker current_github current.term ocaml-ci-api
+             current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version opam-0install))

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -25,10 +25,10 @@ let fmt_dockerfile ~base ~ocamlformat_source ~for_user =
   @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
   @@ run "opam exec -- dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)"
 
-let doc_dockerfile ~base ~opam_files ~variant ~for_user =
+let doc_dockerfile ~base ~opam_files ~selection ~for_user =
   let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
   let open Dockerfile in
-  Opam_build.install_project_deps ~base ~opam_files ~variant ~for_user
+  Opam_build.install_project_deps ~base ~opam_files ~selection ~for_user
   (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
   @@ run "%sopam depext -i dune odoc>=1.5.0" download_cache_prefix
   @@ run "ODOC_WARN_ERROR=true opam exec -- dune build @doc \

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -8,7 +8,7 @@ val fmt_dockerfile :
 val doc_dockerfile :
   base:string ->
   opam_files:string list ->
-  variant:string ->
+  selection:Ocaml_ci_api.Worker.Selection.t ->
   for_user:bool ->
   Dockerfile.t
 (** A Dockerfile that checks that the documentation in [./src/] builds without warnings. *)

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -70,7 +70,7 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
   distro_extras @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
-  run "cd ~/opam-repository && (git reset --hard %s || (git pull origin master && git reset --hard %s)) && opam update" commit commit @@
+  run "cd ~/opam-repository && (git reset --hard %s || (git pull origin master && git reset --hard %s)) && opam update -u" commit commit @@
   pin_opam_files groups @@
   env ["DEPS", String.concat " " non_root_pkgs] @@
   run "%sopam depext --update -y %s $DEPS" download_cache_prefix (String.concat " " root_pkgs) @@

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -50,9 +50,11 @@ let rec get_root_opam_packages = function
 
 let download_cache = "--mount=type=cache,target=/home/opam/.opam/download-cache,uid=1000"
 
-let install_project_deps ~base ~opam_files ~variant ~for_user =
+let install_project_deps ~base ~opam_files ~selection ~for_user =
+  let { Ocaml_ci_api.Worker.Selection.packages; commit; id = variant } = selection in
   let groups = group_opam_files opam_files in
   let root_pkgs = get_root_opam_packages groups in
+  let non_root_pkgs = packages |> List.filter (fun pkg -> not (List.mem pkg root_pkgs)) in
   let download_cache_prefix = if for_user then "" else download_cache ^ " " in
   let open Dockerfile in
   let distro_extras =
@@ -68,15 +70,14 @@ let install_project_deps ~base ~opam_files ~variant ~for_user =
   distro_extras @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
+  run "cd ~/opam-repository && (git reset --hard %s || (git pull origin master && git reset --hard %s)) && opam update" commit commit @@
   pin_opam_files groups @@
-  run "(opam install %s --dry-run --deps-only -ty; echo $? > /tmp/exit-status) | tee /tmp/opam-plan; exit $(cat /tmp/exit-status)" (root_pkgs |> String.concat " ") @@
-  run "%sawk < /tmp/opam-plan '/-> installed/{print $3}' | xargs opam depext --update -iy" download_cache_prefix @@
-  crunch_list (List.map (fun pkg ->
-      run {|test "$(opam show -f depexts: %s)" = "$(printf "\n")" || opam depext -ty %s|} pkg pkg) root_pkgs
-    )
+  env ["DEPS", String.concat " " non_root_pkgs] @@
+  run "%sopam depext --update -y %s $DEPS" download_cache_prefix (String.concat " " root_pkgs) @@
+  run "%sopam install $DEPS" download_cache_prefix
 
-let dockerfile ~base ~opam_files ~variant ~for_user =
+let dockerfile ~base ~opam_files ~selection ~for_user =
   let open Dockerfile in
-  install_project_deps ~base ~opam_files ~variant ~for_user @@
+  install_project_deps ~base ~opam_files ~selection ~for_user @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
   run "opam exec -- dune build @install @runtest && rm -rf _build"

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -3,8 +3,12 @@ val download_cache : string
 val install_project_deps :
   base:string ->
   opam_files:string list ->
-  variant:string ->
+  selection:Ocaml_ci_api.Worker.Selection.t ->
   for_user:bool ->
   Dockerfile.t
 
-val dockerfile : base:string -> opam_files:string list -> variant:string -> for_user:bool -> Dockerfile.t
+val dockerfile :
+  base:string ->
+  opam_files:string list ->
+  selection:Ocaml_ci_api.Worker.Selection.t ->
+  for_user:bool -> Dockerfile.t

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -1,25 +1,11 @@
 (** A platform on which we wish to perform test builds. *)
 
-(** Opam variables. *)
-module Vars : sig
-  type t = {
-    arch : string;
-    os : string;
-    os_family : string;
-    os_distribution : string;
-    os_version : string;
-    ocaml_version : string;
-  } [@@deriving yojson]
-
-  val ocaml_major_version : t -> Ocaml_version.t
-end
-
 type t = {
   label : string;
   builder : Builder.t;
   variant : string;                     (* e.g. "debian-10-ocaml-4.08" *)
   base : Current_docker.Raw.Image.t;
-  vars : Vars.t;
+  vars : Ocaml_ci_api.Worker.Vars.t;
 }
 
 val pp : t Fmt.t

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml-ci-api"
   "conf-libev"
   "dockerfile" {>= "6.3.0"}
+  "opam-0install"
   "ocaml-version" {>= "2.4.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -73,4 +73,6 @@ let platforms =
   | `Dev ->
     [
       v "4.10" Builders.local "debian-10" "4.10";
+      v "4.09" Builders.local "debian-10" "4.09";
+      v "4.02" Builders.local "debian-10" "4.02";
     ]

--- a/service/dune
+++ b/service/dune
@@ -14,5 +14,6 @@
             mirage-crypto-rng.unix
             ocaml_ci
             ocaml-ci-api
+            ocaml_ci_solver
             prometheus)
  (preprocess (pps ppx_deriving_yojson)))

--- a/service/local.ml
+++ b/service/local.ml
@@ -1,5 +1,12 @@
 (* Utility program for testing the CI pipeline on a local repository. *)
 
+let solver =
+  match Sys.argv with
+  | [| _; "--run-solver" |] -> Ocaml_ci_solver.main (); exit 0
+  | args ->
+    let prog = args.(0) in
+    prog, [| prog; "--run-solver" |]
+
 let () =
   Unix.putenv "DOCKER_BUILDKIT" "1";
   Unix.putenv "PROGRESS_NO_TRUNC" "1";
@@ -7,7 +14,7 @@ let () =
 
 let main config mode repo =
   let repo = Current_git.Local.v (Fpath.v repo) in
-  let engine = Current.Engine.create ~config (Pipeline.local_test repo) in
+  let engine = Current.Engine.create ~config (Pipeline.local_test ~solver repo) in
   let site = Current_web.Site.(v ~has_role:allow_all) ~name:"ocaml-ci-local" (Current_web.routes engine) in
   Logging.run begin
     Lwt.choose [

--- a/service/main.ml
+++ b/service/main.ml
@@ -1,5 +1,12 @@
 open Lwt.Infix
 
+let solver =
+  match Sys.argv with
+  | [| _; "--run-solver" |] -> Ocaml_ci_solver.main (); exit 0
+  | args ->
+    let prog = args.(0) in
+    prog, [| prog; "--run-solver" |]
+
 let () =
   Logging.init ();
   Mirage_crypto_rng_unix.initialize ();
@@ -40,7 +47,7 @@ let has_role user = function
     | _ -> false
 
 let main config mode app capnp_address github_auth =
-  let engine = Current.Engine.create ~config (Pipeline.v ~app) in
+  let engine = Current.Engine.create ~config (Pipeline.v ~app ~solver) in
   let authn = Option.map Current_github.Auth.make_login_uri github_auth in
   let has_role =
     if github_auth = None then Current_web.Site.allow_all

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,5 +1,5 @@
-val local_test : Current_git.Local.t -> unit -> unit Current.t
-(** [local_test repo] is a pipeline that tests local repository [repo] as the CI would. *)
+val local_test : solver:Lwt_process.command -> Current_git.Local.t -> unit -> unit Current.t
+(** [local_test ~solver repo] is a pipeline that tests local repository [repo] as the CI would. *)
 
-val v : app:Current_github.App.t -> unit -> unit Current.t
+val v : app:Current_github.App.t -> solver:Lwt_process.command -> unit -> unit Current.t
 (** The main ocaml-ci pipeline. Tests everything configured for GitHub application [app]. *)

--- a/solver/dune
+++ b/solver/dune
@@ -1,0 +1,4 @@
+(library
+  (name ocaml_ci_solver)
+  (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
+  (libraries lwt.unix logs ocaml-ci-api ppx_deriving_yojson.runtime opam-0install))

--- a/solver/ocaml_ci_solver.ml
+++ b/solver/ocaml_ci_solver.ml
@@ -1,0 +1,15 @@
+module Worker = Ocaml_ci_api.Worker
+
+let main () =
+  Logs.(set_level (Some Info));
+  Logs.set_reporter @@ Logs_fmt.reporter ();
+  match Worker.Solve_request.of_yojson (Yojson.Safe.from_channel stdin) with
+  | Error msg -> Fmt.failwith "Bad request: %s" msg
+  | Ok request ->
+    let response =
+      try Ok (Solver.solve request)
+      with
+      | Failure msg -> Error (`Msg msg)
+      | ex -> Fmt.error_msg "%a" Fmt.exn ex
+    in
+    Yojson.Safe.to_channel stdout (Worker.Solve_response.to_yojson response)

--- a/solver/ocaml_ci_solver.mli
+++ b/solver/ocaml_ci_solver.mli
@@ -1,0 +1,1 @@
+val main : unit -> unit

--- a/solver/process.ml
+++ b/solver/process.ml
@@ -1,0 +1,27 @@
+open Lwt.Infix
+
+let pp_args =
+  let sep = Fmt.(const string) " " in
+  Fmt.(array ~sep (quote string))
+
+let pp_cmd f = function
+  | "", args -> pp_args f args
+  | bin, args -> Fmt.pf f "(%S, %a)" bin pp_args args
+
+let pp_signal f x =
+  let open Sys in
+  if x = sigkill then Fmt.string f "kill"
+  else if x = sigterm then Fmt.string f "term"
+  else Fmt.int f x
+
+let check_status cmd = function
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED x -> Fmt.failwith "%a exited with status %d" pp_cmd cmd x
+  | Unix.WSIGNALED x -> Fmt.failwith  "%a failed with signal %d" pp_cmd cmd x
+  | Unix.WSTOPPED x -> Fmt.failwith  "%a stopped with signal %a" pp_cmd cmd pp_signal x
+
+let pread cmd =
+  let proc = Lwt_process.open_process_in cmd in
+  Lwt_io.read proc#stdout >>= fun output ->
+  proc#status >|= check_status cmd >|= fun () ->
+  output

--- a/solver/solver.ml
+++ b/solver/solver.ml
@@ -1,0 +1,168 @@
+open Lwt.Infix
+
+let src = Logs.Src.create "ocaml_ci_solver" ~doc:"ocaml-ci dependency solver"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Worker = Ocaml_ci_api.Worker
+module Solver = Opam_0install.Solver.Make(Opam_0install.Dir_context)
+module Selection = Worker.Selection
+
+let ( / ) = Filename.concat
+
+let env (vars : Worker.Vars.t) =
+  Opam_0install.Dir_context.std_env
+    ~arch:vars.arch
+    ~os:vars.os
+    ~os_distribution:vars.os_distribution
+    ~os_version:vars.os_version
+    ~os_family:vars.os_family
+
+let ocaml_name = OpamPackage.Name.of_string "ocaml"
+
+(* Use "git-log" to find the oldest commit with these package versions.
+   This avoids invalidating the Docker build cache on every update to opam-repository. *)
+let oldest_commit_with ~opam_repository ~pins pkgs =
+  let paths =
+    pkgs |> List.filter_map (fun pkg ->
+        let { OpamPackage.name; version } = OpamPackage.of_string pkg in
+        if OpamPackage.Name.Map.mem name pins then None
+        else (
+          let name = OpamPackage.Name.to_string name in
+          let version = OpamPackage.Version.to_string version in
+          Some (Printf.sprintf "%s/%s.%s" name name version)
+        )
+      )
+  in
+  let cmd = "git" :: "-C" :: opam_repository / "packages" :: "log" :: "-n" :: "1" :: "--format=format:%H" :: paths in
+  let cmd = ("", Array.of_list cmd) in
+  Process.pread cmd >|= String.trim
+
+let version_2 = OpamVersion.of_string "2"
+
+let parse_opam (name, contents) =
+  let pkg = OpamPackage.of_string name in
+  let opam = OpamFile.OPAM.read_from_string contents in
+  let opam_version = OpamFile.OPAM.opam_version opam in
+  if OpamVersion.compare opam_version version_2 < 0 then
+    Fmt.failwith "Package %S uses unsupported opam version %s (need >= 2)" name (OpamVersion.to_string opam_version);
+  OpamPackage.name pkg, (OpamPackage.version pkg, opam)
+
+let run_child ~opam_repository ~pins ~root_pkgs (vars : Worker.Vars.t) =
+  let ocaml_version = OpamPackage.Version.of_string vars.ocaml_version in
+  let context =
+    Opam_0install.Dir_context.create (opam_repository / "packages")
+      ~pins
+      ~env:(env vars)
+      ~constraints:(OpamPackage.Name.Map.singleton ocaml_name (`Eq, ocaml_version))
+      ~test:(OpamPackage.Name.Set.of_list root_pkgs)
+  in
+  let t0 = Unix.gettimeofday () in
+  let r = Solver.solve context root_pkgs in
+  let t1 = Unix.gettimeofday () in
+  Printf.printf "%.2f\n" (t1 -. t0);
+  match r with
+  | Ok sels ->
+    let pkgs = Solver.packages_of_result sels in
+    let packages = List.map OpamPackage.to_string pkgs in
+    Printf.printf "+%s%!" @@ String.concat " " packages
+  | Error diagnostics ->
+    let msg = Solver.diagnostics diagnostics in
+    Printf.printf "-%s%!" msg
+
+let rec waitpid_non_intr pid =
+  try Unix.waitpid [] pid
+  with Unix.Unix_error (Unix.EINTR, _, _) -> waitpid_non_intr pid
+
+let check_exit_status = function
+  | Unix.WEXITED 0 -> ()
+  | Unix.WEXITED code -> Fmt.failwith "Child returned error exit status %d" code
+  | Unix.WSIGNALED signal -> Fmt.failwith "Child aborted (signal %d)" signal
+  | Unix.WSTOPPED signal -> Fmt.failwith "Child is currently stopped (signal %d)" signal
+
+let spawn_child run (id, vars) =
+  let r, w = Unix.pipe ~cloexec:true () in
+  match Unix.fork () with
+  | 0 -> (* We are the child *)
+    begin
+      try
+        Unix.close r;
+        Unix.dup2 w Unix.stdout;
+        run vars;
+        exit 0
+      with ex ->
+        Printf.printf "-%s\n%!" (Printexc.to_string ex);
+        exit 1
+    end
+  | child ->
+    Unix.close w;
+    id, child, r
+
+let pp_name = Fmt.of_to_string OpamPackage.Name.to_string
+
+let solve { Worker.Solve_request.opam_repository; root_pkgs; pinned_pkgs; platforms } =
+  let root_pkgs = List.map parse_opam root_pkgs in
+  let pinned_pkgs = List.map parse_opam pinned_pkgs in
+  let pins =
+    root_pkgs @ pinned_pkgs
+    |> OpamPackage.Name.Map.of_list
+  in
+  let root_pkgs = List.map fst root_pkgs in
+  Log.info (fun f -> f "Solving for %a" (Fmt.(list ~sep:comma) pp_name) root_pkgs);
+  let jobs = List.map (spawn_child (run_child ~opam_repository ~pins ~root_pkgs)) platforms in
+  let results =
+    jobs |> List.map (fun (id, pid, from_child) ->
+        let buf = Bytes.create 4096 in
+        let results = Buffer.create 4096 in
+        let rec read () =
+          let got = Unix.read from_child buf 0 (Bytes.length buf) in
+          if got > 0 then (
+            Buffer.add_subbytes results buf 0 got;
+            read ()
+          ) else (
+            Unix.close from_child;
+            Buffer.contents results
+          )
+        in
+        let results = read () in
+        waitpid_non_intr pid |> snd |> check_exit_status;
+        match Astring.String.cut ~sep:"\n" results with
+        | None -> Fmt.failwith "Missing newline in solver results: %S" results
+        | Some (time, results) ->
+          if String.length results = 0 then Fmt.failwith "No output from solve worker!";
+          match results.[0] with
+          | '+' ->
+            Log.info (fun f -> f "%s: found solution in %s s" id time);
+            let packages =
+              Astring.String.with_range ~first:1 results
+              |> Astring.String.cuts ~sep:" "
+            in
+            (id, Ok packages)
+          | '-' ->
+            Log.info (fun f -> f "%s: eliminated all possibilities in %s s" id time);
+            let msg = results |> Astring.String.with_range ~first:1 in
+            (id, Error msg)
+          | _ ->
+            Fmt.failwith "BUG: bad output: %s" results
+      ) in
+  (* Now all the sub-processes are gone, we can safely start Lwt. *)
+  Lwt_main.run begin
+    results
+    |> Lwt_list.map_p (fun (id, output) ->
+        match output with
+        | Ok packages ->
+          oldest_commit_with packages ~opam_repository ~pins >|= fun commit ->
+          id, Ok { Selection.id; packages; commit }
+        | Error _ as e -> Lwt.return (id, e)
+      )
+    >|= List.filter_map (fun (id, result) ->
+        Log.info (fun f -> f "= %s =" id);
+        match result with
+        | Ok result ->
+          Log.info (fun f -> f "-> @[<hov>%a@]" Fmt.(list ~sep:sp string) result.Selection.packages);
+          Log.info (fun f -> f "(valid since opam-repository commit %s)" result.Selection.commit);
+          Some result
+        | Error msg ->
+          Log.info (fun f -> f "%s" msg);
+          None
+      )
+  end

--- a/solver/solver.mli
+++ b/solver/solver.mli
@@ -1,0 +1,1 @@
+val solve : Ocaml_ci_api.Worker.Solve_request.t -> Ocaml_ci_api.Worker.Selection.t list

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,10 @@
-(test
+(executable
  (name test)
- (package ocaml-ci-service)
- (libraries ocaml_ci alcotest alcotest-lwt ppx_deriving_yojson.runtime)
+ (libraries ocaml_ci alcotest alcotest-lwt ppx_deriving_yojson.runtime logs.fmt)
  (preprocess (pps ppx_deriving.eq ppx_deriving_yojson)))
+
+(rule
+  (alias runtest)
+  (package ocaml-ci-service)
+  (deps (alias ../install))
+  (action (run ./test.exe)))

--- a/test/gen_project.ml
+++ b/test/gen_project.ml
@@ -181,6 +181,20 @@ let dune_get ppf =
  (depexts ()))
 |}
 
+let dummy_opam ppf =
+  Fmt.pf ppf
+    {|opam-version: "2.0"
+maintainer:   "Camelus Bactrianus"
+authors:      ["Camelus Bactrianus"]
+license:      "ISC"
+homepage:     "https://www.example.com"
+bug-reports:  "https://www.example.com/issues"
+dev-repo:     "git+https://example.com/repo.git"
+build: []
+depends: []
+synopsis: "Example project generated for testing purposes"
+|}
+
 let opam ppf =
   Fmt.pf ppf
     {|opam-version: "2.0"
@@ -219,6 +233,10 @@ let empty_file _ppf = ()
 
 type file = Folder of string * file list | File of string * contents
 
+let folder name items = Folder (name, items)
+
+let file name content = File (name, content)
+
 let print_to_file path printer =
   let channel = open_out path in
   let formatter = Format.formatter_of_out_channel channel in
@@ -241,3 +259,11 @@ let rec instantiate ~root =
         mkdir_p name;
         instantiate ~root:(Filename.concat root name) contents
     | File (name, printer) -> print_to_file (Filename.concat root name) printer)
+
+let dummy_package name versions =
+  folder name
+    ( versions
+    |> List.map (fun version ->
+           folder
+             (Printf.sprintf "%s.%s" name version)
+             [ file "opam" dummy_opam ]) )

--- a/test/gen_project.mli
+++ b/test/gen_project.mli
@@ -4,6 +4,10 @@ type contents = Format.formatter -> unit
 
 type file = Folder of string * file list | File of string * contents
 
+val file : string -> contents -> file
+
+val folder : string -> file list -> file
+
 val dune_get : contents
 (** Contents of an example [dune-get] file *)
 
@@ -18,3 +22,9 @@ val empty_file : contents
 
 val instantiate : root:string -> file list -> unit
 (** Take a directory specification and persist it to disk *)
+
+(** {2 Generation of opam-repository} *)
+
+val dummy_package : string -> string list -> file
+(** [dummy_package name versions] is an opam-repository "packages/$name" directory,
+    containing dummy packages for each version. *)

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -1,5 +1,5 @@
 let debian_10_vars ocaml_version =
-  { Ocaml_ci.Platform.Vars.
+  { Ocaml_ci_api.Worker.Vars.
     os = "debian";
     arch = "x86_64";
     os_family = "debian";
@@ -9,8 +9,8 @@ let debian_10_vars ocaml_version =
   }
 
 let v = [
-  "debian-10-ocaml-4.10", debian_10_vars "4.10";
-  "debian-10-ocaml-4.09", debian_10_vars "4.09";
-  "debian-10-ocaml-4.08", debian_10_vars "4.08";
-  "debian-10-ocaml-4.07", debian_10_vars "4.07";
+  "debian-10-ocaml-4.10", debian_10_vars "4.10.0";
+  "debian-10-ocaml-4.09", debian_10_vars "4.09.0";
+  "debian-10-ocaml-4.08", debian_10_vars "4.08.0";
+  "debian-10-ocaml-4.07", debian_10_vars "4.07.0";
 ]


### PR DESCRIPTION
This is faster, and avoids the need to run separate Docker builds on platforms for which there is no solution. More importantly, it allows us to follow changes in opam-repository more closely, since updating that no longer requires pulling a new set of base images and rebuilding everything.