### PR TITLE
Fix lint-fmt when latest available version is below the latest natively supported version of dune

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -21,6 +21,7 @@ let fmt_spec ~base ~ocamlformat_source =
   let network = ["host"] in
   stage ~from:base @@ [
     user ~uid:1000 ~gid:1000;
+    run ~network ~cache "opam depext dune";
     run ~network ~cache "opam install dune";  (* Not necessarily the dune version used by the project *)
     workdir "src";
   ] @ (match ocamlformat_source with

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -21,8 +21,8 @@ let fmt_spec ~base ~ocamlformat_source =
   let network = ["host"] in
   stage ~from:base @@ [
     user ~uid:1000 ~gid:1000;
-    run ~network "opam depext dune";  (* Necessary in case current compiler < 4.08 *)
-    run ~network ~cache "opam install dune";  (* Not necessarily the dune version used by the project *)
+    run ~network ~cache "opam depext -i dune";  (* Necessary in case current compiler < 4.08 *)
+                                                (* Not necessarily the dune version used by the project *)
     workdir "src";
   ] @ (match ocamlformat_source with
       | Some src -> install_ocamlformat src

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -9,7 +9,7 @@ let install_ocamlformat =
       copy [ opam_file ] ~dst:opam_file;
       run "opam pin add -k path -n ocamlformat %S" path;
       (* Pinned to a directory containing only the .opam file *)
-      run ~network ~cache "opam depext ocamlformat";
+      run ~network "opam depext ocamlformat";
       run ~network ~cache "opam install --deps-only -y ocamlformat";
     ]
   | Opam { version } ->
@@ -21,7 +21,7 @@ let fmt_spec ~base ~ocamlformat_source =
   let network = ["host"] in
   stage ~from:base @@ [
     user ~uid:1000 ~gid:1000;
-    run ~network ~cache "opam depext dune";
+    run ~network "opam depext dune";  (* Necessary in case current compiler < 4.08 *)
     run ~network ~cache "opam install dune";  (* Not necessarily the dune version used by the project *)
     workdir "src";
   ] @ (match ocamlformat_source with


### PR DESCRIPTION
Fix issue discovered here: https://ci.ocamllabs.io/github/ocaml-ppx/ppx/commit/40e5a35a4386d969effaf428078c900bd03b78ec/variant/(lint-fmt)

```
/: (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
    (network host) (shell "opam install dune"))
[NOTE] It seems you have not updated your repositories for a while. Consider updating them with:
       opam update

The following actions will be performed:
  - install conf-m4                  1        [required by ocamlfind]
  - install ocaml-secondary-compiler 4.08.1-1 [required by ocamlfind-secondary]
  - install ocamlfind                1.8.1    [required by ocamlfind-secondary]
  - install ocamlfind-secondary      1.8.1    [required by dune]
  - install dune                     2.7.1
===== 5 to install =====

<><> Gathering sources ><><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[dune.2.7.1] found in cache
[ocaml-secondary-compiler.4.08.1-1] found in cache
[ocamlfind.1.8.1] found in cache
[ocamlfind-secondary.1.8.1] found in cache

<><> Processing actions <><><><><><><><><><><><><><><><><><><><><><><><><><><><>
[ERROR] The compilation of conf-m4 failed at "/bin/sh -exc echo | m4".
-> installed ocaml-secondary-compiler.4.08.1-1

#=== ERROR while compiling conf-m4.1 ==========================================#
# context              2.0.7 | linux/x86_64 | ocaml-base-compiler.4.07.1 | file:///home/opam/opam-repository
# path                 ~/.opam/4.07/.opam-switch/build/conf-m4.1
# command              /bin/sh -exc echo | m4
# exit-code            127
# env-file             ~/.opam/log/conf-m4-1-335865.env
# output-file          ~/.opam/log/conf-m4-1-335865.out
### output ###
# + echo
# + m4
# /bin/sh: 1: m4: not found
```

If a package is not compatible with the oldest version dune is natively compatible with, the installation of dune will fail due to the lack of m4 for ocamlfind.

Aside from that, the second commit also disable the cache when `opam depext <pkg>` is called.