### PR TITLE
Add network and cache access to duniverse builds

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -84,7 +84,7 @@ module Op = struct
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
-      | `Duniverse -> Duniverse_build.spec ~base ~repo ~variant
+      | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
     in
     let make_dockerfile ~for_user =
       let open Dockerfile in
@@ -156,7 +156,7 @@ let v ~platforms ~repo ~spec source =
   let result =
     state |> Result.map @@ fun () ->
     match spec.ty with
-    | `Duniverse
+    | `Duniverse _
     | `Opam (`Build, _, _) -> `Built
     | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -183,7 +183,7 @@ module Op = struct
       | `Opam (`Build, selection, _) -> hash_packages selection.packages
       | `Opam (`Lint (`Doc|`Opam), selection, _) -> hash_packages selection.packages
       | `Opam_fmt _ -> "ocamlformat"
-      | `Duniverse -> "duniverse-" ^ (Variant.to_string variant)
+      | `Duniverse _ -> "duniverse-" ^ (Variant.to_string variant)
     in
     Fmt.strf "%s/%s-%s-%a-%s"
       owner name
@@ -199,7 +199,7 @@ module Op = struct
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
-      | `Duniverse -> Duniverse_build.spec ~base ~repo ~variant
+      | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
     in
     Current.Job.write job
       (Fmt.strf "@[<v>Base: %a@,%a@]@."
@@ -282,7 +282,7 @@ let v t ~platforms ~repo ~spec source =
   let result =
     state |> Result.map @@ fun () ->
     match spec.ty with
-    | `Duniverse
+    | `Duniverse _
     | `Opam (`Build, _, _) -> `Built
     | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -31,6 +31,7 @@ let spec ~base ~repo ~opam_files ~variant =
     user ~uid:1000 ~gid:1000
   ] @ install_opam_tools ~network ~cache:[download_cache] @ [
     workdir "/src";
+    run "sudo chown opam /src";
     copy opam_files ~dst:"/src/";
     run ~network ~cache:[download_cache] "opam tools --no-install --compiler `opam exec -- ocamlc -version` -vv";
     copy ["dune-get"] ~dst:"/src/";

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -21,7 +21,7 @@ let install_opam_tools ~network ~cache =
     run ~network ~cache "opam depext -iy opam-tools"
   ]
 
-let spec ~base ~repo ~variant =
+let spec ~base ~repo ~opam_files ~variant =
   let download_cache = Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" in
   let network = ["host"] in
   let dune_cache = build_cache repo in
@@ -31,7 +31,7 @@ let spec ~base ~repo ~variant =
     user ~uid:1000 ~gid:1000
   ] @ install_opam_tools ~network ~cache:[download_cache] @ [
     workdir "/src";
-    copy ["*.opam"] ~dst:"/src/";
+    copy opam_files ~dst:"/src/";
     run ~network ~cache:[download_cache] "opam tools --no-install --compiler `opam exec -- ocamlc -version` -vv";
     copy ["dune-get"] ~dst:"/src/";
     (* TODO make duniverse depext install the package as opam-depext does *)

--- a/lib/duniverse_build.ml
+++ b/lib/duniverse_build.ml
@@ -13,32 +13,31 @@ let build_cache repo =
   let name = Printf.sprintf "dune:%s:%s" owner name in
   Obuilder_spec.Cache.v name ~target:"/src/_build" ~buildkit_options:["sharing", "private"]
 
-let install_opam_tools =
+let install_opam_tools ~network ~cache =
   let opam_tools_hash = "6c56ab9fedd7b3f6c143cb606a0ea6fe6a384013" in
   let open Obuilder_spec in
   [
-    run "opam pin add -n https://github.com/avsm/opam-tools.git#%s" opam_tools_hash;
-    run "opam depext -iy opam-tools"
+    run ~network ~cache "opam pin add -n https://github.com/avsm/opam-tools.git#%s" opam_tools_hash;
+    run ~network ~cache "opam depext -iy opam-tools"
   ]
 
 let spec ~base ~repo ~variant =
-  let cache = [
-    Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache";
-    build_cache repo
-  ] in
+  let download_cache = Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" in
+  let network = ["host"] in
+  let dune_cache = build_cache repo in
   let open Obuilder_spec in
   stage ~from:base @@ [
     comment "%s" (Variant.to_string variant);
     user ~uid:1000 ~gid:1000
-  ] @ install_opam_tools @ [
+  ] @ install_opam_tools ~network ~cache:[download_cache] @ [
     workdir "/src";
     copy ["*.opam"] ~dst:"/src/";
-    run "opam tools --no-install --compiler `opam exec -- ocamlc -version` -vv";
+    run ~network ~cache:[download_cache] "opam tools --no-install --compiler `opam exec -- ocamlc -version` -vv";
     copy ["dune-get"] ~dst:"/src/";
     (* TODO make duniverse depext install the package as opam-depext does *)
-    run "sudo apt-get update && sudo apt-get -y install build-essential `opam exec -- duniverse depext`";
-    run "opam exec -- duniverse pull";
+    run ~network ~cache:[download_cache] "sudo apt-get update && sudo apt-get -y install build-essential `opam exec -- duniverse depext`";
+    run ~network ~cache:[download_cache] "opam exec -- duniverse pull";
     copy ["."] ~dst:"/src/";
-    run ~cache "opam exec -- dune build @install";
-    run ~cache "opam exec -- dune runtest";
+    run ~cache:[dune_cache] "opam exec -- dune build @install";
+    run ~cache:[dune_cache] "opam exec -- dune runtest";
   ]

--- a/lib/duniverse_build.mli
+++ b/lib/duniverse_build.mli
@@ -1,1 +1,6 @@
-val spec : base:string -> repo:Current_github.Repo_id.t -> variant:Variant.t -> Obuilder_spec.stage
+val spec :
+  base:string ->
+  repo:Current_github.Repo_id.t ->
+  opam_files:string list ->
+  variant:Variant.t ->
+  Obuilder_spec.stage

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -3,7 +3,7 @@ type opam_files = string list [@@deriving to_yojson, ord]
 type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * opam_files
   | `Opam_fmt of Analyse_ocamlformat.source option
-  | `Duniverse
+  | `Duniverse of opam_files
 ] [@@deriving to_yojson, ord]
 
 type t = {
@@ -21,8 +21,8 @@ let opam ~label ~selection ~analysis op =
   in
   { label; variant; ty }
 
-let duniverse ~label ~variant =
-  { label; variant; ty = `Duniverse }
+let duniverse ~label ~variant ~opam_files =
+  { label; variant; ty = `Duniverse opam_files }
 
 let pp f t = Fmt.string f t.label
 
@@ -34,4 +34,4 @@ let pp_summary f = function
   | `Opam (`Lint `Opam, _, _) -> Fmt.string f "Opam files lint"
   | `Opam_fmt v -> Fmt.pf f "ocamlformat version: %a"
                      Fmt.(option ~none:(unit "none") Analyse_ocamlformat.pp_source) v
-  | `Duniverse -> Fmt.string f "Duniverse build"
+  | `Duniverse _ -> Fmt.string f "Duniverse build"

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -1,7 +1,7 @@
 type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * string list
   | `Opam_fmt of Analyse_ocamlformat.source option
-  | `Duniverse
+  | `Duniverse of string list
 ] [@@deriving to_yojson, ord]
 
 type t = {
@@ -17,7 +17,7 @@ val opam :
   [ `Build | `Lint of [ `Doc | `Fmt | `Opam ] ] ->
   t
 
-val duniverse : label:string -> variant:Variant.t -> t
+val duniverse : label:string -> variant:Variant.t -> opam_files:string list -> t
 
 val pp : t Fmt.t
 val compare : t -> t -> int

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -85,7 +85,10 @@ let build_with_docker ?ocluster ~repo ~analysis source =
       | `Duniverse variants ->
         variants
         |> List.rev_map (fun variant ->
-            Spec.duniverse ~label:(Variant.to_string variant) ~variant
+            let opam_files = Analyse.Analysis.opam_files analysis
+                             |> List.filter (fun x -> not (String.contains x '/'))
+            in
+            Spec.duniverse ~label:(Variant.to_string variant) ~opam_files ~variant
           )
       | `Opam_build selections ->
         let lint_selection = List.hd selections in


### PR DESCRIPTION
Was failing because it didn't have network access. Also moved download cache to commands that download things.

Also, fix some other problems resulting from the move to OBuilder: don't use globs in copy and ensure `/src` has correct owner.