### PR TITLE
Report statistics about the state of all master branches

### DIFF
--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -2,16 +2,18 @@
 
 using OCurrent = import "ocurrent.capnp";
 
-struct RefInfo {
-  ref  @0 :Text;
-  hash @1 :Text;
-}
-
 enum BuildStatus {
   notStarted @0;
   passed     @1;
   failed     @2;
   pending    @3;
+}
+
+struct RefInfo {
+  ref         @0 :Text;
+  hash        @1 :Text;
+  state       @2 :BuildStatus;
+  # The state of the ref's head commit
 }
 
 struct JobInfo {
@@ -60,10 +62,16 @@ interface Repo {
   # ref should be of the form "refs/heads/..." or "refs/pull/4/head"
 }
 
+struct RepoInfo {
+  name @0 :Text;
+  masterState @1 :BuildStatus;
+  # The status of the repository's master branch (notStarted if there isn't one)
+}
+
 interface Org {
   repo         @0 (name :Text) -> (repo :Repo);
 
-  repos        @1 () -> (repos :List(Text));
+  repos        @1 () -> (repos :List(RepoInfo));
   # Get the list of tracked repositories for this organisation.
 }
 

--- a/client/main.ml
+++ b/client/main.ml
@@ -74,7 +74,8 @@ let list_repos ~owner org =
   | [] ->
     Fmt.pr "@[<v>No repository given and no suggestions available.@."
   | repos ->
-    let full_name f r = Fmt.pf f "%s/%s" owner r in
+    let full_name f { Client.Org.name; master_status } =
+      Fmt.pf f "%s/%s (%a)" owner name Client.Build_status.pp master_status in
     Fmt.pr "@[<v>No repository given. Try one of these:@,@,%a@]@." Fmt.(list full_name) repos
 
 let list_refs repo =
@@ -82,7 +83,7 @@ let list_refs repo =
   if Client.Ref_map.is_empty refs then
     Fmt.pr "No branches or PRs are being tracked by the CI for this repository.@."
   else
-    Client.Ref_map.iter (fun gref hash -> Fmt.pr "%s %s@." hash gref) refs
+    Client.Ref_map.iter (fun gref (hash, status) -> Fmt.pr "%s %s (%a)@." hash gref Client.Build_status.pp status) refs
 
 let pp_job f { Client.variant; outcome } =
   Fmt.pf f "%s (%a)" variant Client.State.pp outcome

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -18,12 +18,6 @@ val record :
   unit
 (** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
 
-val is_known_repo : owner:string -> name:string -> bool
-(** [is_known_repo ~owner ~name] is [true] iff there is an entry for a commit in repository [owner/name]. *)
-
-val list_repos : string -> string list
-(** [list_repos owner] lists all the tracked repos under [owner]. *)
-
 val get_jobs : owner:string -> name:string -> string -> (string * job_state) list
 (** [get_jobs ~owner ~name commit] is the last known set of OCurrent jobs for hash [commit] in repository [owner/name]. *)
 
@@ -40,21 +34,29 @@ val get_status:
 val get_full_hash : owner:string -> name:string -> string -> (string, [> `Ambiguous | `Unknown | `Invalid]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for [short_hash]. *)
 
-module Account_set : Set.S with type elt = string
-module Repo_map : Map.S with type key = Current_github.Repo_id.t
+module Owner_set : Set.S with type elt = string
+module Repo_set : Set.S with type elt = string
 
-val set_active_accounts : Account_set.t -> unit
-(** [set_active_accounts accounts] record that [accounts] is the set of accounts on which the CI is installed.
+val set_active_owners : Owner_set.t -> unit
+(** [set_active_owners owners] records that [owners] is the set of accounts on which the CI is installed.
     This is displayed in the CI web interface. *)
 
-val get_active_accounts : unit -> Account_set.t
-(** [get_active_accounts ()] is the last value passed to [set_active_accounts], or [[]] if not known yet. *)
+val get_active_owners : unit -> Owner_set.t
+(** [get_active_owners ()] is the last value passed to [set_active_owners], or [[]] if not known yet. *)
 
-val set_active_refs : repo:Current_github.Repo_id.t -> (string * string) list -> unit
-(** [set_active_refs ~repo entries] records that [entries] is the current set of Git references that the CI
-    is watching. There is one entry for each branch and PR. Each entry is a pair of the Git reference name
-    and the head commit's hash. *)
+val set_active_repos : owner:string -> Repo_set.t -> unit
+(** [set_active_repos ~owner repos] records that [repos] is the set of active repositories under [owner]. *)
 
-val get_active_refs : Current_github.Repo_id.t -> (string * string) list
+val get_active_repos : owner:string -> Repo_set.t
+(** [get_active_repos ~owner] is the last value passed to [set_active_repos] for [owner], or [empty] if not known yet. *)
+
+module Ref_map : Map.S with type key = string
+
+val set_active_refs : repo:Current_github.Repo_id.t -> string Ref_map.t -> unit
+(** [set_active_refs ~repo refs] records that [refs] is the current set of Git references that the CI
+    is watching. There is one entry for each branch and PR. Each entry maps the Git reference name
+    to the head commit's hash. *)
+
+val get_active_refs : Current_github.Repo_id.t -> string Ref_map.t
 (** [get_active_refs repo] is the entries last set for [repo] with [set_active_refs], or
-    [] if this repository isn't known. *)
+    [empty] if this repository isn't known. *)

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -50,6 +50,7 @@ let make_commit ~engine ~owner ~name hash =
       release_param_caps ();
       let refs =
         Index.get_active_refs { Current_github.Repo_id.owner; name }
+        |> Index.Ref_map.bindings
         |> List.filter_map (fun (name, h) -> if h = hash then Some name else None)
       in
       let response, results = Service.Response.create Results.init_pointer in
@@ -88,7 +89,10 @@ let make_repo ~engine ~owner ~name =
     method refs_impl _params release_param_caps =
       let open Repo.Refs in
       release_param_caps ();
-      let refs = Index.get_active_refs { Current_github.Repo_id.owner; name } in
+      let refs =
+        Index.get_active_refs { Current_github.Repo_id.owner; name }
+        |> Index.Ref_map.bindings
+      in
       let response, results = Service.Response.create Results.init_pointer in
       let arr = Results.refs_init results (List.length refs) in
       refs |> List.iteri (fun i (gref, hash) ->
@@ -107,9 +111,9 @@ let make_repo ~engine ~owner ~name =
       let gref = Params.ref_get params in
       release_param_caps ();
       let refs = Index.get_active_refs { Current_github.Repo_id.owner; name } in
-      match List.assoc_opt gref refs with
+      match Index.Ref_map.find_opt gref refs with
       | None -> Service.fail "@[<v2>Unknown ref %S. Options are:@,%a@]" gref
-                  Fmt.(Dump.list string) (List.map fst refs)
+                  Fmt.(Dump.list string) (List.map fst (Index.Ref_map.bindings refs))
       | Some hash ->
         let commit = get_commit hash in
         let response, results = Service.Response.create Results.init_pointer in
@@ -147,7 +151,8 @@ let make_org ~engine owner =
     match String_map.find_opt name !repos with
     | Some repo -> Some repo
     | None ->
-      if Index.is_known_repo ~owner ~name then (
+      let active_repos = Index.get_active_repos ~owner in
+      if Index.Repo_set.mem name active_repos then (
         let repo = make_repo ~engine ~owner ~name in
         repos := String_map.add name repo !repos;
         Some repo
@@ -171,7 +176,8 @@ let make_org ~engine owner =
       let open Org.Repos in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      Results.repos_set_list results (Index.list_repos owner) |> ignore;
+      let repos = Index.get_active_repos ~owner |> Index.Repo_set.elements in
+      Results.repos_set_list results repos |> ignore;
       Service.return response
   end
 
@@ -183,7 +189,7 @@ let make_ci ~engine =
     match String_map.find_opt owner !orgs with
     | Some org -> Some org
     | None ->
-      if Index.Account_set.mem owner (Index.get_active_accounts ()) then (
+      if Index.Owner_set.mem owner (Index.get_active_owners ()) then (
         let org = make_org ~engine owner in
         orgs := String_map.add owner org !orgs;
         Some org
@@ -207,7 +213,7 @@ let make_ci ~engine =
       let open CI.Orgs in
       release_param_caps ();
       let response, results = Service.Response.create Results.init_pointer in
-      let owners = Index.get_active_accounts () |> Index.Account_set.elements in
+      let owners = Index.get_active_owners () |> Index.Owner_set.elements in
       Results.orgs_set_list results owners |> ignore;
       Service.return response
   end

--- a/service/main.ml
+++ b/service/main.ml
@@ -1,10 +1,50 @@
 open Lwt.Infix
 
+module Metrics = struct
+  open Prometheus
+  open Ocaml_ci
+
+  let namespace = "ocamlci"
+
+  let subsystem = "pipeline"
+
+  let master =
+    let help = "Number of master branches by state" in
+    Gauge.v_label ~label_name:"state" ~help ~namespace ~subsystem "master_state_total"
+
+  type stats = {
+    ok : int;
+    failed : int;
+    active : int;
+  }
+
+  let count_repo ~owner name (acc : stats) =
+    let repo = { Current_github.Repo_id.owner; name } in
+    match Index.Ref_map.find_opt "refs/heads/master" (Index.get_active_refs repo) with
+    | None -> acc
+    | Some hash ->
+      match Index.get_status ~owner ~name ~hash with
+      | `Failed -> { acc with failed = acc.failed + 1 }
+      | `Passed -> { acc with ok = acc.ok + 1 }
+      | `Not_started | `Pending -> { acc with active = acc.active + 1 }
+
+  let count_owner owner (acc : stats) =
+    Index.Repo_set.fold (count_repo ~owner) (Index.get_active_repos ~owner) acc
+
+  let update () =
+    let owners = Index.get_active_owners () in
+    let { ok; failed; active } = Index.Owner_set.fold count_owner owners { ok = 0; failed = 0; active = 0 } in
+    Gauge.set (master "ok") (float_of_int ok);
+    Gauge.set (master "failed") (float_of_int failed);
+    Gauge.set (master "active") (float_of_int active)
+end
+
 let solver = Ocaml_ci.Solver_pool.spawn_local ()
 
 let () =
   Logging.init ();
   Mirage_crypto_rng_unix.initialize ();
+  Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
   match Conf.profile with
   | `Production -> Logs.info (fun f -> f "Using production configuration")
   | `Dev -> Logs.info (fun f -> f "Using dev configuration")

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -1,4 +1,5 @@
 module Index = Ocaml_ci.Index
+module Ref_map = Index.Ref_map
 
 let jobs =
   let state f (variant, state) = Fmt.pf f "%s:%a" variant Index.pp_job_state state in
@@ -13,11 +14,10 @@ let test_simple () =
   Index.init ();
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
-  Index.set_active_refs ~repo ["master", hash];
+  Index.set_active_refs ~repo @@ Ref_map.singleton "master" hash;
   Index.record ~repo ~hash ~status:`Pending [ "analysis", Some "job1";
                              "alpine", None ];
-  Alcotest.(check (list string)) "Repos" ["name"] @@ Index.list_repos owner;
-  Alcotest.(check (list (pair string string))) "Refs" ["master", hash] @@ Index.get_active_refs repo;
+  Alcotest.(check (list (pair string string))) "Refs" ["master", hash] (Index.get_active_refs repo |> Ref_map.bindings);
   Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
   Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
                                      VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";


### PR DESCRIPTION
Reporting states for all PRs and branches isn't very useful because they may be stale, but the master branchs should be a good indicator of things that are supposed to be passing.

Also, we now track the set of active repositories. Before, we listed all repositories for which there were entries in the database, even if they are no longer being monitored. Now, we just list the ones that are still active.