### PR TITLE
Update OCluster for simpler cluster build code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY --chown=opam \
 	/src/ocurrent/
 COPY --chown=opam \
 	ocluster/ocluster-api.opam \
+	ocluster/current_ocluster.opam \
 	/src/ocluster/
 COPY --chown=opam \
 	ocluster/obuilder/obuilder-spec.opam \
@@ -29,6 +30,7 @@ RUN opam pin add -yn current_ansi.dev "./ocurrent" && \
     opam pin add -yn current_slack.dev "./ocurrent" && \
     opam pin add -yn current_web.dev "./ocurrent" && \
     opam pin add -yn obuilder-spec.dev "./ocluster/obuilder" && \
+    opam pin add -yn current_ocluster.dev "./ocluster" && \
     opam pin add -yn ocluster-api.dev "./ocluster"
 COPY --chown=opam ocaml-ci-service.opam ocaml-ci-api.opam ocaml-ci-solver.opam /src/
 RUN opam install -y --deps-only .

--- a/dune-project
+++ b/dune-project
@@ -29,6 +29,7 @@
   current_docker
   current_web
   current_rpc
+  current_ocluster
   (capnp-rpc-unix (>= 0.7.0))
   ocaml-ci-api
   ocaml-ci-solver

--- a/lib/dune
+++ b/lib/dune
@@ -3,4 +3,4 @@
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
   (libraries logs current current_docker current_github current.term ocaml-ci-api str capnp-rpc-unix
              current.cache dockerfile ppx_deriving_yojson.runtime ocaml-version opam-0install
-             ocluster-api obuilder-spec))
+             current_ocluster ocluster-api obuilder-spec))

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -12,6 +12,7 @@ depends: [
   "current_docker"
   "current_web"
   "current_rpc"
+  "current_ocluster"
   "capnp-rpc-unix" {>= "0.7.0"}
   "ocaml-ci-api"
   "ocaml-ci-solver"


### PR DESCRIPTION
This moves much of the cluster logic to OCluster, allowing it to be shared with e.g. opam-repo-ci.