### PR TITLE
support 32-bit and multiarch builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,9 @@
 [submodule "opam-0install-solver"]
 	path = opam-0install-solver
 	url = https://github.com/talex5/opam-0install-solver
+[submodule "ocaml-dockerfile"]
+	path = ocaml-dockerfile
+	url = https://github.com/avsm/ocaml-dockerfile.git
 [submodule "ocluster"]
 	path = ocluster
 	url = https://github.com/ocurrent/ocluster.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "opam-0install-solver"]
 	path = opam-0install-solver
 	url = https://github.com/talex5/opam-0install-solver
-[submodule "ocaml-dockerfile"]
-	path = ocaml-dockerfile
-	url = https://github.com/avsm/ocaml-dockerfile.git
 [submodule "ocluster"]
 	path = ocluster
 	url = https://github.com/ocurrent/ocluster.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard a5e373ef1d13748cb092ede3c5b74ce6b6c03349 && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 0f1d4fba36adc2f86afc246a36e4d76224191b9f && opam update
 COPY --chown=opam \
 	ocurrent/current_ansi.opam \
 	ocurrent/current_docker.opam \

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,4 +39,5 @@ RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-service"]
 ENV OCAMLRUNPARAM=a=2
+ENV DOCKER_CLI_EXPERIMENTAL=enabled
 COPY --from=build /src/_build/install/default/bin/ocaml-ci-service /src/_build/install/default/bin/ocaml-ci-solver /usr/local/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,5 +39,6 @@ RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-service"]
 ENV OCAMLRUNPARAM=a=2
+# Enable experimental for docker manifest support
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 COPY --from=build /src/_build/install/default/bin/ocaml-ci-service /src/_build/install/default/bin/ocaml-ci-solver /usr/local/bin/

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard dbd4c97fbe25d8179a416b7252957de2b53322ad && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 0f1d4fba36adc2f86afc246a36e4d76224191b9f && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	ocurrent/current_ansi.opam \

--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
   ocaml-ci-solver
   ocluster-api
   conf-libev
-  (dockerfile (>= 6.3.0))
+  (dockerfile (>= 6.6.0))
   (ocaml-version (>= 2.4.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -6,14 +6,14 @@ module Analysis : sig
   val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
   val selections : t -> [
-      | `Opam_build of Ocaml_ci_api.Worker.Selection.t list
-      | `Duniverse of string list               (* Variants to build on *)
+      | `Opam_build of Selection.t list
+      | `Duniverse of Variant.t list               (* Variants to build on *)
     ]
 
   val of_dir :
     solver:Ocaml_ci_api.Solver.t ->
     job:Current.Job.t ->
-    platforms:(string * Ocaml_ci_api.Worker.Vars.t) list ->
+    platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
     opam_repository_commit:Current_git.Commit_id.t ->
     Fpath.t ->
     (t, [ `Msg of string ]) result Lwt.t

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -12,8 +12,9 @@ let build { docker_context; pool; build_timeout } ~dockerfile source =
     ~timeout:build_timeout
     ~pull:false
 
-let pull { docker_context; pool = _; build_timeout = _ } tag =
-  Current_docker.Raw.pull tag
+let pull { docker_context; pool = _; build_timeout = _ } ?arch tag =
+  let arch = Variant.to_docker_arch arch in
+  Current_docker.Raw.pull ?arch tag
     ~docker_context
 
 let run { docker_context; pool; build_timeout = _ } ~args img =

--- a/lib/buildkit_syntax.ml
+++ b/lib/buildkit_syntax.ml
@@ -1,0 +1,14 @@
+(* From `docker manifest inspect docker/dockerfile:experimental` *)
+let hash_for = function
+  |`X86_64 -> "sha256:8c69d118cfcd040a222bea7f7d57c6156faa938cb61b47657cd65343babc3664"
+  |`I386 -> "sha256:8c69d118cfcd040a222bea7f7d57c6156faa938cb61b47657cd65343babc3664"
+  |`Aarch64 -> "sha256:d9ced99b409ddb781c245c7c11f72566f940424fc3883ac0b5c5165f402e5a09"
+  |`Aarch32 -> "sha256:5f502d5a34f8cd1780fde9301b69488e9c0cfcecde2d673b6bff19aa4979fdfc"
+  |`Ppc64le -> "sha256:c0fe20821d527e147784f7e782513880bf31b0060b2a7da7a94582ecde81c85f"
+
+let add arch =
+  let hash = hash_for (match arch with
+    | None | Some `X86_64 | Some `I386 -> `X86_64
+    | Some `Aarch64 | Some `Aarch32 -> `Aarch64
+    | Some `Ppc64le -> `Ppc64le) in
+  Dockerfile.comment "syntax = docker/dockerfile:experimental@%s" hash

--- a/lib/buildkit_syntax.mli
+++ b/lib/buildkit_syntax.mli
@@ -1,0 +1,4 @@
+val add : Ocaml_version.arch option -> Dockerfile.t
+(** [add arch] will activate BuildKit experimental syntax with
+    a hash that will work for that architecture. Defaults to x86_64
+    if no arch is specified. *)

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -72,8 +72,7 @@ let dockerfile ~base ~repo ~variant ~for_user =
   in
   let build_platform, install_platform = install_platform ~compiler:"4.10" in
   let open Dockerfile in
-  (if for_user then empty
-   else comment "syntax = docker/dockerfile:experimental@sha256:ee85655c57140bd20a5ebc3bb802e7410ee9ac47ca92b193ed0ab17485024fe5") @@
+  (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
   build_platform @@
   from base @@
   install_platform @@

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -77,7 +77,7 @@ let dockerfile ~base ~repo ~variant ~for_user =
   build_platform @@
   from base @@
   install_platform @@
-  comment "%s" variant @@
+  comment "%s" (Variant.to_string variant) @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
   copy ~chown:"opam" ~src:["dune-get"] ~dst:"/src/" () @@

--- a/lib/duniverse_build.mli
+++ b/lib/duniverse_build.mli
@@ -1,1 +1,1 @@
-val dockerfile : base:string -> repo:Current_github.Repo_id.t -> variant:string -> for_user:bool -> Dockerfile.t
+val dockerfile : base:string -> repo:Current_github.Repo_id.t -> variant:Variant.t -> for_user:bool -> Dockerfile.t

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -14,8 +14,7 @@ let install_ocamlformat =
 let fmt_dockerfile ~base ~ocamlformat_source ~for_user =
   let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
   let open Dockerfile in
-  (if for_user then empty
-   else comment "syntax = docker/dockerfile:experimental@sha256:ee85655c57140bd20a5ebc3bb802e7410ee9ac47ca92b193ed0ab17485024fe5") @@
+  (if for_user then empty else Buildkit_syntax.add None) @@
   from base
   @@ run "%sopam install dune" download_cache_prefix (* Not necessarily the dune version used by the project *)
   @@ workdir "src"

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -8,7 +8,7 @@ val fmt_dockerfile :
 val doc_dockerfile :
   base:string ->
   opam_files:string list ->
-  selection:Ocaml_ci_api.Worker.Selection.t ->
+  selection:Selection.t ->
   for_user:bool ->
   Dockerfile.t
 (** A Dockerfile that checks that the documentation in [./src/] builds without warnings. *)

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -63,8 +63,7 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
     else
       empty
   in
-  (if for_user then empty
-   else comment "syntax = docker/dockerfile:experimental@sha256:ee85655c57140bd20a5ebc3bb802e7410ee9ac47ca92b193ed0ab17485024fe5") @@
+  (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
   from base @@
   (match Variant.arch variant with
    | Some arch ->

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -3,12 +3,12 @@ val download_cache : string
 val install_project_deps :
   base:string ->
   opam_files:string list ->
-  selection:Ocaml_ci_api.Worker.Selection.t ->
+  selection:Selection.t ->
   for_user:bool ->
   Dockerfile.t
 
 val dockerfile :
   base:string ->
   opam_files:string list ->
-  selection:Ocaml_ci_api.Worker.Selection.t ->
+  selection:Selection.t ->
   for_user:bool -> Dockerfile.t

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -80,7 +80,7 @@ module Query = struct
     let cmd = get_ocaml_version ~docker_context image in
     Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vnum ->
     let ocaml_version = String.trim vnum in
-    let cmd = get_vars ~arch:(Variant.arch variant |> Variant.to_docker_arch) docker_context image in
+    let cmd = get_vars ~arch:(Variant.arch variant |> Variant.to_opam_arch) docker_context image in
     Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vars ->
     let json =
       match Yojson.Safe.from_string vars with
@@ -114,7 +114,7 @@ let get ~arch ~label ~builder ~pool ~distro ~ocaml_version base =
   { label; builder; pool; variant; base; vars }
 
 let pull ~arch ~schedule ~builder ~distro ~ocaml_version =
-  let archl = match arch with None -> "" | Some _ -> " " ^ (Variant.to_opam_arch arch) in
+  let archl = Variant.to_opam_arch arch |> Option.value ~default:"" in
   Current.component "pull@,%s %s%s" distro ocaml_version archl |>
   let> () = Current.return () in
   let tag = docker_tag ~distro ~ocaml_version in

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -118,4 +118,6 @@ let pull ~arch ~schedule ~builder ~distro ~ocaml_version =
   Current.component "pull@,%s %s%s" distro ocaml_version archl |>
   let> () = Current.return () in
   let tag = docker_tag ~distro ~ocaml_version in
-  Builder.pull ~schedule ?arch builder @@ "ocurrent/opam:" ^ tag
+  (* Always pull the x86_64 image as it runs on the main builder.
+   * The arch will be overridden in the config vars passed to [get] later *)
+  Builder.pull ~schedule builder @@ "ocurrent/opam:" ^ tag

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -11,7 +11,7 @@ type t = {
   label : string;
   builder : Builder.t;
   pool : string;        (* OCluster pool *)
-  variant : string;
+  variant : Variant.t;
   base : Current_docker.Raw.Image.t;
   vars : Worker.Vars.t;
 }
@@ -29,7 +29,7 @@ module Query = struct
   module Key = struct
     type t = {
       docker_context : string option;
-      variant : string;
+      variant : Variant.t;
     } [@@deriving to_yojson]
 
     let digest t = Yojson.Safe.to_string (to_yojson t)
@@ -57,28 +57,30 @@ module Query = struct
       | Error e -> failwith e
   end
 
-  let opam_template = {|
+  let opam_template arch =
+    let arch = Option.value ~default:"%{arch}%" arch in
+    Fmt.strf {|
     {
-      "arch": "%{arch}%",
-      "os": "%{os}%",
-      "os_family": "%{os-family}%",
-      "os_distribution": "%{os-distribution}%",
-      "os_version": "%{os-version}%"
+      "arch": "%s",
+      "os": "%%{os}%%",
+      "os_family": "%%{os-family}%%",
+      "os_distribution": "%%{os-distribution}%%",
+      "os_version": "%%{os-version}%%"
     }
-  |}
+  |} arch
 
-  let get_vars ~docker_context image =
-    Raw.Cmd.docker ~docker_context ["run"; "-i"; image; "opam"; "config"; "expand"; opam_template]
+  let get_vars ~arch docker_context image =
+    Raw.Cmd.docker ~docker_context ["run"; "-i"; image; "opam"; "config"; "expand"; (opam_template arch)]
 
   let get_ocaml_version ~docker_context image =
     Raw.Cmd.docker ~docker_context ["run"; "-i"; image; "opam"; "exec"; "--"; "ocaml"; "-vnum"]
 
-  let run No_context job { Key.docker_context; variant = _ } { Value.image } =
+  let run No_context job { Key.docker_context; variant } { Value.image } =
     Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
     let cmd = get_ocaml_version ~docker_context image in
     Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vnum ->
     let ocaml_version = String.trim vnum in
-    let cmd = get_vars ~docker_context image in
+    let cmd = get_vars ~arch:(Variant.arch variant |> Variant.to_docker_arch) docker_context image in
     Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vars ->
     let json =
       match Yojson.Safe.from_string vars with
@@ -90,7 +92,7 @@ module Query = struct
     | Error msg -> Lwt_result.fail (`Msg msg)
     | Ok vars -> Lwt_result.return { Outcome.vars; image }
 
-  let pp f (key, value) = Fmt.pf f "opam vars of %s@,(%s)" key.Key.variant value.Value.image
+  let pp f (key, value) = Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant value.Value.image
 
   let auto_cancel = false
   let latched = true
@@ -105,14 +107,15 @@ let query builder ~variant image =
   let docker_context = builder.Builder.docker_context in
   QC.run Query.No_context { Query.Key.docker_context; variant } { Query.Value.image }
 
-let get ~label ~builder ~pool ~distro ~ocaml_version base =
-  let variant = docker_tag ~distro ~ocaml_version in
+let get ~arch ~label ~builder ~pool ~distro ~ocaml_version base =
+  let variant = Variant.v ~arch (docker_tag ~distro ~ocaml_version) in
   let+ { Query.Outcome.vars; image } = query builder base ~variant in
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base; vars }
 
-let pull ~schedule ~builder ~distro ~ocaml_version =
-  Current.component "pull@,%s %s" distro ocaml_version |>
+let pull ~arch ~schedule ~builder ~distro ~ocaml_version =
+  let archl = match arch with None -> "" | Some _ -> " " ^ (Variant.to_opam_arch arch) in
+  Current.component "pull@,%s %s%s" distro ocaml_version archl |>
   let> () = Current.return () in
   let tag = docker_tag ~distro ~ocaml_version in
-  Builder.pull ~schedule builder @@ "ocurrent/opam:" ^ tag
+  Builder.pull ~schedule ?arch builder @@ "ocurrent/opam:" ^ tag

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -117,7 +117,7 @@ let get ~arch ~label ~builder ~pool ~distro ~ocaml_version base =
 
 let pull ~arch ~schedule ~builder ~distro ~ocaml_version =
   let archl = Variant.to_opam_arch arch |> Option.value ~default:"" in
-  Current.component "pull@,%s %s%s" distro ocaml_version archl |>
+  Current.component "pull@,%s %s %s" distro ocaml_version archl |>
   let> () = Current.return () in
   let tag = docker_tag ~distro ~ocaml_version in
   Builder.pull ~schedule ?arch builder @@ "ocurrent/opam:" ^ tag

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -101,17 +101,18 @@ end
 
 module QC = Current_cache.Generic(Query)
 
-let query builder ~variant (host_image, image) =
+let query builder ~variant ~host_image image =
   Current.component "opam-vars" |>
-  let> host_image, image = Current.pair host_image image in
+  let> host_image = host_image
+  and> image = image in
   let image = Raw.Image.hash image in
   let host_image = Raw.Image.hash host_image in
   let docker_context = builder.Builder.docker_context in
   QC.run Query.No_context { Query.Key.docker_context; variant } { Query.Value.image; host_image }
 
-let get ~arch ~label ~builder ~pool ~distro ~ocaml_version base =
+let get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base =
   let variant = Variant.v ~arch (docker_tag ~distro ~ocaml_version) in
-  let+ { Query.Outcome.vars; image } = query builder base ~variant in
+  let+ { Query.Outcome.vars; image } = query builder ~variant ~host_image:host_base base in
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base; vars }
 

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -19,10 +19,11 @@ val get :
   pool:string ->
   distro:string ->
   ocaml_version:string ->
-  Current_docker.Raw.Image.t Current.t *
+  host_base:Current_docker.Raw.Image.t Current.t ->
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
-(** [get ~label ~builder ~variant base] creates a [t] by getting the opam variables from [base]. *)
+(** [get ~label ~builder ~variant ~host_base base] creates a [t] by getting the opam variables from [host_base]
+    and returning [base] for subsequent builds. *)
 
 val pull :
   arch:Ocaml_version.arch option ->

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -19,6 +19,7 @@ val get :
   pool:string ->
   distro:string ->
   ocaml_version:string ->
+  Current_docker.Raw.Image.t Current.t *
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
 (** [get ~label ~builder ~variant base] creates a [t] by getting the opam variables from [base]. *)

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -4,7 +4,7 @@ type t = {
   label : string;
   builder : Builder.t;
   pool : string;        (* OCluster pool *)
-  variant : string;                     (* e.g. "debian-10-ocaml-4.08" *)
+  variant : Variant.t;  (* e.g. "debian-10-ocaml-4.08" *)
   base : Current_docker.Raw.Image.t;
   vars : Ocaml_ci_api.Worker.Vars.t;
 }
@@ -13,6 +13,7 @@ val pp : t Fmt.t
 val compare : t -> t -> int
 
 val get :
+  arch:Ocaml_version.arch option ->
   label:string ->
   builder:Builder.t ->
   pool:string ->
@@ -23,6 +24,7 @@ val get :
 (** [get ~label ~builder ~variant base] creates a [t] by getting the opam variables from [base]. *)
 
 val pull :
+  arch:Ocaml_version.arch option ->
   schedule:Current_cache.Schedule.t ->
   builder:Builder.t ->
   distro:string ->

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -1,0 +1,12 @@
+(** A set of packages for a single build. *)
+type t = {
+  variant : Variant.t;                (** The variant image to build on. *)
+  packages : string list;             (** The selected packages ("name.version"). *)
+  commit : string;                    (** A commit in opam-repository to use. *)
+} [@@deriving yojson, ord]
+
+let of_worker w =
+  let module W = Ocaml_ci_api.Worker.Selection in
+  let { W.id; packages; commit } = w in
+  let variant = Variant.of_string id in
+  { variant; packages; commit }

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -1,0 +1,8 @@
+(** A set of packages for a single build. *)
+type t = {
+  variant : Variant.t;                (** The variant image to build on. *)
+  packages : string list;             (** The selected packages ("name.version"). *)
+  commit : string;                    (** A commit in opam-repository to use. *)
+} [@@deriving yojson, ord]
+
+val of_worker : Ocaml_ci_api.Worker.Selection.t -> t

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -1,5 +1,3 @@
-module Selection = Ocaml_ci_api.Worker.Selection
-
 type opam_files = string list [@@deriving to_yojson, ord]
 
 type ty = [
@@ -10,12 +8,12 @@ type ty = [
 
 type t = {
   label : string;
-  variant : string;
+  variant : Variant.t;
   ty : ty;
 } [@@deriving ord]
 
 let opam ~label ~selection ~analysis op =
-  let variant = selection.Selection.id in
+  let variant = selection.Selection.variant in
   let ty =
     match op with
     | `Build | `Lint `Doc as x -> `Opam (x, selection, Analyse.Analysis.opam_files analysis)

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -1,23 +1,23 @@
 type ty = [
-  | `Opam of [ `Build | `Lint of [ `Doc ]] * Ocaml_ci_api.Worker.Selection.t * string list
+  | `Opam of [ `Build | `Lint of [ `Doc ]] * Selection.t * string list
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse
 ] [@@deriving to_yojson, ord]
 
 type t = {
   label : string;
-  variant : string;
+  variant : Variant.t;
   ty : ty;
 }
 
 val opam :
   label:string ->
-  selection:Ocaml_ci_api.Worker.Selection.t ->
+  selection:Selection.t ->
   analysis:Analyse.Analysis.t ->
   [ `Build | `Lint of [ `Doc | `Fmt ] ] ->
   t
 
-val duniverse : label:string -> variant:string -> t
+val duniverse : label:string -> variant:Variant.t -> t
 
 val pp : t Fmt.t
 val compare : t -> t -> int

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -37,12 +37,8 @@ module Ocaml_version = struct
 
 end
 
-let to_opam_arch = function
-  | None -> "%{arch}%"
-  | Some a -> Ocaml_version.to_opam_arch a
-
-let to_docker_arch a =
-  Option.map Ocaml_version.to_docker_arch a
+let to_opam_arch a = Option.map Ocaml_version.to_opam_arch a
+let to_docker_arch a = Option.map Ocaml_version.to_docker_arch a
 
 type t = string * Ocaml_version.arch option [@@deriving yojson, ord, eq]
 let v ~arch n = n, arch

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -1,0 +1,66 @@
+module Ocaml_version = struct
+  include Ocaml_version
+  let arch_to_yojson arch = `String (string_of_arch arch)
+  let arch_of_yojson j =
+    match j with
+    |`String a -> begin
+       match arch_of_string a with
+       | Ok v -> Ok v
+       | Error _ -> Error ("unknown arch " ^ a)
+     end
+    | _ -> Error "unknown json type for arch"
+
+  let compare_arch = Stdlib.compare
+  let equal_arch = (=)
+
+  let to_opam_arch = function
+  | `I386 -> "x86_32"
+  | `X86_64 -> "x86_64"
+  | `Ppc64le -> "ppc64"
+  | `Aarch32 -> "arm32"
+  | `Aarch64 -> "arm64"
+
+  let to_docker_arch = function
+   | `I386 -> "386"
+   | `X86_64 -> "amd64"
+   | `Ppc64le -> "ppc64le"
+   | `Aarch32 -> "arm"
+   | `Aarch64 -> "arm64"
+
+  let of_opam_arch = function
+  | "x86_32" -> Some `I386
+  | "x86_64" -> Some `X86_64
+  | "ppc64" -> Some `Ppc64le
+  | "arm32" -> Some `Aarch32
+  | "arm64" -> Some `Aarch64
+  | _ -> None
+
+end
+
+let to_opam_arch = function
+  | None -> "%{arch}%"
+  | Some a -> Ocaml_version.to_opam_arch a
+
+let to_docker_arch a =
+  Option.map Ocaml_version.to_docker_arch a
+
+type t = string * Ocaml_version.arch option [@@deriving yojson, ord, eq]
+let v ~arch n = n, arch
+let arch = snd
+let id = fst
+
+let pp f (id,arch) =
+  Fmt.pf f "%s%s" id
+    (match arch with
+     | None -> ""
+     | Some a -> "_" ^ (Ocaml_version.to_opam_arch a))
+
+let to_string =
+  Fmt.strf "%a" pp
+
+let of_string s =
+   match Astring.String.cut ~sep:"_" s with
+   | None -> s, None
+   | Some (s, a) -> s, (Ocaml_version.of_opam_arch a)
+
+

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -1,0 +1,16 @@
+type t [@@deriving eq,ord,yojson]
+
+val v : arch:Ocaml_version.arch option -> string -> t
+
+val arch : t -> Ocaml_version.arch option
+val id : t -> string
+val pp : t Fmt.t
+
+val to_string : t -> string
+val of_string : string -> t
+
+(** [to_opam_arch t] is either an opam-style architecture string, or the [%{arch}%] variable to be expanded later. *)
+val to_opam_arch : Ocaml_version.arch option -> string
+
+(** [to_docker_arch t] outputs a string suitable for mapping to docker multiarch manifests *)
+val to_docker_arch : Ocaml_version.arch option -> string option

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -9,8 +9,8 @@ val pp : t Fmt.t
 val to_string : t -> string
 val of_string : string -> t
 
-(** [to_opam_arch t] is either an opam-style architecture string, or the [%{arch}%] variable to be expanded later. *)
-val to_opam_arch : Ocaml_version.arch option -> string
+(** [to_opam_arch t] outputs a string suitable for use in opam files as the [%{arch}%] variable *)
+val to_opam_arch : Ocaml_version.arch option -> string option
 
 (** [to_docker_arch t] outputs a string suitable for mapping to docker multiarch manifests *)
 val to_docker_arch : Ocaml_version.arch option -> string option

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-ci-solver"
   "ocluster-api"
   "conf-libev"
-  "dockerfile" {>= "6.3.0"}
+  "dockerfile" {>= "6.6.0"}
   "ocaml-version" {>= "2.4.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -69,6 +69,7 @@ let platforms =
       v ~arch:`I386 "4.10+x86_32" "linux-x86_64" "debian-10" "4.10";
       v ~arch:`Aarch32 "4.10+arm32" "linux-arm64" "debian-10" "4.10";
       v ~arch:`Aarch64 "4.10+arm64" "linux-arm64" "debian-10" "4.10";
+      v ~arch:`Ppc64le "4.10+ppc64le" "linux-ppc64" "debian-10" "4.10";
     ]
   | `Dev ->
     [

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -41,10 +41,11 @@ type platform = {
   pool : string;
   distro : string;
   ocaml_version : string;
+  arch: Ocaml_version.arch option;
 }
 
 let platforms =
-  let v label pool distro ocaml_version = { label; builder = Builders.local; pool; distro; ocaml_version } in
+  let v ?arch label pool distro ocaml_version = { arch; label; builder = Builders.local; pool; distro; ocaml_version } in
   match profile with
   | `Production ->
     [
@@ -65,10 +66,12 @@ let platforms =
       v "centos"   "linux-x86_64" "centos-8"      default_compiler;
       v "fedora"   "linux-x86_64" "fedora-31"     default_compiler;
       (* oraclelinux doesn't work in opam 2 yet *)
+      v ~arch:`I386 "4.10+32bit" "linux-x86_64" "debian-10" "4.10";
     ]
   | `Dev ->
     [
       v "4.10" "linux-x86_64" "debian-10" "4.10";
       v "4.09" "linux-x86_64" "debian-10" "4.09";
       v "4.02" "linux-x86_64" "debian-10" "4.02";
+      v ~arch:`I386 "4.10+32bit" "linux-x86_64" "debian-10" "4.10";
     ]

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -66,7 +66,9 @@ let platforms =
       v "centos"   "linux-x86_64" "centos-8"      default_compiler;
       v "fedora"   "linux-x86_64" "fedora-31"     default_compiler;
       (* oraclelinux doesn't work in opam 2 yet *)
-      v ~arch:`I386 "4.10+32bit" "linux-x86_64" "debian-10" "4.10";
+      v ~arch:`I386 "4.10+x86_32" "linux-x86_64" "debian-10" "4.10";
+      v ~arch:`Aarch32 "4.10+arm32" "linux-arm64" "debian-10" "4.10";
+      v ~arch:`Aarch64 "4.10+arm64" "linux-arm64" "debian-10" "4.10";
     ]
   | `Dev ->
     [

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -9,7 +9,12 @@ let platforms =
   let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
   let v { Conf.label; builder; pool; distro; ocaml_version; arch } =
     let base = Platform.pull ~arch ~schedule ~builder ~distro ~ocaml_version in
-    Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version base
+    let host_base =
+      match arch with
+      | None | Some `X86_64 -> base
+      | _ -> Platform.pull ~arch:None ~schedule ~builder ~distro ~ocaml_version
+    in
+    Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version (host_base, base)
   in
   Current.list_seq (List.map v Conf.platforms)
 

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -14,7 +14,7 @@ let platforms =
       | None | Some `X86_64 -> base
       | _ -> Platform.pull ~arch:None ~schedule ~builder ~distro ~ocaml_version
     in
-    Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version (host_base, base)
+    Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base
   in
   Current.list_seq (List.map v Conf.platforms)
 

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -8,9 +8,11 @@ let debian_10_vars ocaml_version =
     ocaml_version
   }
 
+let var = Ocaml_ci.Variant.v ~arch:None 
+
 let v = [
-  "debian-10-ocaml-4.10", debian_10_vars "4.10.0";
-  "debian-10-ocaml-4.09", debian_10_vars "4.09.0";
-  "debian-10-ocaml-4.08", debian_10_vars "4.08.0";
-  "debian-10-ocaml-4.07", debian_10_vars "4.07.0";
+  var "debian-10-ocaml-4.10", debian_10_vars "4.10.0";
+  var "debian-10-ocaml-4.09", debian_10_vars "4.09.0";
+  var "debian-10-ocaml-4.08", debian_10_vars "4.08.0";
+  var "debian-10-ocaml-4.07", debian_10_vars "4.07.0";
 ]


### PR DESCRIPTION
This plumbs through the arch option in order to allow the selection of 32bit builds.  Its only activated for i386 right now, but when we use the builder pool it should also allow for selecting arm32 as well.

Only lightly tested so far. Depends on ocurrent/ocurrent#213

Fixes #182