### PR TITLE
Handle 'post' dependencies

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -18,6 +18,7 @@ module Selection = struct
   type t = {
     id : string;                        (** The platform ID from the request. *)
     packages : string list;             (** The selected packages ("name.version"). *)
+    post_packages : string list;        (** To be installed last, dependencies with flag "post". *)
     commit : string;                    (** A commit in opam-repository to use. *)
   } [@@deriving yojson, ord]
 end
@@ -39,5 +40,5 @@ module Solve_response = struct
     | Error of 'b
   [@@deriving yojson]
 
-  type t = (Selection.t list, [`Msg of string]) result [@@deriving yojson]
+  type t = (Selection.t list, [`No_solution | `Msg of string]) result [@@deriving yojson]
 end

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -185,8 +185,8 @@ module Analysis = struct
                        } in
          Capnp_rpc_lwt.Capability.with_ref (job_log job) @@ fun log ->
          Ocaml_ci_api.Solver.solve solver request ~log >>= function
-         | Ok [] -> Lwt.return (Fmt.error_msg "No solution found for any supported platform")
          | Ok x -> Lwt_result.return (`Opam_build (List.map Selection.of_worker x))
+         | Error `No_solution -> Lwt.return (Fmt.error_msg "No solution found for any supported platform")
          | Error (`Msg msg) -> Lwt.return (Fmt.error_msg "Error from solver: %s" msg)
       )
       (function

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -42,6 +42,13 @@ let pin_opam_files groups =
       )
   )
 
+let install_pin_depends ~download_cache_prefix pin_depends =
+  let open Dockerfile in
+  let pin_add acc (pkg, uri) =
+    acc @@ run "%sopam pin add -yn %s %S" download_cache_prefix pkg uri
+  in
+  List.fold_left pin_add empty pin_depends
+
 (* Get the packages directly in "." *)
 let rec get_root_opam_packages = function
   | [] -> []
@@ -51,7 +58,7 @@ let rec get_root_opam_packages = function
 let download_cache = "--mount=type=cache,target=/home/opam/.opam/download-cache,uid=1000"
 
 let install_project_deps ~base ~opam_files ~selection ~for_user =
-  let { Selection.packages; post_packages; commit; variant } = selection in
+  let { Selection.packages; post_packages; commit; variant; pin_depends } = selection in
   let groups = group_opam_files opam_files in
   let root_pkgs = get_root_opam_packages groups in
   let non_root_pkgs = packages |> List.filter (fun pkg -> not (List.mem pkg root_pkgs)) in
@@ -80,6 +87,7 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
   distro_extras @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
+  install_pin_depends ~download_cache_prefix pin_depends @@
   run "cd ~/opam-repository && (git cat-file -e %s || git fetch origin master) && git reset -q --hard %s && git log --no-decorate -n1 --oneline && opam update -u" commit commit @@
   env ["DEPS", String.concat " " non_root_pkgs] @@
   env ["POST_DEPS", match post_packages with [] -> "\"\"" | p -> String.concat " " p] @@

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -63,7 +63,7 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
     else
       empty
   in
-  let post_deps =
+  let install_post_deps =
     if post_packages <> [] then
       run "%sopam install $POST_DEPS" download_cache_prefix
     else
@@ -78,12 +78,13 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
   workdir "/src" @@
   run "sudo chown opam /src" @@
   run "cd ~/opam-repository && (git cat-file -e %s || git fetch origin master) && git reset -q --hard %s && git log --no-decorate -n1 --oneline && opam update -u" commit commit @@
-  pin_opam_files groups @@
   env ["DEPS", String.concat " " non_root_pkgs] @@
   env ["POST_DEPS", String.concat " " post_packages] @@
-  run "%sopam depext --update -y %s $DEPS $POST_DEPS" download_cache_prefix (String.concat " " root_pkgs) @@
+  run "%sopam depext --update -y $DEPS $POST_DEPS" download_cache_prefix @@
   run "%sopam install $DEPS" download_cache_prefix @@
-  post_deps
+  install_post_deps @@
+  pin_opam_files groups @@
+  run "%sopam depext --update -y %s" download_cache_prefix (String.concat " " root_pkgs)
 
 let dockerfile ~base ~opam_files ~selection ~for_user =
   let open Dockerfile in

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -2,11 +2,12 @@
 type t = {
   variant : Variant.t;                (** The variant image to build on. *)
   packages : string list;             (** The selected packages ("name.version"). *)
+  post_packages : string list;        (** To be installed last, dependencies with flag "post". *)
   commit : string;                    (** A commit in opam-repository to use. *)
 } [@@deriving yojson, ord]
 
 let of_worker w =
   let module W = Ocaml_ci_api.Worker.Selection in
-  let { W.id; packages; commit } = w in
+  let { W.id; packages; post_packages; commit } = w in
   let variant = Variant.of_string id in
-  { variant; packages; commit }
+  { variant; packages; post_packages; commit }

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -4,10 +4,11 @@ type t = {
   packages : string list;             (** The selected packages ("name.version"). *)
   post_packages : string list;        (** To be installed last, dependencies with flag "post". *)
   commit : string;                    (** A commit in opam-repository to use. *)
+  pin_depends : (string * string) list; (** Pinned packages. *)
 } [@@deriving yojson, ord]
 
-let of_worker w =
+let make ~pin_depends w =
   let module W = Ocaml_ci_api.Worker.Selection in
   let { W.id; packages; post_packages; commit } = w in
   let variant = Variant.of_string id in
-  { variant; packages; post_packages; commit }
+  { variant; packages; post_packages; commit; pin_depends }

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -2,6 +2,7 @@
 type t = {
   variant : Variant.t;                (** The variant image to build on. *)
   packages : string list;             (** The selected packages ("name.version"). *)
+  post_packages : string list;        (** To be installed last, dependencies with flag "post". *)
   commit : string;                    (** A commit in opam-repository to use. *)
 } [@@deriving yojson, ord]
 

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -4,6 +4,8 @@ type t = {
   packages : string list;             (** The selected packages ("name.version"). *)
   post_packages : string list;        (** To be installed last, dependencies with flag "post". *)
   commit : string;                    (** A commit in opam-repository to use. *)
+  pin_depends : (string * string) list; (** Pinned packages. *)
 } [@@deriving yojson, ord]
 
-val of_worker : Ocaml_ci_api.Worker.Selection.t -> t
+val make :
+  pin_depends:(string * string) list -> Ocaml_ci_api.Worker.Selection.t -> t

--- a/solver/solver.mli
+++ b/solver/solver.mli
@@ -1,3 +1,18 @@
+module Response : sig
+  type ('a, 'b) result = ('a, 'b) Stdlib.result =
+    | Ok of 'a
+    | Error of 'b
+  [@@deriving yojson]
+
+  type selection = {
+    packages : string list;
+    post_packages : string list;
+  }
+  [@@deriving yojson]
+
+  type t = (selection, [`Solve of string]) result [@@deriving yojson]
+end
+
 val main : Git_unix.Store.Hash.t -> unit
 (** [main hash] runs a worker process that reads requests from stdin and writes results to stdout,
     using commit [hash] in opam-repository. *)


### PR DESCRIPTION
Post dependencies must be installed after other dependencies and are often used to break dependency cycles.

This patch only detects 'post' dependencies that are directly required by the root packages.
Installing the released version of current package is now allowed.

Because of this, the pinning of root packages must be done after installing dependencies.
We must now handle pin-depends from root packages explicitly (it was done implicitly by `opam`).

This is very adhoc but it seems to be working as expected.
