### PR TITLE
Add OCaml 4.11 to the test matrix

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -8,6 +8,7 @@ module Vars = struct
     os_family : string;
     os_distribution : string;
     os_version : string;
+    ocaml_package : string;
     ocaml_version : string;
   } [@@deriving yojson]
 end

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -51,6 +51,7 @@ let platforms =
     [
       (* Compiler versions:*)
       v "4.10" "linux-x86_64" "debian-10" "4.10";       (* Note: first item is also used as lint platform *)
+      v "4.11" "linux-x86_64" "debian-10" "4.11";
       v "4.09" "linux-x86_64" "debian-10" "4.09";
       v "4.08" "linux-x86_64" "debian-10" "4.08";
       v "4.07" "linux-x86_64" "debian-10" "4.07";
@@ -74,7 +75,7 @@ let platforms =
   | `Dev ->
     [
       v "4.10" "linux-x86_64" "debian-10" "4.10";
-      v "4.09" "linux-x86_64" "debian-10" "4.09";
+      v "4.11" "linux-x86_64" "debian-10" "4.11";
       v "4.02" "linux-x86_64" "debian-10" "4.02";
       v ~arch:`I386 "4.10+32bit" "linux-x86_64" "debian-10" "4.10";
     ]

--- a/solver/git_context.ml
+++ b/solver/git_context.ml
@@ -15,6 +15,26 @@ type t = {
   test : OpamPackage.Name.Set.t;
 }
 
+let ocaml_beta_pkg = OpamPackage.of_string "ocaml-beta.enabled"
+
+(* From https://github.com/ocaml/ocaml-beta-repository/blob/master/packages/ocaml-beta/ocaml-beta.enabled/opam *)
+let ocaml_beta_opam = OpamFile.OPAM.read_from_string {|
+opam-version: "2.0"
+maintainer: "platform@lists.ocaml.org"
+bug-reports: "https://github.com/ocaml/ocaml/issues"
+authors: [
+  "Xavier Leroy"
+  "Damien Doligez"
+  "Alain Frisch"
+  "Jacques Garrigue"
+  "Didier Rémy"
+  "Jérôme Vouillon"
+]
+homepage: "https://ocaml.org"
+synopsis: "OCaml beta releases enabled"
+description: "Virtual package enabling the installation of OCaml beta releases."
+|}
+
 let user_restrictions t name =
   OpamPackage.Name.Map.find_opt name t.constraints
 
@@ -42,6 +62,11 @@ let candidates t name =
       OpamConsole.log "opam-0install" "Package %S not found!" (OpamPackage.Name.to_string name);
       []
     | Some versions ->
+      let versions =
+        if OpamPackage.Name.compare name (OpamPackage.name ocaml_beta_pkg) = 0 then 
+          OpamPackage.Version.Map.add (OpamPackage.version ocaml_beta_pkg) ocaml_beta_opam versions
+        else versions
+      in
       let user_constraints = user_restrictions t name in
       OpamPackage.Version.Map.bindings versions
       |> List.rev_map (fun (v, opam) ->

--- a/solver/solver.ml
+++ b/solver/solver.ml
@@ -13,25 +13,24 @@ let env (vars : Worker.Vars.t) =
     ~os_family:vars.os_family
     ()
 
-let ocaml_name = OpamPackage.Name.of_string "ocaml"
-
 let parse_opam (name, contents) =
   let pkg = OpamPackage.of_string name in
   let opam = OpamFile.OPAM.read_from_string contents in
   OpamPackage.name pkg, (OpamPackage.version pkg, opam)
 
 let solve ~packages ~pins ~root_pkgs (vars : Worker.Vars.t) =
+  let ocaml_package = OpamPackage.Name.of_string vars.ocaml_package in
   let ocaml_version = OpamPackage.Version.of_string vars.ocaml_version in
   let context =
     Git_context.create
       ~packages
       ~pins
       ~env:(env vars)
-      ~constraints:(OpamPackage.Name.Map.singleton ocaml_name (`Eq, ocaml_version))
+      ~constraints:(OpamPackage.Name.Map.singleton ocaml_package (`Eq, ocaml_version))
       ~test:(OpamPackage.Name.Set.of_list root_pkgs)
   in
   let t0 = Unix.gettimeofday () in
-  let r = Solver.solve context root_pkgs in
+  let r = Solver.solve context (ocaml_package :: root_pkgs) in
   let t1 = Unix.gettimeofday () in
   Printf.printf "%.2f\n" (t1 -. t0);
   match r with

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -1,18 +1,19 @@
-let debian_10_vars ocaml_version =
+let debian_10_vars ocaml_package ocaml_version =
   { Ocaml_ci_api.Worker.Vars.
     os = "debian";
     arch = "x86_64";
     os_family = "debian";
     os_distribution = "debian";
     os_version = "10";
+    ocaml_package;
     ocaml_version
   }
 
 let var = Ocaml_ci.Variant.v ~arch:None 
 
 let v = [
-  var "debian-10-ocaml-4.10", debian_10_vars "4.10.0";
-  var "debian-10-ocaml-4.09", debian_10_vars "4.09.0";
-  var "debian-10-ocaml-4.08", debian_10_vars "4.08.0";
-  var "debian-10-ocaml-4.07", debian_10_vars "4.07.0";
+  var "debian-10-ocaml-4.10", debian_10_vars "ocaml" "4.10.0";
+  var "debian-10-ocaml-4.09", debian_10_vars "ocaml" "4.09.0";
+  var "debian-10-ocaml-4.08", debian_10_vars "ocaml" "4.08.0";
+  var "debian-10-ocaml-4.07", debian_10_vars "ocaml" "4.07.0";
 ]


### PR DESCRIPTION
OCaml 4.11 is currently in its alpha2 stage and it seems required to test the OCaml 4.11 support in ocamlformat https://github.com/ocaml-ppx/ocamlformat/pull/1387