### PR TITLE
opam-monorepo 0.1.0: use released version

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -48,7 +48,7 @@ module Analysis = struct
     selections :
       [ `Opam_build of Selection.t list
       | `Duniverse of Variant.t list
-      | `Opam_monorepo of Opam_monorepo.selection
+      | `Opam_monorepo of Opam_monorepo.config
       ];
   }
   [@@deriving yojson]
@@ -241,8 +241,8 @@ module Analysis = struct
         match ty with
         | `Opam_monorepo info ->
           begin
-            match Opam_monorepo.selections ~platforms ~info with
-            | Some s -> Lwt_result.return (`Opam_monorepo s)
+            match Opam_monorepo.selections ~platforms ~info ~opam_repository_commit with
+            | Some config -> Lwt_result.return (`Opam_monorepo config)
             | None -> failwith "No supported compilers found!"
           end
         | `Duniverse -> duniverse_selections ~job ~platforms dir

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -7,7 +7,7 @@ module Analysis : sig
   val selections : t -> [
       | `Opam_build of Selection.t list
       | `Duniverse of Variant.t list
-      | `Opam_monorepo of Opam_monorepo.selection
+      | `Opam_monorepo of Opam_monorepo.config
     ]
 
   val of_dir :

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -85,7 +85,7 @@ module Op = struct
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
       | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
-      | `Opam_monorepo spec -> Opam_monorepo.spec ~base ~repo ~spec ~variant
+      | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant
     in
     let make_dockerfile ~for_user =
       let open Dockerfile in

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -85,7 +85,7 @@ module Op = struct
       | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
       | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
-      | `Opam_monorepo spec -> Opam_monorepo.spec ~base ~repo ~spec ~variant
+      | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant
     in
     Current.Job.write job
       (Fmt.strf "@[<v>Base: %a@,%a@]@."

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -75,9 +75,8 @@ let install_project_deps ~opam_files ~selection =
   in
   let network = ["host"] in
   (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
-     [shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]] else []) @ [
-    comment "%s" (Fmt.strf "%a" Variant.pp variant);
-  ] @ distro_extras @ [
+     [shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]] else [])
+  @ distro_extras @ [
     workdir "/src";
     run "sudo chown opam /src";
     run ~network ~cache
@@ -94,6 +93,7 @@ let install_project_deps ~opam_files ~selection =
 let spec ~base ~opam_files ~selection =
   let open Obuilder_spec in
   stage ~from:base (
+    comment "%s" (Fmt.strf "%a" Variant.pp selection.Selection.variant) ::
     user ~uid:1000 ~gid:1000 ::
     install_project_deps ~opam_files ~selection @ [
       copy ["."] ~dst:"/src/";

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -21,16 +21,22 @@ let group_opam_files =
       | _ -> (dir, [x], [pkg]) :: acc
     )
 
+let mkdir dirs =
+  if dirs = [] then
+    []
+  else
+    let dirs =
+      dirs
+      |> List.map (fun (dir, _, _) -> Filename.quote (Fpath.to_string dir))
+      |> String.concat " "
+    in
+    [Obuilder_spec.run "mkdir -p %s" dirs]
+
 (* Generate instructions to copy all the files in [items] into the
    image, creating the necessary directories first, and then pin them all. *)
 let pin_opam_files ~network groups =
   let open Obuilder_spec in
-  let dirs =
-    groups
-    |> List.map (fun (dir, _, _) -> Filename.quote (Fpath.to_string dir))
-    |> String.concat " "
-  in
-  run "mkdir -p %s" dirs :: (
+  mkdir groups @ (
     groups |> List.map (fun (dir, files, _) ->
         copy files ~dst:(Fpath.to_string dir)
       )

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -91,12 +91,12 @@ let selections ~platforms ~info:(package, lock_file) =
 let install_opam_monorepo ~network ~cache ~monorepo_version =
   match monorepo_version with
   | "0.1" ->
-      let monorepo_commit = "6b6c1b8173afab88933762f6b5ee82a070b2d715" in
+      let ref = "0.1.0" in
       let open Obuilder_spec in
       [
         run ~network ~cache
-          "opam pin add -n https://github.com/ocamllabs/duniverse.git#%s"
-          monorepo_commit;
+          "opam pin add -n https://github.com/ocamllabs/opam-monorepo.git#%s"
+          ref;
         run ~network ~cache "opam depext --update -y opam-monorepo";
         run ~network ~cache "opam install opam-monorepo";
       ]

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -91,14 +91,11 @@ let selections ~platforms ~info:(package, lock_file) =
 let install_opam_monorepo ~network ~cache ~monorepo_version =
   match monorepo_version with
   | "0.1" ->
-      let ref = "0.1.0" in
+      let version = "0.1.0" in
       let open Obuilder_spec in
       [
-        run ~network ~cache
-          "opam pin add -n https://github.com/ocamllabs/opam-monorepo.git#%s"
-          ref;
-        run ~network ~cache "opam depext --update -y opam-monorepo";
-        run ~network ~cache "opam install opam-monorepo";
+        run ~network ~cache "opam depext --update -y opam-monorepo.%s" version;
+        run ~network ~cache "opam install opam-monorepo.%s" version;
       ]
   | v -> Printf.ksprintf failwith "unknown opam-monorepo version %S" v
 

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -97,7 +97,8 @@ let selection ~info:(package, lock_file) ~solve =
           ] );
     ]
   in
-  solve ~root_pkgs ~pinned_pkgs:[] >|= fun workers ->
+  solve ~version_filter:(Some ocaml_version) ~root_pkgs ~pinned_pkgs:[]
+  >|= fun workers ->
   let selection =
     List.hd workers |> Selection.remove_package ~package:deps_package
   in

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -3,23 +3,19 @@ type info
 (** Detect whether a project uses opam-monorepo or something else. *)
 val detect : dir:Fpath.t -> info option
 
-(** Find a machine that can build for a given compiler. *)
-val find_compiler :
-  platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
-  version:string ->
-  Variant.t option
-
 type config [@@deriving yojson, ord]
 
 val variant_of_config : config -> Variant.t
 
 (** Determine configuration for a build
     (which machine to run on, dune version, etc) *)
-val selections :
-  platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
+val selection :
   info:info ->
-  opam_repository_commit:Current_git.Commit_id.t ->
-  config option
+  solve:
+    (root_pkgs:(string * string) list ->
+    pinned_pkgs:(string * string) list ->
+    (Selection.t list, Rresult.R.msg) Lwt_result.t) ->
+  ([> `Opam_monorepo of config ], Rresult.R.msg) Lwt_result.t
 
 (** Describe build steps *)
 val spec :

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -12,7 +12,8 @@ val variant_of_config : config -> Variant.t
 val selection :
   info:info ->
   solve:
-    (root_pkgs:(string * string) list ->
+    (version_filter:string option ->
+    root_pkgs:(string * string) list ->
     pinned_pkgs:(string * string) list ->
     (Selection.t list, Rresult.R.msg) Lwt_result.t) ->
   ([> `Opam_monorepo of config ], Rresult.R.msg) Lwt_result.t

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -11,11 +11,12 @@ val variant_of_config : config -> Variant.t
     (which machine to run on, dune version, etc) *)
 val selection :
   info:info ->
+  platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
   solve:
-    (version_filter:string option ->
-    root_pkgs:(string * string) list ->
-    pinned_pkgs:(string * string) list ->
-    (Selection.t list, Rresult.R.msg) Lwt_result.t) ->
+    (root_pkgs:(string * string) list ->
+     pinned_pkgs:(string * string) list ->
+     platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
+     (Selection.t list, Rresult.R.msg) Lwt_result.t) ->
   ([> `Opam_monorepo of config ], Rresult.R.msg) Lwt_result.t
 
 (** Describe build steps *)

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -11,19 +11,20 @@ val find_compiler :
 
 type config [@@deriving yojson, ord]
 
-type selection = Variant.t * config [@@deriving yojson]
+val variant_of_config : config -> Variant.t
 
 (** Determine configuration for a build
     (which machine to run on, dune version, etc) *)
 val selections :
   platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
   info:info ->
-  selection option
+  opam_repository_commit:Current_git.Commit_id.t ->
+  config option
 
 (** Describe build steps *)
 val spec :
   base:string ->
   repo:Current_github.Repo_id.t ->
-  spec:config ->
+  config:config ->
   variant:Variant.t ->
   Obuilder_spec.stage

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -18,6 +18,14 @@ let compare a b = compare a.label b.label
 
 let ( >>!= ) = Lwt_result.bind
 
+let compiler_matches_major_and_minor vars ~version =
+  let vars_version =
+    Ocaml_version.with_just_major_and_minor
+      (Ocaml_version.of_string_exn vars.Worker.Vars.ocaml_version)
+  in
+  Ocaml_version.equal vars_version
+    (Ocaml_version.with_just_major_and_minor version)
+
 module Query = struct
   let id = "opam-vars"
 

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -12,6 +12,11 @@ type t = {
 val pp : t Fmt.t
 val compare : t -> t -> int
 
+val compiler_matches_major_and_minor : Ocaml_ci_api.Worker.Vars.t -> version:Ocaml_version.t -> bool
+(** [compiler_matches_major_and_minor vars ~version] is [true] iff the compiler
+    version in [vars] matches [version], considering only the major and minor
+    parts of the version number. *)
+
 val get :
   arch:Ocaml_version.arch ->
   label:string ->

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -10,3 +10,10 @@ let of_worker w =
   let { W.id; packages; commit } = w in
   let variant = Variant.of_string id in
   { variant; packages; commit }
+
+let remove_package t ~package =
+  {
+    t with
+    packages =
+      List.filter (fun p -> not (String.equal p package)) t.packages;
+  }

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -6,3 +6,5 @@ type t = {
 } [@@deriving yojson, ord]
 
 val of_worker : Ocaml_ci_api.Worker.Selection.t -> t
+
+val remove_package : t -> package:string -> t

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -25,11 +25,12 @@ let opam ~label ~selection ~analysis op =
 let duniverse ~label ~variant ~opam_files =
   { label; variant; ty = `Duniverse opam_files }
 
-let opam_monorepo ~variant ~spec =
+let opam_monorepo ~config =
+  let variant = Opam_monorepo.variant_of_config config in
   {
     label = Variant.to_string variant;
     variant;
-    ty = `Opam_monorepo spec
+    ty = `Opam_monorepo config
   }
 
 let pp f t = Fmt.string f t.label

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -20,10 +20,7 @@ val opam :
 
 val duniverse : label:string -> variant:Variant.t -> opam_files:string list -> t
 
-val opam_monorepo :
-  variant:Variant.t ->
-  spec:Opam_monorepo.config ->
-  t
+val opam_monorepo : config:Opam_monorepo.config -> t
 
 val pp : t Fmt.t
 val compare : t -> t -> int

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -90,8 +90,8 @@ let build_with_docker ?ocluster ~repo ~analysis source =
             in
             Spec.duniverse ~label:(Variant.to_string variant) ~opam_files ~variant
           )
-      | `Opam_monorepo (variant, spec) ->
-        [Spec.opam_monorepo ~variant ~spec]
+      | `Opam_monorepo config ->
+        [Spec.opam_monorepo ~config]
       | `Opam_build selections ->
         let lint_selection = List.hd selections in
         let builds =

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -70,6 +70,7 @@ let expect_test name ~project ~expected =
                 dummy_package "fmt" [ "1.0" ];
                 dummy_package "logs" [ "1.0" ];
                 dummy_package "alcotest" [ "1.0" ];
+                dummy_package "opam-monorepo" [ "0.1.0" ];
               ];
           ];
       let opam_repository = Fpath.v repo in
@@ -194,7 +195,7 @@ let test_opam_monorepo =
     let open Gen_project in
     [ File ("example.opam", opam_monorepo_spec_file);
       File ("example.opam.locked",
-            opam_monorepo_lock_file ~monorepo_version:(Some "0.1.0"));
+            opam_monorepo_lock_file ~monorepo_version:(Some "0.1"));
       File ("dune-project", empty_file);
     ]
   in


### PR DESCRIPTION
This bumps the commit to use the released version.