### PR TITLE
lint-doc: copy project source into container before building docs

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -29,7 +29,8 @@ let doc_dockerfile ~base ~opam_files ~selection ~for_user =
   let open Dockerfile in
   Opam_build.install_project_deps ~base ~opam_files ~selection ~for_user
   (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
-  @@ run "%sopam depext -i dune odoc>=1.5.0" download_cache_prefix
+  @@ run "%sopam depext -i dune 'odoc>=1.5.0'" download_cache_prefix
+  @@ copy ~chown:"opam" ~src:["."] ~dst:"/src/" ()
   @@ run "ODOC_WARN_ERROR=true opam exec -- dune build @doc \
           || (echo \"dune build @doc failed\"; exit 2)"
 


### PR DESCRIPTION
Fix https://github.com/ocurrent/ocaml-ci/issues/250. The implementation of `Lint.doc_dockerfile` is now almost identical to that of [`Opam_build.dockerfile`](https://github.com/ocurrent/ocaml-ci/blob/655edd03d94c44874bf1561efe8429ab1d2dab53/lib/opam_build.ml#L80), as it should be.

Also fixes an escaping issue in the use of "odoc>=1.5.0" which was causing the creation of a file named "=1.5.0" inside the lint container.