### PR TITLE
Check for opam-repository updates hourly

### DIFF
--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -18,7 +18,9 @@ let platforms =
 (* Link for GitHub statuses. *)
 let url ~owner ~name ~hash = Uri.of_string (Printf.sprintf "https://ci.ocamllabs.io/github/%s/%s/commit/%s" owner name hash)
 
-let opam_repository = Git.clone ~schedule:daily "https://github.com/ocaml/opam-repository.git"
+let opam_repository =
+  let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_hour 1) () in
+  Git.clone ~schedule "https://github.com/ocaml/opam-repository.git"
 
 let github_status_of_state ~head result =
   let+ head = head


### PR DESCRIPTION
Now we have queue priorities, frequent updates shouldn't be so much of a problem. This might use a lot of CPU time resolving everything, but let's try it and see what happens...