### PR TITLE
Improve log messages from solver

### DIFF
--- a/api/solver.ml
+++ b/api/solver.ml
@@ -24,7 +24,7 @@ module Log = struct
       let thread = write t msg in
       Lwt.on_failure thread (fun ex -> Format.eprintf "Log.info(%S) failed: %a@." msg Fmt.exn ex)
     in
-    Fmt.kstr k ("%a [INFO] " ^^ fmt ^^ "@.") pp_timestamp now
+    Fmt.kstr k ("%a [INFO] @[" ^^ fmt ^^ "@]@.") pp_timestamp now
 end
 
 module X = Raw.Client.Solver

--- a/solver/service.ml
+++ b/solver/service.ml
@@ -74,6 +74,9 @@ end = struct
         Log.info log "%s: eliminated all possibilities in %s s" id time;
         let msg = results |> Astring.String.with_range ~first:1 in
         Error msg
+      | '!' ->
+        let msg = results |> Astring.String.with_range ~first:1 in
+        Fmt.failwith "BUG: solver worker failed: %s" msg;
       | _ ->
         Fmt.failwith "BUG: bad output: %s" results
 

--- a/solver/solver.ml
+++ b/solver/solver.ml
@@ -75,3 +75,16 @@ let main commit =
       aux ()
   in
   aux ()
+
+let main commit =
+  try main commit
+  with ex ->
+    Fmt.epr "solver bug: %a@." Fmt.exn ex;
+    let msg =
+      match ex with
+      | Failure msg -> msg
+      | ex -> Printexc.to_string ex
+    in
+    let msg = "!" ^ msg in
+    Printf.printf "0.0\n%d\n%s%!" (String.length msg) msg;
+    raise ex


### PR DESCRIPTION
- Fix bad line-break in solver log message formatting.
- Report solver exceptions back to ocaml-ci, instead of just printing to stderr.