### PR TITLE
Use a project name that is a package name

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,5 +1,5 @@
 (lang dune 2.0)
-(name ocaml-ci)
+(name ocaml-ci-api)
 (formatting disabled)
 
 (generate_opam_files true)


### PR DESCRIPTION
Otherwise `dune subst` (invoked when pinning) fails.