### PR TITLE
Generate Dockerfiles from OBuilder specs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard c332c82dc33e39c4d23fd4c8179d953ac2fddcc6 && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 6be4f42a8ad6d8d8bfcd0a368c590e425a4b21c4 && opam update
 COPY --chown=opam \
 	ocurrent/current_ansi.opam \
 	ocurrent/current_docker.opam \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 FROM ocurrent/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard c332c82dc33e39c4d23fd4c8179d953ac2fddcc6 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard 6be4f42a8ad6d8d8bfcd0a368c590e425a4b21c4 && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	ocurrent/current_ansi.opam \

--- a/dune-project
+++ b/dune-project
@@ -33,6 +33,7 @@
   ocaml-ci-api
   ocaml-ci-solver
   ocluster-api
+  obuilder-spec
   conf-libev
   (dockerfile (>= 7.0.0))
   (dockerfile-opam (>= 7.0.0))

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -77,14 +77,19 @@ module Op = struct
 
   let run { Builder.docker_context; pool; build_timeout } job
       { Key.commit; label = _; repo } { Value.base; variant; ty } =
-    let make_dockerfile =
+    let build_spec =
       let base = Raw.Image.hash base in
       match ty with
-      | `Opam (`Build, selection, opam_files) -> Opam_build.dockerfile ~base ~opam_files ~selection
-      | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_dockerfile ~base ~opam_files ~selection
-      | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_dockerfile ~base ~opam_files
-      | `Opam_fmt ocamlformat_source -> Lint.fmt_dockerfile ~base ~ocamlformat_source
-      | `Duniverse -> Duniverse_build.dockerfile ~base ~repo ~variant
+      | `Opam (`Build, selection, opam_files) -> Opam_build.spec ~base ~opam_files ~selection
+      | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
+      | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
+      | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
+      | `Duniverse -> Duniverse_build.spec ~base ~repo ~variant
+    in
+    let make_dockerfile ~for_user =
+      let open Dockerfile in
+      (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
+      Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:(not for_user) build_spec
     in
     Current.Job.write job
       (Fmt.strf "@[<v>Base: %a@,%a@]@."

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
   (libraries logs current current_docker current_github current.term ocaml-ci-api str capnp-rpc-unix
              current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version opam-0install
-             ocluster-api))
+             ocluster-api obuilder-spec))

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -10,36 +10,35 @@ let build_cache repo =
   let { Current_github.Repo_id.owner; name } = repo in
   check_safe owner;
   check_safe name;
-  Printf.sprintf
-    "--mount=type=cache,target=/src/_build,uid=1000,sharing=private,id=dune:%s:%s"
-    owner name
-
-let download_cache = "--mount=type=cache,target=/home/opam/.opam/download-cache,uid=1000"
+  let name = Printf.sprintf "dune:%s:%s" owner name in
+  Obuilder_spec.Cache.v name ~target:"/src/_build" ~buildkit_options:["sharing", "private"]
 
 let install_opam_tools =
   let opam_tools_hash = "6c56ab9fedd7b3f6c143cb606a0ea6fe6a384013" in
-  let open Dockerfile in
-     run "opam pin add -n https://github.com/avsm/opam-tools.git#%s" opam_tools_hash
-  @@ run "opam depext -iy opam-tools"
+  let open Obuilder_spec in
+  [
+    run "opam pin add -n https://github.com/avsm/opam-tools.git#%s" opam_tools_hash;
+    run "opam depext -iy opam-tools"
+  ]
 
-let dockerfile ~base ~repo ~variant ~for_user =
-  let caches =
-    if for_user then ""
-    else Printf.sprintf "%s %s" download_cache (build_cache repo)
-  in
-  let open Dockerfile in
-  (if for_user then empty else Buildkit_syntax.add (Variant.arch variant)) @@
-  from base @@
-  comment "%s" (Variant.to_string variant) @@
-  install_opam_tools @@
-  workdir "/src" @@
-  run "sudo chown opam /src" @@
-  copy ~chown:"opam" ~src:["*.opam"] ~dst:"/src/" () @@
-  run "opam tools --no-install --compiler `opam exec -- ocamlc -version` -vv" @@
-  copy ~chown:"opam" ~src:["dune-get"] ~dst:"/src/" () @@
-  (* TODO make duniverse depext install the package as opam-depext does *)
-  run "sudo apt-get update && sudo apt-get -y install build-essential `opam exec -- duniverse depext`" @@
-  run "opam exec -- duniverse pull" @@
-  copy ~chown:"opam" ~src:["."] ~dst:"/src/" () @@
-  run "%s opam exec -- dune build @install" caches @@
-  run "%s opam exec -- dune runtest" caches
+let spec ~base ~repo ~variant =
+  let cache = [
+    Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache";
+    build_cache repo
+  ] in
+  let open Obuilder_spec in
+  stage ~from:base @@ [
+    comment "%s" (Variant.to_string variant);
+    user ~uid:1000 ~gid:1000
+  ] @ install_opam_tools @ [
+    workdir "/src";
+    copy ["*.opam"] ~dst:"/src/";
+    run "opam tools --no-install --compiler `opam exec -- ocamlc -version` -vv";
+    copy ["dune-get"] ~dst:"/src/";
+    (* TODO make duniverse depext install the package as opam-depext does *)
+    run "sudo apt-get update && sudo apt-get -y install build-essential `opam exec -- duniverse depext`";
+    run "opam exec -- duniverse pull";
+    copy ["."] ~dst:"/src/";
+    run ~cache "opam exec -- dune build @install";
+    run ~cache "opam exec -- dune runtest";
+  ]

--- a/lib/duniverse_build.mli
+++ b/lib/duniverse_build.mli
@@ -1,1 +1,1 @@
-val dockerfile : base:string -> repo:Current_github.Repo_id.t -> variant:Variant.t -> for_user:bool -> Dockerfile.t
+val spec : base:string -> repo:Current_github.Repo_id.t -> variant:Variant.t -> Obuilder_spec.stage

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -1,42 +1,50 @@
 let install_ocamlformat =
-  let open Dockerfile in
+  let open Obuilder_spec in
   function
   | Analyse_ocamlformat.Vendored { path } ->
     let opam_file = Filename.concat path "ocamlformat.opam" in
-    copy ~chown:"opam" ~src:[ opam_file ] ~dst:opam_file ()
-    @@ run "opam pin add -k path -n ocamlformat %S" path
-    (* Pinned to a directory containing only the .opam file *)
-    @@ run "opam depext ocamlformat"
-    @@ run "opam install --deps-only -y ocamlformat"
+    [
+      copy [ opam_file ] ~dst:opam_file;
+      run "opam pin add -k path -n ocamlformat %S" path;
+      (* Pinned to a directory containing only the .opam file *)
+      run "opam depext ocamlformat";
+      run "opam install --deps-only -y ocamlformat";
+    ]
   | Opam { version } ->
-    run "opam depext -it ocamlformat=%s" version
+    [ run "opam depext -it ocamlformat=%s" version ]
 
-let fmt_dockerfile ~base ~ocamlformat_source ~for_user =
-  let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
-  let open Dockerfile in
-  (if for_user then empty else Buildkit_syntax.add `X86_64) @@
-  from base
-  @@ run "%sopam install dune" download_cache_prefix (* Not necessarily the dune version used by the project *)
-  @@ workdir "src"
-  @@ (match ocamlformat_source with
+let fmt_spec ~base ~ocamlformat_source =
+  let open Obuilder_spec in
+  let cache = [ Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" ] in
+  stage ~from:base @@ [
+    user ~uid:1000 ~gid:1000;
+    run ~cache "opam install dune";  (* Not necessarily the dune version used by the project *)
+    workdir "src";
+  ] @ (match ocamlformat_source with
       | Some src -> install_ocamlformat src
-      | None -> empty)
-  @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
-  @@ run "opam exec -- dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)"
+      | None -> []) @ [
+    copy ["./"] ~dst:"./";
+    run "opam exec -- dune build @fmt || (echo \"dune build @fmt failed\"; exit 2)";
+  ]
 
-let doc_dockerfile ~base ~opam_files ~selection ~for_user =
-  let download_cache_prefix = if for_user then "" else Opam_build.download_cache ^ " " in
-  let open Dockerfile in
-  Opam_build.install_project_deps ~base ~opam_files ~selection ~for_user
-  (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
-  @@ run "%sopam depext -i dune 'odoc>=1.5.0'" download_cache_prefix
-  @@ copy ~chown:"opam" ~src:["."] ~dst:"/src/" ()
-  @@ run "ODOC_WARN_ERROR=true opam exec -- dune build @doc \
-          || (echo \"dune build @doc failed\"; exit 2)"
+let doc_spec ~base ~opam_files ~selection =
+  let cache = [ Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" ] in
+  let open Obuilder_spec in
+  stage ~from:base @@
+    user ~uid:1000 ~gid:1000 ::
+    Opam_build.install_project_deps ~opam_files ~selection @ [
+      (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
+      run ~cache "opam depext -i dune 'odoc>=1.5.0'";
+      copy ["."] ~dst:"/src/";
+      run "ODOC_WARN_ERROR=true opam exec -- dune build @doc \
+           || (echo \"dune build @doc failed\"; exit 2)";
+    ]
 
-let opam_lint_dockerfile ~base ~opam_files ~for_user:_ =
-  let open Dockerfile in
-  from base
-  @@ workdir "src"
-  @@ copy ~chown:"opam" ~src:["./"] ~dst:"./" ()
-  @@ run "opam lint %s" (String.concat " " opam_files)
+let opam_lint_spec ~base ~opam_files =
+  let open Obuilder_spec in
+  stage ~from:base [
+    user ~uid:1000 ~gid:1000;
+    workdir "src";
+    copy ["./"] ~dst:"./";
+    run "opam lint %s" (String.concat " " opam_files);
+  ]

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,20 +1,17 @@
-val fmt_dockerfile :
+val fmt_spec :
   base:string ->
   ocamlformat_source:Analyse_ocamlformat.source option ->
-  for_user:bool ->
-  Dockerfile.t
-(** A Dockerfile that checks the formatting. *)
+  Obuilder_spec.stage
+(** A build spec that checks the formatting. *)
 
-val doc_dockerfile :
+val doc_spec :
   base:string ->
   opam_files:string list ->
   selection:Selection.t ->
-  for_user:bool ->
-  Dockerfile.t
-(** A Dockerfile that checks that the documentation in [./src/] builds without warnings. *)
+  Obuilder_spec.stage
+(** A build spec that checks that the documentation in [./src/] builds without warnings. *)
 
-val opam_lint_dockerfile :
+val opam_lint_spec :
   base:string ->
   opam_files:string list ->
-  for_user:bool ->
-  Dockerfile.t
+  Obuilder_spec.stage

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,14 +1,12 @@
 val download_cache : string
 
 val install_project_deps :
-  base:string ->
   opam_files:string list ->
   selection:Selection.t ->
-  for_user:bool ->
-  Dockerfile.t
+  Obuilder_spec.op list
 
-val dockerfile :
+val spec :
   base:string ->
   opam_files:string list ->
   selection:Selection.t ->
-  for_user:bool -> Dockerfile.t
+  Obuilder_spec.stage

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -16,6 +16,7 @@ depends: [
   "ocaml-ci-api"
   "ocaml-ci-solver"
   "ocluster-api"
+  "obuilder-spec"
   "conf-libev"
   "dockerfile" {>= "7.0.0"}
   "dockerfile-opam" {>= "7.0.0"}
@@ -41,3 +42,6 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
+pin-depends: [
+  ["obuilder-spec.dev" "git+https://github.com/ocurrent/obuilder.git#a43d2132312e46f0b0aa1f9d0da24b9f1e5574e2"]
+]

--- a/ocaml-ci-service.opam.template
+++ b/ocaml-ci-service.opam.template
@@ -1,0 +1,3 @@
+pin-depends: [
+  ["obuilder-spec.dev" "git+https://github.com/ocurrent/obuilder.git#a43d2132312e46f0b0aa1f9d0da24b9f1e5574e2"]
+]


### PR DESCRIPTION
Instead of generating Dockerfiles directly, generate OBuilder specs and then convert them to Dockerfiles.

This lets us test that the conversion works, before enabling OBuilder builds on the main cluster.