### PR TITLE
opam_build: check that the source tree is unmodified post build

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -84,4 +84,4 @@ let dockerfile ~base ~opam_files ~selection ~for_user =
   let open Dockerfile in
   install_project_deps ~base ~opam_files ~selection ~for_user @@
   copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
-  run "opam exec -- dune build @install @runtest && rm -rf _build"
+  run "opam exec -- dune build @install @runtest && git diff --exit-code && rm -rf _build"


### PR DESCRIPTION
This will catch the case of modifying a dune-project file but
forgetting to commit the corresponding opam file (or vice versa).

Fixes #220