### PR TITLE
Improve build log output

### DIFF
--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -268,7 +268,7 @@ module Op = struct
       @@ with_commit_lock ~job commit variant
       @@ submit ~job ~pool ~action ~cache_hint ~src t in
     Current.Job.start_with ~pool:build_pool job ?timeout:t.timeout ~level:Current.Level.Average >>= fun build_job ->
-    Current.Job.write job (Fmt.strf "Using BuildKit Dockerfile:@.%s@." dockerfile);
+    Current.Job.write job (Fmt.strf "@.Using BuildKit Dockerfile:@.%s@.@." dockerfile);
     Capability.with_ref build_job @@ fun build_job ->
     let on_cancel _ =
       Cluster_api.Job.cancel build_job >|= function

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -71,7 +71,7 @@ let install_project_deps ~base ~opam_files ~selection ~for_user =
   distro_extras @@
   workdir "/src" @@
   run "sudo chown opam /src" @@
-  run "cd ~/opam-repository && (git reset --hard %s || (git fetch origin master && git reset --hard %s)) && opam update -u" commit commit @@
+  run "cd ~/opam-repository && (git cat-file -e %s || git fetch origin master) && git reset -q --hard %s && git log --no-decorate -n1 --oneline && opam update -u" commit commit @@
   pin_opam_files groups @@
   env ["DEPS", String.concat " " non_root_pkgs] @@
   run "%sopam depext --update -y %s $DEPS" download_cache_prefix (String.concat " " root_pkgs) @@


### PR DESCRIPTION
- Avoid "fatal: Could not parse object" and "Checking out files" messages from `git reset`.
- Log blank lines around the Dockerfile display.

Fixes #239.