### PR TITLE
Add some support for pin-depends

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -75,6 +75,57 @@ module Analysis = struct
   let ocaml_major_version vars =
     Ocaml_version.with_just_major_and_minor (Ocaml_version.of_string_exn vars.Worker.Vars.ocaml_version)
 
+  let duniverse_selections ~job ~platforms dir =
+    let vs = get_ocaml_versions dir in
+    if vs = [] then failwith "No OCaml compilers specified!";
+    let find_compiler v =
+      let v = Ocaml_version.with_just_major_and_minor (Ocaml_version.of_string_exn v) in
+      let matches_compiler (_variant, vars) =
+        Ocaml_version.compare v (ocaml_major_version vars) = 0
+      in
+      match List.find_opt matches_compiler platforms with
+      | None ->
+        Current.Job.log job "WARNING: Unsupported compiler version %a (have: %a)"
+          Ocaml_version.pp v Fmt.(Dump.list pp_ocaml_version) platforms;
+        None
+      | Some (variant, _vars) ->
+        Some variant
+    in
+    let variants = List.filter_map find_compiler vs in
+    if variants = [] then failwith "No supported compilers found!";
+    Lwt_result.return (`Duniverse variants)
+
+  let opam_selections ~solver ~job ~platforms ~opam_repository ~opam_files dir =
+    let src = Fpath.to_string dir in
+    let ( / ) = Filename.concat in
+    let root_pkgs, pinned_pkgs =
+      opam_files |> List.fold_left (fun (root_pkgs, pinned_pkgs) path ->
+          let name = Filename.basename path |> Filename.chop_extension in
+          let name = if String.contains name '.' then name else name ^ ".dev" in
+          let item = name, read_file ~max_len:102400 (src / path) in
+          if Filename.dirname path = "." then
+            (item :: root_pkgs, pinned_pkgs)
+          else
+            (root_pkgs, item :: pinned_pkgs)
+        ) ([], [])
+    in
+    let request = { Ocaml_ci_api.Worker.Solve_request.
+                    opam_repository = Fpath.to_string opam_repository;
+                    root_pkgs;
+                    pinned_pkgs;
+                    platforms
+                  } in
+    let stdin = Yojson.Safe.to_string (Ocaml_ci_api.Worker.Solve_request.to_yojson request) in
+    Current.Process.check_output ~job ~stdin ~cancellable:false solver >>!= fun response ->
+    let json = Yojson.Safe.from_string response in
+    match Worker.Solve_response.of_yojson json with
+    | Error msg -> Lwt.return (Fmt.error_msg "Bad solver response: %s" msg)
+    | Ok response ->
+      match response with
+      | Ok [] -> Lwt.return (Fmt.error_msg "No solution found for any supported platform")
+      | Ok x -> Lwt_result.return (`Opam_build x)
+      | Error (`Msg msg) -> Lwt.return (Fmt.error_msg "Error from solver: %s" msg)
+
   let of_dir ~solver ~job ~platforms ~opam_repository dir =
     let is_duniverse = Sys.file_exists (Filename.concat (Fpath.to_string dir) "dune-get") in
     let cmd = "", [| "find"; "."; "-maxdepth"; "3"; "-name"; "*.opam" |] in
@@ -117,56 +168,8 @@ module Analysis = struct
     else if List.filter is_toplevel opam_files = [] then Lwt_result.fail (`Msg "No top-level opam files found!")
     else (
       begin
-        if is_duniverse then (
-          let vs = get_ocaml_versions dir in
-          if vs = [] then failwith "No OCaml compilers specified!";
-          let find_compiler v =
-            let v = Ocaml_version.with_just_major_and_minor (Ocaml_version.of_string_exn v) in
-            let matches_compiler (_variant, vars) =
-              Ocaml_version.compare v (ocaml_major_version vars) = 0
-            in
-            match List.find_opt matches_compiler platforms with
-            | None ->
-              Current.Job.log job "WARNING: Unsupported compiler version %a (have: %a)"
-                Ocaml_version.pp v Fmt.(Dump.list pp_ocaml_version) platforms;
-              None
-            | Some (variant, _vars) ->
-              Some variant
-          in
-          let variants = List.filter_map find_compiler vs in
-          if variants = [] then failwith "No supported compilers found!";
-          Lwt_result.return (`Duniverse variants)
-        ) else (
-          let src = Fpath.to_string dir in
-          let ( / ) = Filename.concat in
-          let root_pkgs, pinned_pkgs =
-            opam_files |> List.fold_left (fun (root_pkgs, pinned_pkgs) path ->
-                let name = Filename.basename path |> Filename.chop_extension in
-                let name = if String.contains name '.' then name else name ^ ".dev" in
-                let item = name, read_file ~max_len:102400 (src / path) in
-                if Filename.dirname path = "." then
-                  (item :: root_pkgs, pinned_pkgs)
-                else
-                  (root_pkgs, item :: pinned_pkgs)
-              ) ([], [])
-          in
-          let request = { Ocaml_ci_api.Worker.Solve_request.
-            opam_repository = Fpath.to_string opam_repository;
-            root_pkgs;
-            pinned_pkgs;
-            platforms
-          } in
-          let stdin = Yojson.Safe.to_string (Ocaml_ci_api.Worker.Solve_request.to_yojson request) in
-          Current.Process.check_output ~job ~stdin ~cancellable:false solver >>!= fun response ->
-          let json = Yojson.Safe.from_string response in
-          match Worker.Solve_response.of_yojson json with
-          | Error msg -> Lwt.return (Fmt.error_msg "Bad solver response: %s" msg)
-          | Ok response ->
-            match response with
-            | Ok [] -> Lwt.return (Fmt.error_msg "No solution found for any supported platform")
-            | Ok x -> Lwt_result.return (`Opam_build x)
-            | Error (`Msg msg) -> Lwt.return (Fmt.error_msg "Error from solver: %s" msg)
-        )
+        if is_duniverse then duniverse_selections ~job ~platforms dir
+        else opam_selections ~solver ~job ~platforms ~opam_repository ~opam_files dir
       end >>!= fun selections ->
       let r = { opam_files; ocamlformat_source; selections } in
       Current.Job.log job "@[<v2>Results:@,%a@]" Yojson.Safe.(pretty_print ~std:true) (to_yojson r);

--- a/lib/dune
+++ b/lib/dune
@@ -1,5 +1,5 @@
 (library
   (name ocaml_ci)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries logs current current_docker current_github current.term ocaml-ci-api
+  (libraries logs current current_docker current_github current.term ocaml-ci-api str
              current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version opam-0install))

--- a/lib/pin_depends.ml
+++ b/lib/pin_depends.ml
@@ -1,0 +1,91 @@
+open Lwt.Infix
+
+module Repo_map = Map.Make(String)
+
+let ( >>!= ) x f =
+  x >>= function
+  | Ok x -> f x
+  | Error (`Msg m) -> failwith m
+
+let repo_locks = ref Repo_map.empty
+
+let repo_lock repo =
+  match Repo_map.find_opt repo !repo_locks with
+  | Some l -> l
+  | None ->
+    let l = Lwt_mutex.create () in
+    repo_locks := Repo_map.add repo l !repo_locks;
+    l
+
+module Cmd = struct
+  let id_of_repo repo =
+    let base = Filename.basename repo in
+    let digest = Digest.string repo |> Digest.to_hex in
+    Fmt.strf "%s-%s" base digest
+
+  (* .../var/pin-depends/myrepo-hhh *)
+  let local_copy repo =
+    let repos_dir = Current.state_dir "pin-depends" in
+    Fpath.append repos_dir (Fpath.v (id_of_repo repo))
+
+  let dir_exists path =
+    match Unix.lstat (Fpath.to_string path) with
+    | { Unix.st_kind = S_DIR; _ } -> true
+    | _ -> false
+    | exception Unix.Unix_error(Unix.ENOENT, _, _) -> false
+
+  let git ~cancellable ~job ?cwd args =
+    let args =
+      match cwd with
+      | None -> args
+      | Some cwd -> "-C" :: Fpath.to_string cwd :: args
+    in
+    let cmd = Array.of_list ("git" :: args) in
+    Current.Process.exec ~cancellable ~job ("", cmd)
+
+  let git_clone ~cancellable ~job ~src dst =
+    git ~cancellable ~job ["clone"; "-q"; src; Fpath.to_string dst]
+
+  let git_fetch ~cancellable ~job repo =
+    git ~cancellable ~job ~cwd:repo ["fetch"]
+
+  let git_show ~job ~repo hash file =
+    let cmd = ["git"; "-C"; Fpath.to_string repo; "show"; Printf.sprintf "%s:%s" hash file] in
+    Current.Process.check_output ~cancellable:true ~job ("", Array.of_list cmd)
+end
+
+let clone ~job repo =
+  Lwt_mutex.with_lock (repo_lock repo) @@ fun () ->
+  let local_repo = Cmd.local_copy repo in
+  begin
+    if Cmd.dir_exists local_repo
+    then Cmd.git_fetch ~cancellable:true ~job local_repo
+    else Cmd.git_clone ~cancellable:true ~job ~src:repo local_repo
+  end >>!= fun () ->
+  Lwt_result.return local_repo
+
+let re_hash = Str.regexp "^[0-9A-Fa-f]+$"
+
+let get_opam ~job ~pkg url =
+  let { OpamUrl.transport; path = _; hash; backend } = url in
+  if backend <> `git then
+    Fmt.failwith "Only Git pin-depends are supported (got %S for %s)"
+      (OpamUrl.to_string url) (OpamPackage.to_string pkg);
+  if transport <> "https" then Fmt.failwith "Only 'git+https://' scheme is supported (got %S for %s)"
+      transport (OpamPackage.to_string pkg);
+  match hash with
+  | None ->
+    Fmt.failwith "Missing '#commit' in %S for package %s"
+      (OpamUrl.to_string url) (OpamPackage.to_string pkg)
+  | Some hash ->
+    if not (Str.string_match re_hash hash 0) then
+      Fmt.failwith "Invalid commit hash %S for package %s" hash (OpamPackage.to_string pkg);
+    let opam_filename = OpamPackage.name_to_string pkg ^ ".opam" in
+    let repo_url = OpamUrl.base_url url in
+    let repo = Cmd.local_copy repo_url in
+    Cmd.git_show ~job ~repo hash opam_filename >>= function
+    | Ok contents -> Lwt.return contents
+    | Error _ ->
+      clone ~job repo_url >>!= fun repo ->
+      Cmd.git_show ~job ~repo hash opam_filename >>!= fun contents ->
+      Lwt.return contents

--- a/lib/pin_depends.mli
+++ b/lib/pin_depends.mli
@@ -1,0 +1,2 @@
+(** [pkg] should be pinned to [url]; return the opam file. *)
+val get_opam : job:Current.Job.t -> pkg:OpamPackage.t -> OpamUrl.t -> string Lwt.t


### PR DESCRIPTION
Only accepts pins with a `git+https` scheme, and pin must be to a specific hash. Should be enough to unblock projects using pin-depends though.