### PR TITLE
Add support of OCaml 4.10+32bit on Debian

### DIFF
--- a/service/conf.ml
+++ b/service/conf.ml
@@ -69,6 +69,8 @@ let platforms =
       v "centos"   Builders.amd3 "centos-8"      default_compiler;
       v "fedora"   Builders.amd3 "fedora-31"     default_compiler;
       (* oraclelinux doesn't work in opam 2 yet *)
+      (* Variants *)
+      v "4.10+32bit" Builders.amd4 "debian-10" "4.10+32bit";
     ]
   | `Dev ->
     [

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -70,7 +70,7 @@ let platforms =
       v "fedora"   Builders.amd3 "fedora-31"     default_compiler;
       (* oraclelinux doesn't work in opam 2 yet *)
       (* Variants *)
-      v "4.10+32bit" Builders.amd4 "debian-10" "4.10+32bit";
+      v (default_compiler ^ "+32bit") Builders.amd4 "debian-10" (default_compiler ^ "+32bit");
     ]
   | `Dev ->
     [


### PR DESCRIPTION
Want to fix #182, 4.10 seems enough I think - however, a docker image is missing.