### PR TITLE
opam monorepo 0.1.0 support

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -2,12 +2,12 @@ module Analysis : sig
   type t [@@deriving yojson]
 
   val opam_files : t -> string list
-  val is_duniverse : t -> bool
   val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
   val selections : t -> [
       | `Opam_build of Selection.t list
       | `Duniverse of Variant.t list
+      | `Opam_monorepo of Opam_monorepo.selection
     ]
 
   val of_dir :

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -85,6 +85,7 @@ module Op = struct
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
       | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
+      | `Opam_monorepo spec -> Opam_monorepo.spec ~base ~repo ~spec ~variant
     in
     let make_dockerfile ~for_user =
       let open Dockerfile in
@@ -157,6 +158,7 @@ let v ~platforms ~repo ~spec source =
     state |> Result.map @@ fun () ->
     match spec.ty with
     | `Duniverse _
+    | `Opam_monorepo _
     | `Opam (`Build, _, _) -> `Built
     | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -68,6 +68,7 @@ module Op = struct
       | `Opam (`Lint (`Doc|`Opam), selection, _) -> hash_packages selection.packages
       | `Opam_fmt _ -> "ocamlformat"
       | `Duniverse _ -> "duniverse-" ^ (Variant.to_string variant)
+      | `Opam_monorepo _ -> "opam-monorepo-" ^ (Variant.to_string variant)
     in
     Fmt.strf "%s/%s-%s-%a-%s"
       owner name
@@ -84,6 +85,7 @@ module Op = struct
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
       | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
+      | `Opam_monorepo spec -> Opam_monorepo.spec ~base ~repo ~spec ~variant
     in
     Current.Job.write job
       (Fmt.strf "@[<v>Base: %a@,%a@]@."
@@ -155,6 +157,7 @@ let v t ~platforms ~repo ~spec source =
     state |> Result.map @@ fun () ->
     match spec.ty with
     | `Duniverse _
+    | `Opam_monorepo _
     | `Opam (`Build, _, _) -> `Built
     | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
     | `Opam_fmt _ -> `Checked

--- a/lib/duniverse_build.mli
+++ b/lib/duniverse_build.mli
@@ -4,3 +4,5 @@ val spec :
   opam_files:string list ->
   variant:Variant.t ->
   Obuilder_spec.stage
+
+val build_cache : Current_github.Repo_id.t -> Obuilder_spec.Cache.t

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -1,0 +1,148 @@
+type info = string * OpamFile.OPAM.t
+
+type config = {
+  package : string;
+  dune_version : string;
+  monorepo_version : string;
+}
+[@@deriving yojson, ord]
+
+type selection = Variant.t * config [@@deriving yojson]
+
+let only_lockfile_in ~dir =
+  let opam_locked = ".opam.locked" in
+  let lock_files =
+    Sys.readdir (Fpath.to_string dir)
+    |> Array.to_list
+    |> List.filter (Astring.String.is_suffix ~affix:opam_locked)
+  in
+  match lock_files with
+  | [ lock_file ] ->
+      let last = String.length lock_file - String.length opam_locked - 1 in
+      let base = Astring.String.with_index_range ~last lock_file in
+      Some (base, lock_file)
+  | _ -> None
+
+let guard = function true -> Some () | false -> None
+
+let file_exists_in ~dir ~name =
+  let path = Filename.concat (Fpath.to_string dir) name in
+  Sys.file_exists path
+
+let x_opam_monorepo_version opam =
+  try
+    OpamFile.OPAM.extended opam "x-opam-monorepo-version" (function
+      | String (_, s) -> s
+      | _ -> assert false)
+  with Invalid_argument _ -> None
+
+let detect ~dir =
+  let ( let* ) = Option.bind in
+  let* package, lock_file_path = only_lockfile_in ~dir in
+  let opam_file_path = package ^ ".opam" in
+  let* () = guard (file_exists_in ~dir ~name:opam_file_path) in
+  let* () = guard (file_exists_in ~dir ~name:"dune-project") in
+  let full_path = Filename.concat (Fpath.to_string dir) lock_file_path in
+  let lock_file_contents =
+    OpamFile.OPAM.read (OpamFile.make (OpamFilename.of_string full_path))
+  in
+  let* _ = x_opam_monorepo_version lock_file_contents in
+  Some (package, lock_file_contents)
+
+let packages_in_depends f =
+  let get_atom = function OpamFormula.Atom a -> a | _ -> assert false in
+  OpamFormula.ands_to_list f |> List.map get_atom
+
+let version_of_equal_constraint f =
+  match f with
+  | OpamFormula.Atom (OpamTypes.Constraint (`Eq, OpamTypes.FString s)) -> s
+  | _ -> assert false
+
+let opam_monorepo_dep_version ~lock_file ~package =
+  OpamFile.OPAM.depends lock_file
+  |> packages_in_depends
+  |> List.assoc (OpamPackage.Name.of_string package)
+  |> version_of_equal_constraint
+
+let ocaml_major_version vars =
+  Ocaml_version.with_just_major_and_minor
+    (Ocaml_version.of_string_exn vars.Ocaml_ci_api.Worker.Vars.ocaml_version)
+
+let find_compiler ~platforms ~version =
+  let v =
+    Ocaml_version.with_just_major_and_minor
+      (Ocaml_version.of_string_exn version)
+  in
+  let matches_compiler (variant, vars) =
+    if Ocaml_version.equal v (ocaml_major_version vars) then Some variant
+    else None
+  in
+  List.find_map matches_compiler platforms
+
+let selections ~platforms ~info:(package, lock_file) =
+  let ocaml_version = opam_monorepo_dep_version ~lock_file ~package:"ocaml" in
+  let dune_version = opam_monorepo_dep_version ~lock_file ~package:"dune" in
+  let monorepo_version = x_opam_monorepo_version lock_file |> Option.get in
+  let spec = { package; dune_version; monorepo_version } in
+  Option.map
+    (fun variant -> (variant, spec))
+    (find_compiler ~platforms ~version:ocaml_version)
+
+let install_opam_monorepo ~network ~cache ~monorepo_version =
+  match monorepo_version with
+  | "0.1" ->
+      let monorepo_commit = "6b6c1b8173afab88933762f6b5ee82a070b2d715" in
+      let open Obuilder_spec in
+      [
+        run ~network ~cache
+          "opam pin add -n https://github.com/ocamllabs/duniverse.git#%s"
+          monorepo_commit;
+        run ~network ~cache "opam depext --update -y opam-monorepo";
+        run ~network ~cache "opam install opam-monorepo";
+      ]
+  | v -> Printf.ksprintf failwith "unknown opam-monorepo version %S" v
+
+let install_dune ~network ~cache ~dune_version =
+  let open Obuilder_spec in
+  [ run ~network ~cache "opam install dune.%s" dune_version ]
+
+let install_tools ~network ~cache ~dune_version ~monorepo_version =
+  install_dune ~network ~cache ~dune_version
+  @ install_opam_monorepo ~network ~cache ~monorepo_version
+
+let install_depexts ~network ~cache ~package =
+  let open Obuilder_spec in
+  [
+    run ~network ~cache "opam pin -n add %s . --locked" package;
+    run ~network ~cache "opam depext --update -y %s" package;
+    run ~network ~cache "opam pin remove %s" package;
+  ]
+
+let spec ~base ~repo ~spec ~variant =
+  let { package; dune_version; monorepo_version } = spec in
+  let opam_file = package ^ ".opam" in
+  let lock_file = package ^ ".opam.locked" in
+  let download_cache =
+    Obuilder_spec.Cache.v Opam_build.download_cache
+      ~target:"/home/opam/.opam/download-cache"
+  in
+  let dune_cache = Duniverse_build.build_cache repo in
+  let network = [ "host" ] in
+  let dune_project = "dune-project" in
+  let open Obuilder_spec in
+  stage ~from:base
+  @@ [ comment "%s" (Variant.to_string variant); user ~uid:1000 ~gid:1000 ]
+  @ install_tools ~network ~cache:[ download_cache ] ~dune_version
+      ~monorepo_version
+  @ [
+      workdir "/src";
+      run "sudo chown opam /src";
+      copy [ dune_project; opam_file; lock_file ] ~dst:"/src/";
+    ]
+  @ install_depexts ~network ~cache:[ download_cache ] ~package
+  @ [
+      run ~network ~cache:[ download_cache ] "opam exec -- opam monorepo pull";
+      copy [ "." ] ~dst:"/src/";
+      run ~cache:[ dune_cache ] "opam exec -- dune build @install";
+      run ~cache:[ dune_cache ] "opam exec -- dune runtest";
+    ]

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -115,7 +115,7 @@ let install_depexts ~network ~cache ~package =
   [
     run ~network ~cache "opam pin -n add %s . --locked" package;
     run ~network ~cache "opam depext --update -y %s" package;
-    run ~network ~cache "opam pin remove %s" package;
+    run ~network ~cache "opam pin -n remove %s" package;
   ]
 
 let spec ~base ~repo ~spec ~variant =

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -1,0 +1,29 @@
+type info
+
+(** Detect whether a project uses opam-monorepo or something else. *)
+val detect : dir:Fpath.t -> info option
+
+(** Find a machine that can build for a given compiler. *)
+val find_compiler :
+  platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
+  version:string ->
+  Variant.t option
+
+type config [@@deriving yojson, ord]
+
+type selection = Variant.t * config [@@deriving yojson]
+
+(** Determine configuration for a build
+    (which machine to run on, dune version, etc) *)
+val selections :
+  platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
+  info:info ->
+  selection option
+
+(** Describe build steps *)
+val spec :
+  base:string ->
+  repo:Current_github.Repo_id.t ->
+  spec:config ->
+  variant:Variant.t ->
+  Obuilder_spec.stage

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -4,6 +4,7 @@ type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * opam_files
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse of opam_files
+  | `Opam_monorepo of Opam_monorepo.config
 ] [@@deriving to_yojson, ord]
 
 type t = {
@@ -24,6 +25,13 @@ let opam ~label ~selection ~analysis op =
 let duniverse ~label ~variant ~opam_files =
   { label; variant; ty = `Duniverse opam_files }
 
+let opam_monorepo ~variant ~spec =
+  {
+    label = Variant.to_string variant;
+    variant;
+    ty = `Opam_monorepo spec
+  }
+
 let pp f t = Fmt.string f t.label
 
 let label t = t.label
@@ -35,3 +43,4 @@ let pp_summary f = function
   | `Opam_fmt v -> Fmt.pf f "ocamlformat version: %a"
                      Fmt.(option ~none:(unit "none") Analyse_ocamlformat.pp_source) v
   | `Duniverse _ -> Fmt.string f "Duniverse build"
+  | `Opam_monorepo _ -> Fmt.string f "opam-monorepo build"

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -2,6 +2,7 @@ type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * string list
   | `Opam_fmt of Analyse_ocamlformat.source option
   | `Duniverse of string list
+  | `Opam_monorepo of Opam_monorepo.config
 ] [@@deriving to_yojson, ord]
 
 type t = {
@@ -18,6 +19,11 @@ val opam :
   t
 
 val duniverse : label:string -> variant:Variant.t -> opam_files:string list -> t
+
+val opam_monorepo :
+  variant:Variant.t ->
+  spec:Opam_monorepo.config ->
+  t
 
 val pp : t Fmt.t
 val compare : t -> t -> int

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -90,6 +90,8 @@ let build_with_docker ?ocluster ~repo ~analysis source =
             in
             Spec.duniverse ~label:(Variant.to_string variant) ~opam_files ~variant
           )
+      | `Opam_monorepo (variant, spec) ->
+        [Spec.opam_monorepo ~variant ~spec]
       | `Opam_build selections ->
         let lint_selection = List.hd selections in
         let builds =

--- a/test/gen_project.ml
+++ b/test/gen_project.ml
@@ -181,6 +181,37 @@ let dune_get ppf =
  (depexts ()))
 |}
 
+let opam_monorepo_spec_file ppf =
+  Fmt.pf ppf
+      {|
+opam-version: "2.0"
+synopsis: "spec file"
+maintainer: "opam-monorepo"
+depends: [
+  "dune" {= "1.0"}
+  "ocaml" {= "4.10.0"}
+] |}
+
+let opam_monorepo_lock_file ~monorepo_version ppf =
+  let pp_version_field ppf s =
+    Fmt.pf ppf "x-opam-monorepo-version: \"%s\"\n" s
+  in
+  Fmt.pf ppf
+    {|
+opam-version: "2.0"
+synopsis: "opam-monorepo generated lockfile"
+maintainer: "opam-monorepo"
+depends: [
+  "dune" {= "1.0"}
+  "ocaml" {= "4.10.0"}
+]
+%a
+x-opam-monorepo-root-packages: [ "test-opam-monorepo" ]
+x-opam-monorepo-duniverse-dirs: [ ]
+    |}
+    (Fmt.option pp_version_field) monorepo_version
+
+
 let dummy_opam ppf =
   Fmt.pf ppf
     {|opam-version: "2.0"

--- a/test/gen_project.mli
+++ b/test/gen_project.mli
@@ -11,6 +11,13 @@ val folder : string -> file list -> file
 val dune_get : contents
 (** Contents of an example [dune-get] file *)
 
+val opam_monorepo_spec_file : contents
+(** Contents of an example [.opam] file for opam-monorepo *)
+
+val opam_monorepo_lock_file : monorepo_version:string option -> contents
+(** Contents of an example [.opam.locked] file for opam-monorepo.
+    [monorepo_version] will populate a [x-opam-monorepo-version] field. *)
+
 val opam : contents
 (** Contents of an example [.opam] file *)
 


### PR DESCRIPTION
This contains support for opam-monorepo 0.1.0.

It detects the project based on the presence of a `pkg.opam.locked` file
with a `x-opam-monorepo-version` field.

Such builds perform the following steps:
- install `opam-monorepo` and the dune at the right version
- call `opam monorepo pull` on the repository to fetch dependencies
- call `dune build @install`
- call `dune runtest`

As follow-up for this work we'll need to:

- update the installation method to use opam once the plugin is released
- add lint builds
- install the plugin in a separate switch by hand or using opam-tools