### PR TITLE
Update to latest opam-0install-solver to fix availability bug

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ocurrent"]
 	path = ocurrent
 	url = https://github.com/ocurrent/ocurrent.git
+[submodule "opam-0install-solver"]
+	path = opam-0install-solver
+	url = https://github.com/talex5/opam-0install-solver

--- a/solver/solver.ml
+++ b/solver/solver.ml
@@ -11,6 +11,7 @@ let env (vars : Worker.Vars.t) =
     ~os_distribution:vars.os_distribution
     ~os_version:vars.os_version
     ~os_family:vars.os_family
+    ()
 
 let ocaml_name = OpamPackage.Name.of_string "ocaml"
 


### PR DESCRIPTION
The solver ignored `available` filters. See https://github.com/talex5/opam-0install-solver/pull/12.