### PR TITLE
Only list active accounts

### DIFF
--- a/lib/index.mli
+++ b/lib/index.mli
@@ -7,6 +7,9 @@ type job_state = [`Not_started | `Active | `Failed of string | `Passed | `Aborte
 
 type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
 
+val init : unit -> unit
+(** Ensure the database is initialised (for unit-tests). *)
+
 val record :
   repo:Current_github.Repo_id.t ->
   hash:string ->
@@ -15,14 +18,8 @@ val record :
   unit
 (** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
 
-val is_known_owner : string -> bool
-(** [is_known_owner owner] is [true] iff there is an entry for a commit in organisation [owner]. *)
-
 val is_known_repo : owner:string -> name:string -> bool
 (** [is_known_repo ~owner ~name] is [true] iff there is an entry for a commit in repository [owner/name]. *)
-
-val list_owners : unit -> string list
-(** [list_owners ()] lists all the tracked owners. *)
 
 val list_repos : string -> string list
 (** [list_repos owner] lists all the tracked repos under [owner]. *)
@@ -43,7 +40,15 @@ val get_status:
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)
 
+module Account_set : Set.S with type elt = string
 module Repo_map : Map.S with type key = Current_github.Repo_id.t
+
+val set_active_accounts : Account_set.t -> unit
+(** [set_active_accounts accounts] record that [accounts] is the set of accounts on which the CI is installed.
+    This is displayed in the CI web interface. *)
+
+val get_active_accounts : unit -> Account_set.t
+(** [get_active_accounts ()] is the last value passed to [set_active_accounts], or [[]] if not known yet. *)
 
 val set_active_refs : repo:Current_github.Repo_id.t -> (string * string) list -> unit
 (** [set_active_refs ~repo entries] records that [entries] is the current set of Git references that the CI

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -183,7 +183,7 @@ let make_ci ~engine =
     match String_map.find_opt owner !orgs with
     | Some org -> Some org
     | None ->
-      if Index.is_known_owner owner then (
+      if Index.Account_set.mem owner (Index.get_active_accounts ()) then (
         let org = make_org ~engine owner in
         orgs := String_map.add owner org !orgs;
         Some org
@@ -207,6 +207,7 @@ let make_ci ~engine =
       let open CI.Orgs in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      Results.orgs_set_list results (Index.list_owners ()) |> ignore;
+      let owners = Index.get_active_accounts () |> Index.Account_set.elements in
+      Results.orgs_set_list results owners |> ignore;
       Service.return response
   end


### PR DESCRIPTION
Previously, we listed all accounts that existed in the database, which included various stale accounts (e.g. `ocaml-ci`, which got renamed to `ocurrent`). Now, we just list the accounts being monitored at the current time.