### PR TITLE
duniverse: do not pin the tool

### DIFF
--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -23,7 +23,6 @@ let install_bin ~compiler ~repo ~tag ~bins name =
     workdir "/home/opam/src" @@
     run "echo \"(lang dune 2.0)\" > dune-workspace" @@
     run "echo \"(env (_ (flags -cclib -static)))\" >> dune-workspace" @@
-    run "opam pin add -n ." @@
     run "opam depext %s" name @@
     run "opam install --deps-only %s" name @@
     run "opam exec -- dune build @install" @@@


### PR DESCRIPTION
The ocamlformat failure on the live CI is because the opam metadata
in the release branch is wrong. Since these tools are all guaranteed
to be in the opam repo, simply do not pin the tool while building
the binary.

This should fix the live CI which is failing with ocamlformat
trying to use base.v0.14.0 and thus not building.