### PR TITLE
Show opam-repository at left of diagram

### DIFF
--- a/service/main.ml
+++ b/service/main.ml
@@ -53,11 +53,12 @@ let main config mode app capnp_address github_auth =
     if github_auth = None then Current_web.Site.allow_all
     else has_role
   in
+  let secure_cookies = github_auth <> None in
   let routes =
     Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook) ::
     Routes.(s "login" /? nil @--> Current_github.Auth.login github_auth) ::
     Current_web.routes engine in
-  let site = Current_web.Site.v ?authn ~has_role ~secure_cookies:true ~name:"ocaml-ci" routes in
+  let site = Current_web.Site.v ?authn ~has_role ~secure_cookies ~name:"ocaml-ci" routes in
   Logging.run begin
     run_capnp ~engine capnp_address >>= fun () ->
     Lwt.choose [

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -142,6 +142,7 @@ let local_test ~solver repo () =
   Current_incr.const (result, None)
 
 let v ~app ~solver () =
+  Current.with_context opam_repository @@ fun () ->
   Current.with_context platforms @@ fun () ->
   Github.App.installations app |> Current.list_iter ~collapse_key:"org" (module Github.Installation) @@ fun installation ->
   let repos = Github.Installation.repositories installation in


### PR DESCRIPTION
This makes it clearer that it's the same for all analysis jobs, avoiding the need to expand a particular repository to find it.