### PR TITLE
Add support for building OCaml variant versions

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version = 0.12
+version = 0.15.0
 disable = true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 0f1d4fba36adc2f86afc246a36e4d76224191b9f && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard c332c82dc33e39c4d23fd4c8179d953ac2fddcc6 && opam update
 COPY --chown=opam \
 	ocurrent/current_ansi.opam \
 	ocurrent/current_docker.opam \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 0f1d4fba36adc2f86afc246a36e4d76224191b9f && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard c332c82dc33e39c4d23fd4c8179d953ac2fddcc6 && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	ocurrent/current_ansi.opam \

--- a/dune-project
+++ b/dune-project
@@ -34,8 +34,9 @@
   ocaml-ci-solver
   ocluster-api
   conf-libev
-  (dockerfile (>= 6.6.0))
-  (ocaml-version (>= 2.4.0))
+  (dockerfile (>= 7.0.0))
+  (dockerfile-opam (>= 7.0.0))
+  (ocaml-version (>= 3.0.0))
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))
 ))

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -7,7 +7,7 @@ module Analysis : sig
 
   val selections : t -> [
       | `Opam_build of Selection.t list
-      | `Duniverse of Variant.t list               (* Variants to build on *)
+      | `Duniverse of Variant.t list
     ]
 
   val of_dir :

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -12,8 +12,8 @@ let build { docker_context; pool; build_timeout } ~dockerfile source =
     ~timeout:build_timeout
     ~pull:false
 
-let pull { docker_context; pool = _; build_timeout = _ } ?arch tag =
-  let arch = Variant.to_docker_arch arch in
+let pull { docker_context; pool = _; build_timeout = _ } ~arch tag =
+  let arch = if Ocaml_version.arch_is_32bit arch then Some (Ocaml_version.to_docker_arch arch) else None in
   Current_docker.Raw.pull ?arch tag
     ~docker_context
 

--- a/lib/buildkit_syntax.ml
+++ b/lib/buildkit_syntax.ml
@@ -8,7 +8,7 @@ let hash_for = function
 
 let add arch =
   let hash = hash_for (match arch with
-    | None | Some `X86_64 | Some `I386 -> `X86_64
-    | Some `Aarch64 | Some `Aarch32 -> `Aarch64
-    | Some `Ppc64le -> `Ppc64le) in
+    | `X86_64 | `I386 -> `X86_64
+    | `Aarch64 | `Aarch32 -> `Aarch64
+    | `Ppc64le -> `Ppc64le) in
   Dockerfile.comment "syntax = docker/dockerfile:experimental@%s" hash

--- a/lib/buildkit_syntax.mli
+++ b/lib/buildkit_syntax.mli
@@ -1,4 +1,4 @@
-val add : Ocaml_version.arch option -> Dockerfile.t
+val add : Ocaml_version.arch -> Dockerfile.t
 (** [add arch] will activate BuildKit experimental syntax with
     a hash that will work for that architecture. Defaults to x86_64
     if no arch is specified. *)

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -226,7 +226,7 @@ module Op = struct
       | `Opam (`Build, selection, _) -> hash_packages selection.packages
       | `Opam (`Lint (`Doc|`Opam), selection, _) -> hash_packages selection.packages
       | `Opam_fmt _ -> "ocamlformat"
-      | `Duniverse -> "duniverse"
+      | `Duniverse -> "duniverse-" ^ (Variant.to_string variant)
     in
     Fmt.strf "%s/%s-%s-%a-%s"
       owner name

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -14,7 +14,7 @@ let install_ocamlformat =
 let fmt_dockerfile ~base ~ocamlformat_source ~for_user =
   let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
   let open Dockerfile in
-  (if for_user then empty else Buildkit_syntax.add None) @@
+  (if for_user then empty else Buildkit_syntax.add `X86_64) @@
   from base
   @@ run "%sopam install dune" download_cache_prefix (* Not necessarily the dune version used by the project *)
   @@ workdir "src"

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -65,11 +65,8 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
   in
   (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
   from base @@
-  (match Variant.arch variant with
-   | Some arch ->
-       if Ocaml_version.arch_is_32bit arch then
-         shell ["/usr/bin/linux32"; "/bin/sh"; "-c"] else empty
-   | None -> empty) @@
+  (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
+     shell ["/usr/bin/linux32"; "/bin/sh"; "-c"] else empty) @@
   comment "%s" (Fmt.strf "%a" Variant.pp variant) @@
   distro_extras @@
   workdir "/src" @@

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -125,6 +125,10 @@ let get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base =
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
   let+ { Query.Outcome.vars; image } = query builder ~variant ~host_image:host_base base in
+  (* It would be better to run the opam query on the platform itself, but for
+     now we run everything on x86_64 and then assume that the other
+     architectures are the same except for the arch flag. *)
+  let vars = { vars with arch = Ocaml_version.to_opam_arch arch } in
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base; vars }
 

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -4,9 +4,6 @@ open Current.Syntax
 module Raw = Current_docker.Raw
 module Worker = Ocaml_ci_api.Worker
 
-let docker_tag ~distro ~ocaml_version =
-  Printf.sprintf "%s-ocaml-%s" distro ocaml_version
-
 type t = {
   label : string;
   builder : Builder.t;
@@ -85,7 +82,12 @@ module Query = struct
       | Some (name, version) -> (name, version)
       | None -> Fmt.failwith "Unexpected opam package name: %s" ocaml_package
     in
-    let cmd = get_vars ~arch:(Variant.(arch variant |> to_opam_arch)) docker_context host_image in
+    let arch =
+      Variant.arch variant |> fun v ->
+      if Ocaml_version.arch_is_32bit v then
+        Some (Ocaml_version.to_opam_arch v) else None
+    in
+    let cmd = get_vars ~arch docker_context host_image in
     Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vars ->
     let json =
       match Yojson.Safe.from_string vars with
@@ -119,14 +121,19 @@ let query builder ~variant ~host_image image =
   QC.run Query.No_context { Query.Key.docker_context; variant } { Query.Value.image; host_image }
 
 let get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base =
-  let variant = Variant.v ~arch (docker_tag ~distro ~ocaml_version) in
+  match Variant.v ~arch ~distro ~ocaml_version with
+  | Error (`Msg m) -> Current.fail m
+  | Ok variant ->
   let+ { Query.Outcome.vars; image } = query builder ~variant ~host_image:host_base base in
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base; vars }
 
 let pull ~arch ~schedule ~builder ~distro ~ocaml_version =
-  let archl = Variant.to_opam_arch arch |> Option.value ~default:"" in
-  Current.component "pull@,%s %s %s" distro ocaml_version archl |>
+  match Variant.v ~arch ~distro ~ocaml_version with
+  | Error (`Msg m) -> Current.fail m
+  | Ok variant ->
+  let archl = Ocaml_version.to_opam_arch arch in
+  Current.component "pull@,%s %a %s" distro Ocaml_version.pp ocaml_version archl |>
   let> () = Current.return () in
-  let tag = docker_tag ~distro ~ocaml_version in
-  Builder.pull ~schedule ?arch builder @@ "ocurrent/opam:" ^ tag
+  let tag = Variant.docker_tag variant in
+  Builder.pull ~schedule ~arch builder @@ "ocurrent/opam:" ^ tag

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -13,12 +13,12 @@ val pp : t Fmt.t
 val compare : t -> t -> int
 
 val get :
-  arch:Ocaml_version.arch option ->
+  arch:Ocaml_version.arch ->
   label:string ->
   builder:Builder.t ->
   pool:string ->
   distro:string ->
-  ocaml_version:string ->
+  ocaml_version:Ocaml_version.t ->
   host_base:Current_docker.Raw.Image.t Current.t ->
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
@@ -26,10 +26,10 @@ val get :
     and returning [base] for subsequent builds. *)
 
 val pull :
-  arch:Ocaml_version.arch option ->
+  arch:Ocaml_version.arch ->
   schedule:Current_cache.Schedule.t ->
   builder:Builder.t ->
   distro:string ->
-  ocaml_version:string ->
+  ocaml_version:Ocaml_version.t ->
   Current_docker.Raw.Image.t Current.t
 (** [pull ~schedule ~builder ~distro ~ocaml_version] pulls "ocurrent/opam:{distro}-ocaml-{version}" on [schedule]. *)

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -1,16 +1,17 @@
 type t [@@deriving eq,ord,yojson]
 
-val v : arch:Ocaml_version.arch option -> string -> t
+val v : arch:Ocaml_version.arch ->
+        distro:string -> ocaml_version:Ocaml_version.t ->
+        (t, [> `Msg of string ]) result
 
-val arch : t -> Ocaml_version.arch option
+val arch : t -> Ocaml_version.arch
+val distro : t -> string
+val ocaml_version : t -> Ocaml_version.t
+val with_ocaml_version : Ocaml_version.t -> t -> t
+
 val id : t -> string
+val docker_tag : t -> string
 val pp : t Fmt.t
 
 val to_string : t -> string
 val of_string : string -> t
-
-(** [to_opam_arch t] outputs a string suitable for use in opam files as the [%{arch}%] variable *)
-val to_opam_arch : Ocaml_version.arch option -> string option
-
-(** [to_docker_arch t] outputs a string suitable for mapping to docker multiarch manifests *)
-val to_docker_arch : Ocaml_version.arch option -> string option

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -17,8 +17,9 @@ depends: [
   "ocaml-ci-solver"
   "ocluster-api"
   "conf-libev"
-  "dockerfile" {>= "6.6.0"}
-  "ocaml-version" {>= "2.4.0"}
+  "dockerfile" {>= "7.0.0"}
+  "dockerfile-opam" {>= "7.0.0"}
+  "ocaml-version" {>= "3.0.0"}
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
 ]

--- a/service/dune
+++ b/service/dune
@@ -8,6 +8,7 @@
             current_git
             current_github
             current_rpc
+            dockerfile-opam
             ocluster-api
             capnp-rpc-unix
             mirage-crypto-rng.unix

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -11,8 +11,8 @@ let platforms =
     let base = Platform.pull ~arch ~schedule ~builder ~distro ~ocaml_version in
     let host_base =
       match arch with
-      | None | Some `X86_64 -> base
-      | _ -> Platform.pull ~arch:None ~schedule ~builder ~distro ~ocaml_version
+      | `X86_64 -> base
+      | _ -> Platform.pull ~arch:`X86_64 ~schedule ~builder ~distro ~ocaml_version
     in
     Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base base
   in

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -9,11 +9,13 @@ let debian_10_vars ocaml_package ocaml_version =
     ocaml_version
   }
 
-let var = Ocaml_ci.Variant.v ~arch:None 
+let var distro ov =
+  Ocaml_ci.Variant.v ~arch:`X86_64 ~distro ~ocaml_version:(Ocaml_version.of_string_exn ov) |>
+  function Ok v -> v | Error (`Msg m) -> failwith m
 
 let v = [
-  var "debian-10-ocaml-4.10", debian_10_vars "ocaml" "4.10.0";
-  var "debian-10-ocaml-4.09", debian_10_vars "ocaml" "4.09.0";
-  var "debian-10-ocaml-4.08", debian_10_vars "ocaml" "4.08.0";
-  var "debian-10-ocaml-4.07", debian_10_vars "ocaml" "4.07.0";
+  var "debian-10" "4.10", debian_10_vars "ocaml" "4.10.0";
+  var "debian-10" "4.09", debian_10_vars "ocaml" "4.09.0";
+  var "debian-10" "4.08", debian_10_vars "ocaml" "4.08.0";
+  var "debian-10" "4.07", debian_10_vars "ocaml" "4.07.0";
 ]


### PR DESCRIPTION
This adds support for parsing compiler variants (e.g. flambda) in
the Variant module.

The arch value is now explicitly specified, so the build modules can
choose whether to introduce a personality or not in their
Dockerfiles.

The configuration now uses Ocaml_version to setup the various
architecture choices.  This just adds flambda to the set of
tested defaults, using the latest stable compiler version.