### PR TITLE
Add missing ppx_deriving dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -15,7 +15,9 @@
   current_rpc
   (capnp (>= 3.4.0))
   capnp-rpc-lwt
-  dockerfile))
+  dockerfile
+  ppx_deriving
+  ppx_deriving_yojson))
 
 (package
  (name ocaml-ci-service)

--- a/ocaml-ci-api.opam
+++ b/ocaml-ci-api.opam
@@ -11,6 +11,8 @@ depends: [
   "capnp" {>= "3.4.0"}
   "capnp-rpc-lwt"
   "dockerfile"
+  "ppx_deriving"
+  "ppx_deriving_yojson"
 ]
 build: [
   ["dune" "subst"] {pinned}


### PR DESCRIPTION
These are referenced in the dune file but not in the opam metadata:

https://github.com/ocurrent/ocaml-ci/blob/f0f51c2aad906c95b98706e600282ddc5262f0b5/api/dune#L6