### PR TITLE
add an opam lint checking phase

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -82,6 +82,7 @@ module Op = struct
       match ty with
       | `Opam (`Build, selection, opam_files) -> Opam_build.dockerfile ~base ~opam_files ~selection
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_dockerfile ~base ~opam_files ~selection
+      | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_dockerfile ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_dockerfile ~base ~ocamlformat_source
       | `Duniverse -> Duniverse_build.dockerfile ~base ~repo ~variant
     in
@@ -152,7 +153,7 @@ let v ~platforms ~repo ~spec source =
     match spec.ty with
     | `Duniverse
     | `Opam (`Build, _, _) -> `Built
-    | `Opam (`Lint `Doc, _, _) -> `Checked
+    | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked
   in
   result, job_id

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -220,7 +220,7 @@ module Op = struct
     let deps =
       match ty with
       | `Opam (`Build, selection, _) -> hash_packages selection.packages
-      | `Opam (`Lint `Doc, selection, _) -> hash_packages selection.packages
+      | `Opam (`Lint (`Doc|`Opam), selection, _) -> hash_packages selection.packages
       | `Opam_fmt _ -> "ocamlformat"
       | `Duniverse -> "duniverse"
     in
@@ -236,6 +236,7 @@ module Op = struct
       match ty with
       | `Opam (`Build, selection, opam_files) -> Opam_build.dockerfile ~base ~opam_files ~selection
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_dockerfile ~base ~opam_files ~selection
+      | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_dockerfile ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_dockerfile ~base ~ocamlformat_source
       | `Duniverse -> Duniverse_build.dockerfile ~base ~repo ~variant
     in
@@ -324,7 +325,7 @@ let v t ~platforms ~repo ~spec source =
     match spec.ty with
     | `Duniverse
     | `Opam (`Build, _, _) -> `Built
-    | `Opam (`Lint `Doc, _, _) -> `Checked
+    | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked
   in
   result, job_id

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -32,3 +32,10 @@ let doc_dockerfile ~base ~opam_files ~selection ~for_user =
   @@ run "%sopam depext -i dune odoc>=1.5.0" download_cache_prefix
   @@ run "ODOC_WARN_ERROR=true opam exec -- dune build @doc \
           || (echo \"dune build @doc failed\"; exit 2)"
+
+let opam_lint_dockerfile ~base ~opam_files ~for_user:_ =
+  let open Dockerfile in
+  from base
+  @@ workdir "src"
+  @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
+  @@ run "opam lint %s" (String.concat " " opam_files)

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -12,3 +12,9 @@ val doc_dockerfile :
   for_user:bool ->
   Dockerfile.t
 (** A Dockerfile that checks that the documentation in [./src/] builds without warnings. *)
+
+val opam_lint_dockerfile :
+  base:string ->
+  opam_files:string list ->
+  for_user:bool ->
+  Dockerfile.t

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -1,7 +1,7 @@
 type opam_files = string list [@@deriving to_yojson, ord]
 
 type ty = [
-  | `Opam of [ `Build | `Lint of [ `Doc ]] * Selection.t * opam_files
+  | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * opam_files
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse
 ] [@@deriving to_yojson, ord]
@@ -16,7 +16,7 @@ let opam ~label ~selection ~analysis op =
   let variant = selection.Selection.variant in
   let ty =
     match op with
-    | `Build | `Lint `Doc as x -> `Opam (x, selection, Analyse.Analysis.opam_files analysis)
+    | `Build | `Lint (`Doc | `Opam) as x -> `Opam (x, selection, Analyse.Analysis.opam_files analysis)
     | `Lint `Fmt -> `Opam_fmt (Analyse.Analysis.ocamlformat_source analysis)
   in
   { label; variant; ty }
@@ -31,6 +31,7 @@ let label t = t.label
 let pp_summary f = function
   | `Opam (`Build, _, _) -> Fmt.string f "Opam project build"
   | `Opam (`Lint `Doc, _, _) -> Fmt.string f "Opam project lint documentation"
+  | `Opam (`Lint `Opam, _, _) -> Fmt.string f "Opam files lint"
   | `Opam_fmt v -> Fmt.pf f "ocamlformat version: %a"
                      Fmt.(option ~none:(unit "none") Analyse_ocamlformat.pp_source) v
   | `Duniverse -> Fmt.string f "Duniverse build"

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -1,5 +1,5 @@
 type ty = [
-  | `Opam of [ `Build | `Lint of [ `Doc ]] * Selection.t * string list
+  | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * string list
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse
 ] [@@deriving to_yojson, ord]
@@ -14,7 +14,7 @@ val opam :
   label:string ->
   selection:Selection.t ->
   analysis:Analyse.Analysis.t ->
-  [ `Build | `Lint of [ `Doc | `Fmt ] ] ->
+  [ `Build | `Lint of [ `Doc | `Fmt | `Opam ] ] ->
   t
 
 val duniverse : label:string -> variant:Variant.t -> t

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -98,6 +98,7 @@ let build_with_docker ?ocluster ~repo ~analysis source =
           [
             Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis (`Lint `Fmt);
             Spec.opam ~label:"(lint-doc)" ~selection:lint_selection ~analysis (`Lint `Doc);
+            Spec.opam ~label:"(lint-opam)" ~selection:lint_selection ~analysis (`Lint `Opam);
           ]
         in
         lint @ builds


### PR DESCRIPTION
This runs opam lint on all the detected opam files. It should
perhaps only run them on the toplevel ones, but its useful to
know if any sub-files are also wrong I think.

I considered making the check only copy the opam files, but
there may be other dependencies required from the source
tree (via extra-files), so its best to just take the whole
source tree over. It's very fast to recompute this lint, so
rebuilds shouldn't be too much worse.

Fixes #151