### PR TITLE
Use Filename.quote to escape filenames

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -25,7 +25,11 @@ let group_opam_files =
    image, creating the necessary directories first, and then pin them all. *)
 let pin_opam_files groups =
   let open Obuilder_spec in
-  let dirs = groups |> List.map (fun (dir, _, _) -> Printf.sprintf "%S" (Fpath.to_string dir)) |> String.concat " " in
+  let dirs =
+    groups
+    |> List.map (fun (dir, _, _) -> Filename.quote (Fpath.to_string dir))
+    |> String.concat " "
+  in
   run "mkdir -p %s" dirs :: (
     groups |> List.map (fun (dir, files, _) ->
         copy files ~dst:(Fpath.to_string dir)
@@ -34,10 +38,10 @@ let pin_opam_files groups =
     groups |> List.concat_map (fun (dir, _, pkgs) ->
         pkgs
         |> List.map (fun pkg ->
-            Printf.sprintf "opam pin add -yn %s %S" pkg (Fpath.to_string dir)
+            Printf.sprintf "opam pin add -yn %s %s" pkg (Filename.quote (Fpath.to_string dir))
           )
       )
-    |> String.concat " && \\\n  "
+    |> String.concat " && \n"
     |> run "%s"
   ]
 

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -43,5 +43,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 pin-depends: [
-  ["obuilder-spec.dev" "git+https://github.com/ocurrent/obuilder.git#a43d2132312e46f0b0aa1f9d0da24b9f1e5574e2"]
+  ["obuilder-spec.dev" "git+https://github.com/ocurrent/obuilder.git#4d579495f34d258d5623a32025614d7cb3e3c3a8"]
 ]

--- a/ocaml-ci-service.opam.template
+++ b/ocaml-ci-service.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["obuilder-spec.dev" "git+https://github.com/ocurrent/obuilder.git#a43d2132312e46f0b0aa1f9d0da24b9f1e5574e2"]
+  ["obuilder-spec.dev" "git+https://github.com/ocurrent/obuilder.git#4d579495f34d258d5623a32025614d7cb3e3c3a8"]
 ]


### PR DESCRIPTION
This is more correct, and the use of `'` instead of `"` also results in prettier output in the OBuilder spec.

Also, don't insert the Dockerfile continuation character (`\) in multi-line shell commands. That's now done by the Dockerfile conversion.