### PR TITLE
Use git-unix to read opam-repository

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -24,7 +24,7 @@ end
 (** A request to select sets of packages for the builds. *)
 module Solve_request = struct
   type t = {
-    opam_repository : string;                   (** Path of opam repository checkout. *)
+    opam_repository_commit : string;            (** Commit in opam repository to use. *)
     root_pkgs : (string * string) list;         (** Name and contents of top-level opam files. *)
     pinned_pkgs : (string * string) list;       (** Name and contents of other pinned opam files. *)
     platforms : (string * Vars.t) list;         (** Possible build platforms, by ID. *)

--- a/dune-project
+++ b/dune-project
@@ -1,6 +1,6 @@
 (lang dune 2.0)
 (name ocaml-ci)
-(formatting (enabled_for ocaml))
+(formatting disabled)
 
 (generate_opam_files true)
 
@@ -48,6 +48,7 @@
   ocaml-ci-api
   conf-libev
   opam-0install
+  git-unix
   (capnp-rpc-unix (>= 0.7.0))
 ))
 

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -14,7 +14,7 @@ module Analysis : sig
     solver:Ocaml_ci_api.Solver.t ->
     job:Current.Job.t ->
     platforms:(string * Ocaml_ci_api.Worker.Vars.t) list ->
-    opam_repository:Fpath.t ->
+    opam_repository_commit:Current_git.Commit_id.t ->
     Fpath.t ->
     (t, [ `Msg of string ]) result Lwt.t
 end

--- a/lib/solver_pool.ml
+++ b/lib/solver_pool.ml
@@ -1,7 +1,13 @@
-let spawn_local () : Ocaml_ci_api.Solver.t =
+let spawn_local ?solver_dir () : Ocaml_ci_api.Solver.t =
   let p, c = Unix.(socketpair PF_UNIX SOCK_STREAM 0 ~cloexec:true) in
   Unix.clear_close_on_exec c;
-  let _child = Lwt_process.open_process_none ~stdin:(`FD_move c) ("", [| "ocaml-ci-solver" |]) in
+  let solver_dir =
+    match solver_dir with
+    | None -> Fpath.to_string (Current.state_dir "solver")
+    | Some x -> x
+  in
+  let cmd = ("", [| "ocaml-ci-solver" |]) in
+  let _child = Lwt_process.open_process_none ~cwd:solver_dir ~stdin:(`FD_move c) cmd in
   let switch = Lwt_switch.create () in
   let p = Lwt_unix.of_unix_file_descr p
           |> Capnp_rpc_unix.Unix_flow.connect ~switch

--- a/ocaml-ci-solver.opam
+++ b/ocaml-ci-solver.opam
@@ -14,6 +14,7 @@ depends: [
   "ocaml-ci-api"
   "conf-libev"
   "opam-0install"
+  "git-unix"
   "capnp-rpc-unix" {>= "0.7.0"}
 ]
 build: [

--- a/solver/dune
+++ b/solver/dune
@@ -3,4 +3,4 @@
   (public_name ocaml-ci-solver)
   (package ocaml-ci-solver)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries lwt.unix ocaml-ci-api ppx_deriving_yojson.runtime opam-0install capnp-rpc-unix))
+  (libraries lwt.unix ocaml-ci-api ppx_deriving_yojson.runtime opam-0install capnp-rpc-unix git-unix))

--- a/solver/epoch_lock.ml
+++ b/solver/epoch_lock.ml
@@ -1,0 +1,63 @@
+open Lwt.Infix
+
+type 'a t = {
+  mutable current : [
+    | `Idle
+    | `Activating of unit Lwt.t                      (* Promise resolves after moving to [`Active] *)
+    | `Active of string * 'a
+    | `Draining of unit Lwt.t * unit Lwt_condition.t (* Promise resolves after moving back to [`Active] *)
+  ];
+  mutable users : int;          (* Zero unless active or draining *)
+  create : string -> 'a Lwt.t;
+  dispose : 'a -> unit Lwt.t;
+}
+
+let activate t epoch ~ready ~set_ready =
+  t.current <- `Activating ready;
+  t.create epoch >|= fun v ->
+  t.current <- `Active (epoch, v);
+  Lwt.wakeup_later set_ready ()
+
+let rec with_epoch t epoch fn =
+  match t.current with
+  | `Active (current_epoch, v) when current_epoch = epoch ->
+    t.users <- t.users + 1;
+    Lwt.finalize
+      (fun () -> fn v)
+      (fun () ->
+        t.users <- t.users - 1;
+        begin match t.current with
+          | `Active _ ->  ()
+          | `Draining (_, cond) -> if t.users = 0 then Lwt_condition.broadcast cond ()
+          | `Idle | `Activating _ -> assert false
+        end;
+        Lwt.return_unit
+      )
+  | `Active (_, old_v) ->
+    let cond = Lwt_condition.create () in
+    let ready, set_ready = Lwt.wait () in
+    t.current <- `Draining (ready, cond);
+    (* After this point, no new users can start. *)
+    let rec drain () =
+      if t.users = 0 then Lwt.return_unit
+      else Lwt_condition.wait cond >>= drain
+    in
+    drain () >>= fun () ->
+    t.dispose old_v >>= fun () ->
+    activate t epoch ~ready ~set_ready >>= fun () ->
+    with_epoch t epoch fn
+  | `Draining (ready, _) | `Activating ready ->
+    ready >>= fun () ->
+    with_epoch t epoch fn
+  | `Idle ->
+    let ready, set_ready = Lwt.wait () in
+    activate t epoch ~ready ~set_ready >>= fun () ->
+    with_epoch t epoch fn
+
+let v ~create ~dispose () =
+  {
+    current = `Idle;
+    users = 0;
+    create;
+    dispose;
+  }

--- a/solver/epoch_lock.mli
+++ b/solver/epoch_lock.mli
@@ -1,0 +1,18 @@
+(** Divide jobs up into distinct epochs. Any number of jobs can run at the same
+    time within an epoch, but changing epoch requires first draining the
+    existing jobs, finishing the epoch, and then creating the new one.
+    The solver uses this to handle updates to opam-repository (each commit is a
+    separate epoch). *)
+
+type 'a t
+
+val v : create:(string -> 'a Lwt.t) -> dispose:('a -> unit Lwt.t) -> unit -> 'a t
+(** [v ~create ~dispose ()] is an epoch lock that calls [create] to start a new epoch
+    and [dispose] to finish one. A new epoch doesn't start until the old one has been
+    disposed. *)
+
+val with_epoch : 'a t -> string -> ('a -> 'b Lwt.t) -> 'b Lwt.t
+(** [with_epoch t epoch fn] runs [fn v] with the [v] for [epoch].
+    If we are already in [epoch], [fn] runs immediately.
+    If we are already in another epoch then we wait for all users in the
+    previous epoch to finish, then create a new one, then run [fn]. *)

--- a/solver/git_context.ml
+++ b/solver/git_context.ml
@@ -1,0 +1,114 @@
+module Store = Git_unix.Store
+module Search = Git.Search.Make(Store)
+
+open Lwt.Infix
+
+type rejection = UserConstraint of OpamFormula.atom
+
+type t = {
+  env : string -> OpamVariable.variable_contents option;
+  packages : OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t;
+  pins : (OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t;
+  constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
+  test : OpamPackage.Name.Set.t;
+}
+
+let load t pkg =
+  let { OpamPackage.name; version } = pkg in
+  match OpamPackage.Name.Map.find_opt name t.pins with
+  | Some (_, opam) -> opam
+  | None ->
+    match OpamPackage.Name.Map.find_opt name t.packages with
+    | None -> Fmt.failwith "Package %S not found" (OpamPackage.Name.to_string name)
+    | Some versions ->
+      match OpamPackage.Version.Map.find_opt version versions with
+      | None -> Fmt.failwith "Package %S not found" (OpamPackage.to_string pkg)
+      | Some opam -> opam
+
+let user_restrictions t name =
+  OpamPackage.Name.Map.find_opt name t.constraints
+
+let dev = OpamPackage.Version.of_string "dev"
+
+let env t pkg v =
+  if List.mem v OpamPackageVar.predefined_depends_variables then None
+  else match OpamVariable.Full.to_string v with
+    | "version" -> Some (OpamTypes.S (OpamPackage.version_to_string pkg))
+    | x -> t.env x
+
+let filter_deps t pkg f =
+  let dev = OpamPackage.Version.compare (OpamPackage.version pkg) dev = 0 in
+  let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
+  f
+  |> OpamFilter.partial_filter_formula (env t pkg)
+  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev ~default:false
+
+let candidates t name =
+  match OpamPackage.Name.Map.find_opt name t.pins with
+  | Some (version, _) -> [version, None]
+  | None ->
+    match OpamPackage.Name.Map.find_opt name t.packages with
+    | None ->
+      OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);
+      []
+    | Some versions ->
+      let user_constraints = user_restrictions t name in
+      OpamPackage.Version.Map.bindings versions
+      |> List.rev_map (fun (v, _) ->
+          match user_constraints with
+          | Some test when not (OpamFormula.check_version_formula (OpamFormula.Atom test) v) ->
+            v, Some (UserConstraint (name, Some test))  (* Reject *)
+          | _ -> v, None
+        )
+
+let pp_rejection f = function
+  | UserConstraint x -> Fmt.pf f "Rejected by user-specified constraint %s" (OpamFormula.string_of_atom x)
+
+let read_dir store hash =
+  Store.read store hash >|= function
+  | Error e -> Fmt.failwith "Failed to read tree: %a" Store.pp_error e
+  | Ok (Store.Value.Tree tree) -> Some tree
+  | Ok _ -> None
+
+let read_package store pkg hash =
+  Search.find store hash (`Path ["opam"]) >>= function
+  | None -> Fmt.failwith "opam file not found for %s" (OpamPackage.to_string pkg)
+  | Some hash ->
+    Store.read store hash >|= function
+    | Ok (Store.Value.Blob blob) -> OpamFile.OPAM.read_from_string (Store.Value.Blob.to_string blob)
+    | _ -> Fmt.failwith "Bad Git object type for %s!" (OpamPackage.to_string pkg)
+
+(* Get a map of the versions inside [entry] (an entry under "packages") *)
+let read_versions store (entry : Store.Value.Tree.entry) =
+  read_dir store entry.node >>= function
+  | None -> Lwt.return_none
+  | Some tree ->
+    Store.Value.Tree.to_list tree |> Lwt_list.fold_left_s (fun acc (entry : Store.Value.Tree.entry) ->
+        match OpamPackage.of_string_opt entry.name with
+        | Some pkg -> read_package store pkg entry.node >|= fun opam -> OpamPackage.Version.Map.add pkg.version opam acc
+        | None ->
+          OpamConsole.log "opam-0install" "Invalid package name %S" entry.name;
+          Lwt.return acc
+      ) OpamPackage.Version.Map.empty
+    >|= fun versions -> Some versions
+
+let read_packages store commit =
+  Search.find store commit (`Commit (`Path ["packages"])) >>= function
+  | None -> Fmt.failwith "Failed to find packages directory!"
+  | Some tree_hash ->
+    read_dir store tree_hash >>= function
+    | None -> Fmt.failwith "'packages' is not a directory!"
+    | Some tree ->
+      Store.Value.Tree.to_list tree |> Lwt_list.fold_left_s (fun acc (entry : Store.Value.Tree.entry) ->
+          match OpamPackage.Name.of_string entry.name with
+          | exception ex ->
+            OpamConsole.log "opam-0install" "Invalid package name %S: %s" entry.name (Printexc.to_string ex);
+            Lwt.return acc
+          | name ->
+            read_versions store entry >|= function
+            | None -> acc
+            | Some versions -> OpamPackage.Name.Map.add name versions acc
+        ) OpamPackage.Name.Map.empty
+
+let create ?(test=OpamPackage.Name.Set.empty) ?(pins=OpamPackage.Name.Map.empty) ~constraints ~env ~packages =
+  { env; packages; pins; constraints; test }

--- a/solver/git_context.mli
+++ b/solver/git_context.mli
@@ -1,0 +1,15 @@
+include Opam_0install.S.CONTEXT
+
+val read_packages :
+  Git_unix.Store.t ->
+  Git_unix.Store.Hash.t ->
+  OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t Lwt.t
+(** [read_packages store commit] is an index of the opam files in [store] at [commit]. *)
+
+val create :
+  ?test:OpamPackage.Name.Set.t ->
+  ?pins:(OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t ->
+  constraints:OpamFormula.version_constraint OpamPackage.Name.Map.t ->
+  env:(string -> OpamVariable.variable_contents option) ->
+  packages:OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t ->
+  t

--- a/solver/opam_repository.ml
+++ b/solver/opam_repository.ml
@@ -1,23 +1,36 @@
 open Lwt.Infix
 
-type t = {
-  dir : string;
-}
+module Log = Ocaml_ci_api.Solver.Log
+module Store = Git_unix.Store
 
-let ( / ) = Filename.concat
+let clone_path = "opam-repository"
 
-let of_dir dir = { dir }
+let open_store () =
+  let path = Fpath.v clone_path in
+  Git_unix.Store.v ~dotgit:path path >|= function
+  | Ok x -> x
+  | Error e -> Fmt.failwith "Failed to open opam-repository: %a" Store.pp_error e
 
-let packages_dir t = t.dir / "packages"
+let clone () =
+  begin match Unix.lstat clone_path with
+    | Unix.{ st_kind = S_DIR; _ } -> Lwt.return_unit
+    | _ -> Fmt.failwith "%S is not a directory!" clone_path
+    | exception Unix.Unix_error(Unix.ENOENT, _, "opam-repository") ->
+      Process.exec ("", [| "git"; "clone"; "--bare"; "https://github.com/ocaml/opam-repository.git"; clone_path |])
+  end
 
-let oldest_commit_with t pkgs =
+let oldest_commit_with ~from pkgs =
+  let from = Store.Hash.to_hex from in
   let paths =
     pkgs |> List.map (fun pkg ->
         let name = OpamPackage.name_to_string pkg in
         let version = OpamPackage.version_to_string pkg in
-        Printf.sprintf "%s/%s.%s" name name version
+        Printf.sprintf "packages/%s/%s.%s" name name version
       )
   in
-  let cmd = "git" :: "-C" :: packages_dir t :: "log" :: "-n" :: "1" :: "--format=format:%H" :: paths in
+  let cmd = "git" :: "-C" :: clone_path :: "log" :: "-n" :: "1" :: "--format=format:%H" :: from :: "--" :: paths in
   let cmd = ("", Array.of_list cmd) in
   Process.pread cmd >|= String.trim
+
+let fetch () =
+  Process.exec ("", [| "git"; "-C"; clone_path; "fetch"; "origin"|])

--- a/solver/opam_repository.mli
+++ b/solver/opam_repository.mli
@@ -1,12 +1,12 @@
-type t
-(** A Git clone of opam-repository. *)
+val open_store : unit -> Git_unix.Store.t Lwt.t
 
-val of_dir : string -> t
-(** [of_dir root] uses the opam repository Git clone at [root]. *)
+val clone : unit -> unit Lwt.t
+(** [clone ()] ensures that "./opam-repository" exists. If not, it clones it. *)
 
-val packages_dir : t -> string
-(** [packages_dir t] is the path of [t]'s "packages" directory. *)
-
-val oldest_commit_with : t -> OpamPackage.t list -> string Lwt.t
+val oldest_commit_with : from:Git_unix.Store.Hash.t -> OpamPackage.t list -> string Lwt.t
 (** Use "git-log" to find the oldest commit with these package versions.
-    This avoids invalidating the Docker build cache on every update to opam-repository. *)
+    This avoids invalidating the Docker build cache on every update to opam-repository.
+    @param from The commit at which to begin the search. *)
+
+val fetch : unit -> unit Lwt.t
+(* Does a "git fetch origin" to update the store. *)

--- a/solver/process.ml
+++ b/solver/process.ml
@@ -14,11 +14,18 @@ let pp_signal f x =
   else if x = sigterm then Fmt.string f "term"
   else Fmt.int f x
 
+let pp_status f = function
+  | Unix.WEXITED x -> Fmt.pf f "exited with status %d" x
+  | Unix.WSIGNALED x -> Fmt.pf f "failed with signal %d" x
+  | Unix.WSTOPPED x -> Fmt.pf f "stopped with signal %d" x
+
 let check_status cmd = function
   | Unix.WEXITED 0 -> ()
-  | Unix.WEXITED x -> Fmt.failwith "%a exited with status %d" pp_cmd cmd x
-  | Unix.WSIGNALED x -> Fmt.failwith  "%a failed with signal %d" pp_cmd cmd x
-  | Unix.WSTOPPED x -> Fmt.failwith  "%a stopped with signal %a" pp_cmd cmd pp_signal x
+  | status -> Fmt.failwith "%a %a" pp_cmd cmd pp_status status
+
+let exec cmd =
+  let proc = Lwt_process.open_process_none cmd in
+  proc#status >|= check_status cmd
 
 let pread cmd =
   let proc = Lwt_process.open_process_in cmd in

--- a/solver/service.ml
+++ b/solver/service.ml
@@ -4,77 +4,127 @@ open Capnp_rpc_lwt
 module Worker = Ocaml_ci_api.Worker
 module Log = Ocaml_ci_api.Solver.Log
 module Selection = Worker.Selection
+module Store = Git_unix.Store
 
-(* Send [request] to [worker] and read the reply. *)
-let process ~log ~id request worker =
-  let request_str = Worker.Solve_request.to_yojson request |> Yojson.Safe.to_string in
-  let request_str = Printf.sprintf "%d\n%s" (String.length request_str) request_str in
-  Lwt_io.write worker#stdin request_str >>= fun () ->
-  Lwt_io.read_line worker#stdout >>= fun time ->
-  Lwt_io.read_line worker#stdout >>= fun len ->
-  match Astring.String.to_int len with
-  | None ->
-    Fmt.failwith "Bad frame from worker: time=%S len=%S" time len
-  | Some len ->
-    let buf = Bytes.create len in
-    Lwt_io.read_into_exactly worker#stdout buf 0 len >|= fun () ->
-    let results = Bytes.unsafe_to_string buf in
-    match results.[0] with
-    | '+' ->
-      Log.info log "%s: found solution in %s s" id time;
-      let packages =
-        Astring.String.with_range ~first:1 results
-        |> Astring.String.cuts ~sep:" "
-      in
-      Ok packages
-    | '-' ->
-      Log.info log "%s: eliminated all possibilities in %s s" id time;
-      let msg = results |> Astring.String.with_range ~first:1 in
-      Error msg
-    | _ ->
-      Fmt.failwith "BUG: bad output: %s" results
+module Epoch : sig
+  type t
+  (* An Epoch handles all requests for a single opam-repository HEAD commit. *)
+
+  val create : n_workers:int -> create_worker:(Git_unix.Store.Hash.t -> Lwt_process.process) -> Store.Hash.t -> t Lwt.t
+  val handle : log:Ocaml_ci_api.Solver.Log.t -> Worker.Solve_request.t -> t -> Selection.t list Lwt.t
+  val dispose : t -> unit Lwt.t
+end = struct
+  type t = Lwt_process.process Lwt_pool.t
+
+  let validate (worker : Lwt_process.process) =
+    match Lwt.state worker#status with
+    | Lwt.Sleep -> Lwt.return true
+    | Lwt.Fail ex -> Lwt.fail ex
+    | Lwt.Return status ->
+      Format.eprintf "Worker %d is dead (%a) - removing from pool@." worker#pid Process.pp_status status;
+      Lwt.return false
+
+  let dispose (worker : Lwt_process.process) =
+    let pid = worker#pid in
+    Fmt.epr "Terminating worker %d@." pid;
+    worker#terminate;
+    worker#status >|= fun _ ->
+    Fmt.epr "Worker %d finished@." pid
+
+  let create ~n_workers ~create_worker hash =
+    begin
+      Opam_repository.open_store () >>= fun store ->
+      Store.mem store hash >>= function
+      | true -> Lwt.return_unit
+      | false ->
+        Fmt.pr "Need to update opam-repository to get new commit %a@." Store.Hash.pp hash;
+        Opam_repository.fetch () >>= fun () ->
+        Opam_repository.open_store () >>= fun new_store ->
+        Store.mem new_store hash >>= function
+        | false -> Fmt.failwith "Still missing commit after update!"
+        | true -> Lwt.return_unit
+    end >|= fun () ->
+    Lwt_pool.create n_workers ~validate ~dispose (fun () -> Lwt.return (create_worker hash))
+
+  let dispose = Lwt_pool.clear
+
+  (* Send [request] to [worker] and read the reply. *)
+  let process ~log ~id request worker =
+    let request_str = Worker.Solve_request.to_yojson request |> Yojson.Safe.to_string in
+    let request_str = Printf.sprintf "%d\n%s" (String.length request_str) request_str in
+    Lwt_io.write worker#stdin request_str >>= fun () ->
+    Lwt_io.read_line worker#stdout >>= fun time ->
+    Lwt_io.read_line worker#stdout >>= fun len ->
+    match Astring.String.to_int len with
+    | None ->
+      Fmt.failwith "Bad frame from worker: time=%S len=%S" time len
+    | Some len ->
+      let buf = Bytes.create len in
+      Lwt_io.read_into_exactly worker#stdout buf 0 len >|= fun () ->
+      let results = Bytes.unsafe_to_string buf in
+      match results.[0] with
+      | '+' ->
+        Log.info log "%s: found solution in %s s" id time;
+        let packages =
+          Astring.String.with_range ~first:1 results
+          |> Astring.String.cuts ~sep:" "
+        in
+        Ok packages
+      | '-' ->
+        Log.info log "%s: eliminated all possibilities in %s s" id time;
+        let msg = results |> Astring.String.with_range ~first:1 in
+        Error msg
+      | _ ->
+        Fmt.failwith "BUG: bad output: %s" results
+
+  let handle ~log request t =
+    let { Worker.Solve_request.opam_repository_commit; platforms; root_pkgs; pinned_pkgs } = request in
+    let opam_repository_commit = Store.Hash.of_hex opam_repository_commit in
+    let root_pkgs = List.map fst root_pkgs in
+    let pinned_pkgs = List.map fst pinned_pkgs in
+    let pins =
+      root_pkgs @ pinned_pkgs
+      |> List.map (fun pkg -> OpamPackage.name (OpamPackage.of_string pkg))
+      |> OpamPackage.Name.Set.of_list
+    in
+    Log.info log "Solving for %a" Fmt.(list ~sep:comma string) root_pkgs;
+    platforms |> Lwt_list.map_p (fun p ->
+        let id = fst p in
+        let slice = { request with platforms = [p] } in
+        Lwt_pool.use t (process ~log ~id slice) >>= function
+        | Error _ as e -> Lwt.return (id, e)
+        | Ok packages ->
+          let repo_packages =
+            packages |> List.filter_map (fun pkg ->
+                let pkg = OpamPackage.of_string pkg in
+                if OpamPackage.Name.Set.mem pkg.name pins then None
+                else Some pkg
+              )
+          in
+          Opam_repository.oldest_commit_with repo_packages ~from:opam_repository_commit >|= fun commit ->
+          id, Ok { Worker.Selection.id; packages; commit }
+      )
+    >|= List.filter_map (fun (id, result) ->
+        Log.info log "= %s =" id;
+        match result with
+        | Ok result ->
+          Log.info log "-> @[<hov>%a@]" Fmt.(list ~sep:sp string) result.Selection.packages;
+          Log.info log "(valid since opam-repository commit %s)" result.Selection.commit;
+          Some result
+        | Error msg ->
+          Log.info log "%s" msg;
+          None
+      )
+end
 
 (* Handle a request by distributing it among the worker processes and then aggregating their responses. *)
-let handle ~pool ~log request =
-  let { Worker.Solve_request.opam_repository; platforms; root_pkgs; pinned_pkgs } = request in
-  let opam_repository = Opam_repository.of_dir opam_repository in
-  let root_pkgs = List.map fst root_pkgs in
-  let pinned_pkgs = List.map fst pinned_pkgs in
-  let pins =
-    root_pkgs @ pinned_pkgs
-    |> List.map (fun pkg -> OpamPackage.name (OpamPackage.of_string pkg))
-    |> OpamPackage.Name.Set.of_list
-  in
-  Log.info log "Solving for %a" Fmt.(list ~sep:comma string) root_pkgs;
-  platforms |> Lwt_list.map_p (fun p ->
-      let id = fst p in
-      let slice = { request with platforms = [p] } in
-      Lwt_pool.use pool (process ~log ~id slice) >>= function
-      | Error _ as e -> Lwt.return (id, e)
-      | Ok packages ->
-        let repo_packages =
-          packages |> List.filter_map (fun pkg ->
-              let pkg = OpamPackage.of_string pkg in
-              if OpamPackage.Name.Set.mem pkg.name pins then None
-              else Some pkg
-            )
-        in
-        Opam_repository.oldest_commit_with opam_repository repo_packages >|= fun commit ->
-        id, Ok { Worker.Selection.id; packages; commit }
-    )
-  >|= List.filter_map (fun (id, result) ->
-      Log.info log "= %s =" id;
-      match result with
-      | Ok result ->
-        Log.info log "-> @[<hov>%a@]" Fmt.(list ~sep:sp string) result.Selection.packages;
-        Log.info log "(valid since opam-repository commit %s)" result.Selection.commit;
-        Some result
-      | Error msg ->
-        Log.info log "%s" msg;
-        None
-    )
+let handle t ~log (request : Worker.Solve_request.t) =
+  Epoch_lock.with_epoch t request.opam_repository_commit (Epoch.handle ~log request)
 
-let v ~pool =
+let v ~n_workers ~create_worker =
+  Opam_repository.clone () >|= fun () ->
+  let create hash = Epoch.create ~n_workers ~create_worker (Store.Hash.of_hex hash) in
+  let t = Epoch_lock.v ~create ~dispose:Epoch.dispose () in
   let module X = Ocaml_ci_api.Raw.Service.Solver in
   X.local @@ object
     inherit X.service
@@ -92,7 +142,7 @@ let v ~pool =
         | Ok request ->
           Capnp_rpc_lwt.Service.return_lwt @@ fun () ->
           Lwt.catch
-            (fun () -> handle ~log ~pool request >|= Result.ok)
+            (fun () -> handle t ~log request >|= Result.ok)
             (function
               | Failure msg -> Lwt_result.fail (`Msg msg)
               | ex -> Lwt.return (Fmt.error_msg "%a" Fmt.exn ex)

--- a/solver/service.mli
+++ b/solver/service.mli
@@ -1,2 +1,6 @@
-val v : pool:Lwt_process.process Lwt_pool.t -> Ocaml_ci_api.Solver.t
-(** [v ~pool] is a solver service that distributes work to workers in [pool]. *)
+val v :
+  n_workers:int ->
+  create_worker:(Git_unix.Store.Hash.t -> Lwt_process.process) ->
+  Ocaml_ci_api.Solver.t Lwt.t
+(** [v ~n_workers ~create_worker] is a solver service that distributes work to up to
+    [n_workers] subprocesses, using [create_worker hash] to spawn new workers. *)

--- a/solver/solver.mli
+++ b/solver/solver.mli
@@ -1,2 +1,3 @@
-val main : unit -> unit
-(** [main ()] runs a worker process that reads requests from stdin and writes results to stdout. *)
+val main : Git_unix.Store.Hash.t -> unit
+(** [main hash] runs a worker process that reads requests from stdin and writes results to stdout,
+    using commit [hash] in opam-repository. *)


### PR DESCRIPTION
Instead of checking out the whole of opam-repository on each analysis run, just pass the hash to the solver. The solver maintains a bare opam-repository clone and reads it directly.

We also parse all the opam files in opam-repository and keep them in memory until the head commit changes, which should be faster when doing lots of solves.