### PR TITLE
Respond immediately to opam-repository changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![OCaml-CI Build Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fci.ocamllabs.io%2Fbadge%2Focurrent%2Focaml-ci%2Fmaster&logo=ocaml)](https://ci.ocamllabs.io/github/ocurrent/ocaml-ci)
 
-Status: **experimental**
-
 This is an [OCurrent][] pipeline that provides CI for OCaml projects hosted on GitHub.
 
 The pipeline is defined in [pipeline.ml][]. It:
@@ -58,6 +56,9 @@ docker build -f Dockerfile.web -t ocaml-ci-web .
 
 The `stack.yml` contains the configuration used on the live system.
 You'll have to register your own GitHub app to be able to test the services locally.
+
+If you want it to update to changes in opam-repository automatically you'll also need
+to register a webhook there sending push events to the CI's `/webhooks/github` path.
 
 ## Remote API
 

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -22,8 +22,8 @@ end
 val examine :
   solver:Ocaml_ci_api.Solver.t ->
   platforms:Platform.t list Current.t ->
-  opam_repository:Current_git.Commit.t Current.t ->
+  opam_repository_commit:Current_git.Commit_id.t Current.t ->
   Current_git.Commit.t Current.t ->
   Analysis.t Current.t
-(** [examine ~solver ~platforms ~opam_repository src] analyses the source code [src] and selects
-    package versions to test using [opam_repository]. *)
+(** [examine ~solver ~platforms ~opam_repository_commit src] analyses the source code [src] and selects
+    package versions to test using [opam_repository_commit]. *)


### PR DESCRIPTION
Instead of polling for changes to opam-repository each hour, monitor it using GitHub events. This allows us to respond immediately to new commits.