### PR TITLE
Add ocaml-gospel to authorized users

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -12,7 +12,7 @@ secrets:
 services:
   ci:
     image: ocurrent/ocaml-ci-service:live
-    command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-allowlist "talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,vocal-project,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci.ocamllabs.io:8102 --github-oauth /run/secrets/ocaml-ci-oauth --submission-service /run/secrets/ocaml-ci-submission.cap
+    command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-allowlist "talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci.ocamllabs.io:8102 --github-oauth /run/secrets/ocaml-ci-oauth --submission-service /run/secrets/ocaml-ci-submission.cap
     environment:
       - "CI_PROFILE=production"
       - "DOCKER_BUILDKIT=1"


### PR DESCRIPTION
The `vocal-project` org is being replaced by `ocaml-gospel` for Gospel related projects.