### PR TITLE
Better error for missing ocamlformat version

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -225,7 +225,7 @@ module Analysis = struct
     in
     (* [opam_files] are used to detect vendored OCamlformat but this only works
        with duniverse, as other opam files are filtered above. *)
-    Analyse_ocamlformat.get_ocamlformat_source job ~opam_files ~root:dir >>= fun ocamlformat_source ->
+    Analyse_ocamlformat.get_ocamlformat_source job ~opam_files ~root:dir >>!= fun ocamlformat_source ->
     if opam_files = [] then Lwt_result.fail (`Msg "No opam files found!")
     else if List.filter is_toplevel opam_files = [] then Lwt_result.fail (`Msg "No top-level opam files found!")
     else (

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -5,6 +5,6 @@ type source =
 
 val pp_source : source Fmt.t
 
-val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> root:Fpath.t -> source option Lwt.t
+val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> root:Fpath.t -> (source option, [> `Msg of string]) Lwt_result.t
 (** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)


### PR DESCRIPTION
Before:

    Job failed: (Failure "Unable to parse .ocamlformat file")

After:

    Job failed: Missing 'version=' line in .ocamlformat