### PR TITLE
Add support for building OCaml compiler repositories and variants

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,9 @@
 [submodule "ocluster"]
 	path = ocluster
 	url = https://github.com/ocurrent/ocluster.git
+[submodule "ocaml-version"]
+	path = ocaml-version
+	url = https://github.com/ocurrent/ocaml-version.git
+[submodule "ocaml-dockerfile"]
+	path = ocaml-dockerfile
+	url = https://github.com/avsm/ocaml-dockerfile.git

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -258,9 +258,10 @@ module Analysis = struct
             let check_whitelist_path path =
               match Fpath.v path |> Fpath.segs with
               | [_file] -> true
-              | ["duniverse"; _pkg; _file] -> true
+              | ["duniverse"; _pkg; _file] when ty = `Duniverse -> true
+              | ["duniverse"; _pkg; _file] -> false
               | _ when ty = `Duniverse ->
-                Current.Job.log job "WARNING: ignoring opam file %S as not in root or duniverse subdir" path; false
+                Current.Job.log job "WARNING: ignoring opam file %S as not in root subdir" path; false
               | segs when List.exists is_test_dir segs ->
                 Current.Job.log job "Ignoring test directory %S" path;
                 false

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -7,7 +7,8 @@ module Analysis : sig
 
   val selections : t -> [
       | `Opam_build of Selection.t list
-      | `Duniverse of Variant.t list               (* Variants to build on *)
+      | `Duniverse of Variant.t list
+      | `Ocaml_compiler of Variant.t list
     ]
 
   val of_dir :

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -84,6 +84,7 @@ module Op = struct
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_dockerfile ~base ~opam_files ~selection
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_dockerfile ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_dockerfile ~base ~ocamlformat_source
+      | `Ocaml_compiler -> Ocaml_compiler_build.dockerfile ~base ~variant
       | `Duniverse -> Duniverse_build.dockerfile ~base ~repo ~variant
     in
     Current.Job.write job
@@ -151,7 +152,7 @@ let v ~platforms ~repo ~spec source =
   let result =
     state |> Result.map @@ fun () ->
     match spec.ty with
-    | `Duniverse
+    | `Duniverse | `Ocaml_compiler
     | `Opam (`Build, _, _) -> `Built
     | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -12,8 +12,8 @@ let build { docker_context; pool; build_timeout } ~dockerfile source =
     ~timeout:build_timeout
     ~pull:false
 
-let pull { docker_context; pool = _; build_timeout = _ } ?arch tag =
-  let arch = Variant.to_docker_arch arch in
+let pull { docker_context; pool = _; build_timeout = _ } ~arch tag =
+  let arch = if Ocaml_version.arch_is_32bit arch then Some (Ocaml_version.to_docker_arch arch) else None in
   Current_docker.Raw.pull ?arch tag
     ~docker_context
 

--- a/lib/buildkit_syntax.ml
+++ b/lib/buildkit_syntax.ml
@@ -8,7 +8,7 @@ let hash_for = function
 
 let add arch =
   let hash = hash_for (match arch with
-    | None | Some `X86_64 | Some `I386 -> `X86_64
-    | Some `Aarch64 | Some `Aarch32 -> `Aarch64
-    | Some `Ppc64le -> `Ppc64le) in
+    | `X86_64 | `I386 -> `X86_64
+    | `Aarch64 | `Aarch32 -> `Aarch64
+    | `Ppc64le -> `Ppc64le) in
   Dockerfile.comment "syntax = docker/dockerfile:experimental@%s" hash

--- a/lib/buildkit_syntax.mli
+++ b/lib/buildkit_syntax.mli
@@ -1,4 +1,4 @@
-val add : Ocaml_version.arch option -> Dockerfile.t
+val add : Ocaml_version.arch -> Dockerfile.t
 (** [add arch] will activate BuildKit experimental syntax with
     a hash that will work for that architecture. Defaults to x86_64
     if no arch is specified. *)

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -222,7 +222,8 @@ module Op = struct
       | `Opam (`Build, selection, _) -> hash_packages selection.packages
       | `Opam (`Lint (`Doc|`Opam), selection, _) -> hash_packages selection.packages
       | `Opam_fmt _ -> "ocamlformat"
-      | `Duniverse -> "duniverse"
+      | `Ocaml_compiler -> "ocaml-" ^ (Variant.to_string variant)
+      | `Duniverse -> "duniverse-" ^ (Variant.to_string variant)
     in
     Fmt.strf "%s/%s-%s-%a-%s"
       owner name
@@ -238,6 +239,7 @@ module Op = struct
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_dockerfile ~base ~opam_files ~selection
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_dockerfile ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_dockerfile ~base ~ocamlformat_source
+      | `Ocaml_compiler -> Ocaml_compiler_build.dockerfile ~base ~variant
       | `Duniverse -> Duniverse_build.dockerfile ~base ~repo ~variant
     in
     Current.Job.write job
@@ -323,7 +325,7 @@ let v t ~platforms ~repo ~spec source =
   let result =
     state |> Result.map @@ fun () ->
     match spec.ty with
-    | `Duniverse
+    | `Duniverse | `Ocaml_compiler
     | `Opam (`Build, _, _) -> `Built
     | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -14,7 +14,7 @@ let install_ocamlformat =
 let fmt_dockerfile ~base ~ocamlformat_source ~for_user =
   let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
   let open Dockerfile in
-  (if for_user then empty else Buildkit_syntax.add None) @@
+  (if for_user then empty else Buildkit_syntax.add `X86_64) @@
   from base
   @@ run "%sopam install dune" download_cache_prefix (* Not necessarily the dune version used by the project *)
   @@ workdir "src"

--- a/lib/ocaml_compiler_build.ml
+++ b/lib/ocaml_compiler_build.ml
@@ -1,0 +1,18 @@
+module OV = Ocaml_version
+module OVC = OV.Configure_options
+
+let dockerfile ~base ~variant ~for_user =
+  let ov = Variant.ocaml_version variant in
+  let opts = OVC.of_t ov |> Rresult.R.get_ok |> List.map (OVC.to_configure_flag ov) |> String.concat " " in
+  let open Dockerfile in
+  (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
+  from base @@
+  (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
+     shell ["/usr/bin/linux32"; "/bin/sh"; "-c"] else empty) @@
+  comment "%s" (Variant.to_string variant) @@
+  workdir "/src" @@
+  run "sudo chown opam /src" @@
+  copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
+  run "./configure %s" opts @@
+  run "make -j world.opt" @@
+  run "make tests"

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -65,11 +65,8 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
   in
   (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
   from base @@
-  (match Variant.arch variant with
-   | Some arch ->
-       if Ocaml_version.arch_is_32bit arch then
-         shell ["/usr/bin/linux32"; "/bin/sh"; "-c"] else empty
-   | None -> empty) @@
+  (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
+     shell ["/usr/bin/linux32"; "/bin/sh"; "-c"] else empty) @@
   comment "%s" (Fmt.strf "%a" Variant.pp variant) @@
   distro_extras @@
   workdir "/src" @@

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -13,12 +13,12 @@ val pp : t Fmt.t
 val compare : t -> t -> int
 
 val get :
-  arch:Ocaml_version.arch option ->
+  arch:Ocaml_version.arch ->
   label:string ->
   builder:Builder.t ->
   pool:string ->
   distro:string ->
-  ocaml_version:string ->
+  ocaml_version:Ocaml_version.t ->
   host_base:Current_docker.Raw.Image.t Current.t ->
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
@@ -26,10 +26,10 @@ val get :
     and returning [base] for subsequent builds. *)
 
 val pull :
-  arch:Ocaml_version.arch option ->
+  arch:Ocaml_version.arch ->
   schedule:Current_cache.Schedule.t ->
   builder:Builder.t ->
   distro:string ->
-  ocaml_version:string ->
+  ocaml_version:Ocaml_version.t ->
   Current_docker.Raw.Image.t Current.t
 (** [pull ~schedule ~builder ~distro ~ocaml_version] pulls "ocurrent/opam:{distro}-ocaml-{version}" on [schedule]. *)

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -2,6 +2,7 @@ type opam_files = string list [@@deriving to_yojson, ord]
 
 type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * opam_files
+  | `Ocaml_compiler
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse
 ] [@@deriving to_yojson, ord]
@@ -24,6 +25,9 @@ let opam ~label ~selection ~analysis op =
 let duniverse ~label ~variant =
   { label; variant; ty = `Duniverse }
 
+let ocaml_compiler ~label ~variant =
+  { label; variant; ty = `Ocaml_compiler}
+
 let pp f t = Fmt.string f t.label
 
 let label t = t.label
@@ -35,3 +39,4 @@ let pp_summary f = function
   | `Opam_fmt v -> Fmt.pf f "ocamlformat version: %a"
                      Fmt.(option ~none:(unit "none") Analyse_ocamlformat.pp_source) v
   | `Duniverse -> Fmt.string f "Duniverse build"
+  | `Ocaml_compiler -> Fmt.string f "OCaml compiler build"

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -1,5 +1,6 @@
 type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * string list
+  | `Ocaml_compiler
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse
 ] [@@deriving to_yojson, ord]
@@ -18,6 +19,8 @@ val opam :
   t
 
 val duniverse : label:string -> variant:Variant.t -> t
+
+val ocaml_compiler : label:string -> variant:Variant.t -> t
 
 val pp : t Fmt.t
 val compare : t -> t -> int

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -1,16 +1,17 @@
 type t [@@deriving eq,ord,yojson]
 
-val v : arch:Ocaml_version.arch option -> string -> t
+val v : arch:Ocaml_version.arch ->
+        distro:string -> ocaml_version:Ocaml_version.t ->
+        (t, [> `Msg of string ]) result
 
-val arch : t -> Ocaml_version.arch option
+val arch : t -> Ocaml_version.arch
+val distro : t -> string
+val ocaml_version : t -> Ocaml_version.t
+val with_ocaml_version : Ocaml_version.t -> t -> t
+
 val id : t -> string
+val docker_tag : t -> string
 val pp : t Fmt.t
 
 val to_string : t -> string
 val of_string : string -> t
-
-(** [to_opam_arch t] outputs a string suitable for use in opam files as the [%{arch}%] variable *)
-val to_opam_arch : Ocaml_version.arch option -> string option
-
-(** [to_docker_arch t] outputs a string suitable for mapping to docker multiarch manifests *)
-val to_docker_arch : Ocaml_version.arch option -> string option

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -93,7 +93,9 @@ let platforms =
         `X86_64,  `CentOS `V8, false;
         `X86_64,  `Fedora `V32, false ] @
       (* Compiler versions:*)
-      releases (List.map OV.without_patch (OV.Releases.recent |> List.rev))
+      (* The first one in this list is used for lint actions *)
+      let rels = (List.rev OV.Releases.recent) @ OV.Releases.unreleased_betas in
+      releases (List.map OV.without_patch rels)
   | `Dev ->
       releases (List.map OV.of_string_exn ["4.10"; "4.11"; "4.12"; "4.03"])
     @ releases ~arch:`I386 [OV.of_string_exn "4.10"]

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -79,8 +79,6 @@ let platforms =
   let releases ?arch l = List.map (v ?arch) l in
   match profile with
   | `Production ->
-      (* Compiler versions:*)
-      releases (List.map OV.without_patch (OV.Releases.recent |> List.rev)) @
       (* Distributions: *)
       distros [
         `X86_64,  `Debian `V10, true;
@@ -93,7 +91,9 @@ let platforms =
         `X86_64,  `Ubuntu `V18_04, false;
         `X86_64,  `OpenSUSE `V15_2, false;
         `X86_64,  `CentOS `V8, false;
-        `X86_64,  `Fedora `V32, false ]
+        `X86_64,  `Fedora `V32, false ] @
+      (* Compiler versions:*)
+      releases (List.map OV.without_patch (OV.Releases.recent |> List.rev))
   | `Dev ->
       releases (List.map OV.of_string_exn ["4.10"; "4.11"; "4.12"; "4.03"])
     @ releases ~arch:`I386 [OV.of_string_exn "4.10"]

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -80,7 +80,7 @@ let platforms =
   match profile with
   | `Production ->
       (* Compiler versions:*)
-      releases (List.map OV.without_patch OV.Releases.recent) @
+      releases (List.map OV.without_patch (OV.Releases.recent |> List.rev)) @
       (* Distributions: *)
       distros [
         `X86_64,  `Debian `V10, true;

--- a/service/dune
+++ b/service/dune
@@ -8,6 +8,7 @@
             current_git
             current_github
             current_rpc
+            dockerfile-opam
             ocluster-api
             capnp-rpc-unix
             mirage-crypto-rng.unix

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -11,8 +11,8 @@ let platforms =
     let base = Platform.pull ~arch ~schedule ~builder ~distro ~ocaml_version in
     let host_base =
       match arch with
-      | None | Some `X86_64 -> base
-      | _ -> Platform.pull ~arch:None ~schedule ~builder ~distro ~ocaml_version
+      | `X86_64 -> base
+      | _ -> Platform.pull ~arch:`X86_64 ~schedule ~builder ~distro ~ocaml_version
     in
     Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base
   in
@@ -82,6 +82,12 @@ let build_with_docker ?ocluster ~repo ~analysis source =
         []
     | Ok analysis ->
       match Analyse.Analysis.selections analysis with
+      | `Ocaml_compiler vs ->
+        vs
+        |>  List.rev_map (fun variant ->
+           let label = Variant.to_string variant in
+           Spec.ocaml_compiler ~label ~variant
+          )
       | `Duniverse variants ->
         variants
         |> List.rev_map (fun variant ->

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -9,11 +9,13 @@ let debian_10_vars ocaml_package ocaml_version =
     ocaml_version
   }
 
-let var = Ocaml_ci.Variant.v ~arch:None 
+let var distro ov =
+  Ocaml_ci.Variant.v ~arch:`X86_64 ~distro ~ocaml_version:(Ocaml_version.of_string_exn ov) |>
+  function Ok v -> v | Error (`Msg m) -> failwith m
 
 let v = [
-  var "debian-10-ocaml-4.10", debian_10_vars "ocaml" "4.10.0";
-  var "debian-10-ocaml-4.09", debian_10_vars "ocaml" "4.09.0";
-  var "debian-10-ocaml-4.08", debian_10_vars "ocaml" "4.08.0";
-  var "debian-10-ocaml-4.07", debian_10_vars "ocaml" "4.07.0";
+  var "debian-10" "4.10", debian_10_vars "ocaml" "4.10.0";
+  var "debian-10" "4.09", debian_10_vars "ocaml" "4.09.0";
+  var "debian-10" "4.08", debian_10_vars "ocaml" "4.08.0";
+  var "debian-10" "4.07", debian_10_vars "ocaml" "4.07.0";
 ]


### PR DESCRIPTION
This adds support for parsing compiler variants (e.g. flambda) in
the Variant module, which in turns allows for the compilation of
OCaml compilers.

OCaml compiler repositories are detected (using the experimental
dune flag that signifies that the compiler dune rules are active).
We then use the base distros and variants defined for the trunk
compiler (in service/conf.ml) to generate Dockerfiles that run
the full test suite.

In order to prevent an explosion of tests for non-OCaml compilers
(i.e. normal repositories), we filter out all the non-standard
variants before solving for normal repositories.  We could bring
in opt-in support for (e.g. flambda or nnp) by looking for x-
fields in their opam files, but this is not implemented yet.