### PR TITLE
initial ocaml-ci-github idea

### DIFF
--- a/github/dune
+++ b/github/dune
@@ -1,0 +1,29 @@
+(executables
+ (names main)
+ (libraries logs.fmt
+            fmt.tty
+            current
+            current_web
+            current_docker
+            current_git
+            current_github
+            current_rpc
+            dockerfile-opam
+            ocluster-api
+            capnp-rpc-unix
+            mirage-crypto-rng.unix
+            ocaml_ci
+            ocaml-ci-api
+            prometheus
+            github-workflow)
+ (preprocess (pps ppx_deriving_yojson)))
+
+(install
+ (section bin)
+ (package ocaml-ci-service)
+ (files (main-copy.exe as ocaml-ci-github)))
+
+ (rule
+  (target main-copy.exe)
+  (deps (package ocaml-ci-solver))
+  (action (copy main.exe main-copy.exe)))

--- a/github/gh.ml
+++ b/github/gh.ml
@@ -1,0 +1,103 @@
+open Ocaml_ci
+
+type t = {
+  win : bool;
+  mac : bool;
+  ovs : string list;
+} [@@deriving yojson]
+
+(* If the package's directory name doesn't contain a dot then opam will default to
+   using the last known version, which is usually wrong. In particular, if a multi-project
+   repostory adds a new package with a constraint "{ =version }" on an existing one,
+   this will fail because opam will pin the new package as "dev" but the old one with
+   the version of its last release. *)
+  let maybe_add_dev ~dir name =
+  if Fpath.is_current_dir dir || not (String.contains (Fpath.basename dir) '.') then name ^ ".dev" else name
+
+(* Group opam files by directory.
+    e.g. ["a/a1.opam"; "a/a2.opam"; "b/b1.opam"] ->
+        [("a", ["a/a1.opam"; "a/a2.opam"], ["a1.dev"; "a2.dev"]);
+          ("b", ["b/b1.opam"], ["b1.dev"])
+        ] *)
+let group_opam_files =
+  ListLabels.fold_left ~init:[] ~f:(fun acc x ->
+      let item = Fpath.v x in
+      let dir = Fpath.parent item in
+      let pkg = Filename.basename x |> Filename.chop_extension |> maybe_add_dev ~dir in
+      match acc with
+      | (prev_dir, prev_items, pkgs) :: rest when Fpath.equal dir prev_dir -> (prev_dir, x :: prev_items, pkg :: pkgs) :: rest
+      | _ -> (dir, [x], [pkg]) :: acc
+    )
+
+(* Generate instructions to copy all the files in [items] into the
+    image, creating the necessary directories first, and then pin them all. *)
+(* Generate Dockerfile instructions to copy all the files in [items] into the
+   image, creating the necessary directories first, and then pin them all. *)
+let pin_opam_files ?(github=false) groups =
+  let open Obuilder_spec in
+  let dirs = groups |> List.map (fun (dir, _, _) -> Printf.sprintf "%S" (Fpath.to_string dir)) |> String.concat " " in
+  (if github then [] else run "mkdir -p %s" dirs :: (
+    groups |> List.map (fun (dir, files, _) ->
+        copy files ~dst:(Fpath.to_string dir)
+      )
+  )) @ [
+    groups |> List.concat_map (fun (dir, _, pkgs) ->
+        pkgs
+        |> List.map (fun pkg ->
+            Printf.sprintf "opam pin add -yn %s %S" pkg (Fpath.to_string dir)
+          )
+      )
+    |> (if github then String.concat " && " else String.concat " && \\\n  ")
+    |> run "%s"
+  ]
+
+(* Get the packages directly in "." *)
+let rec get_root_opam_packages = function
+  | [] -> []
+  | (dir, _, pkgs) ::_ when Fpath.is_current_dir dir -> pkgs
+  | _ :: rest -> get_root_opam_packages rest
+
+let download_cache = "opam-archives"
+
+let install_for_github ~winmac ~opam_files ~selection =
+  ignore winmac;
+  let { Selection.packages; commit; variant } = selection in
+  let groups = group_opam_files opam_files in
+  let root_pkgs = get_root_opam_packages groups in
+  let non_root_pkgs = packages |> List.filter (fun pkg -> not (List.mem pkg root_pkgs)) in
+  let open Obuilder_spec in
+  let cache = [ Obuilder_spec.Cache.v download_cache ~target:"/home/opam/.opam/download-cache" ] in
+  let distro_extras =
+    if Astring.String.is_prefix ~affix:"fedora" (Variant.id variant) then
+      [run "sudo dnf install -y findutils"] (* (we need xargs) *)
+    else
+      []
+  in
+  if winmac then
+  ( pin_opam_files ~github:true groups @ [
+    env "DEPS" (String.concat " " non_root_pkgs);
+    (* run "cd ~/opam-repository && (git cat-file -e %s || git fetch origin master) && git reset -q --hard %s && git log --no-decorate -n1 --oneline && opam update -u" commit commit; *)
+    run ~cache "opam depext --update -yt %s" (String.concat " " root_pkgs);
+    run ~cache "opam list --short --columns=package > installed.deps; for dep in $DEPS; do [[ ! \"$dep\" =~ $(echo ^\\($(paste -sd'|' installed.deps)\\)$) && ! \"$dep\" = \"ocaml.\"* && ! \"$dep\" = \"ocaml-base-compiler.\"* ]] && export NEW_DEPS=\"$dep $NEW_DEPS\"; done; echo $NEW_DEPS; opam install $NEW_DEPS"
+  ]) else ( 
+  (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
+     [shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]] else []) @ [
+    comment "%s" (Fmt.strf "%a" Variant.pp variant);
+  ] @ distro_extras @ [
+    run "cd ~/opam-repository && (git cat-file -e %s || git fetch origin master) && git reset -q --hard %s && git log --no-decorate -n1 --oneline && opam update -u" commit commit;
+    workdir "/home/opam/package";
+    run "git clone https://github.com/$GITHUB_REPOSITORY . && git checkout $GITHUB_SHA";
+  ] @ pin_opam_files ~github:true groups @ [
+    env "DEPS" (String.concat " " non_root_pkgs);
+    run ~cache "opam depext --update -y %s $DEPS" (String.concat " " root_pkgs);
+    run ~cache "opam install $DEPS"
+  ])
+
+let spec ~base ~opam_files ~selection ~winmac =
+  let open Obuilder_spec in
+  stage ~from:base (
+    user ~uid:1000 ~gid:1000 ::
+    install_for_github ~winmac ~opam_files ~selection @ [
+      run "opam exec -- dune build @install @runtest && rm -rf _build"
+    ]
+  )

--- a/github/logging.ml
+++ b/github/logging.ml
@@ -1,0 +1,48 @@
+module Metrics = struct
+  open Prometheus
+
+  let namespace = "ocamlci"
+
+  let subsystem = "logs"
+
+  let inc_messages =
+    let help = "Total number of messages logged" in
+    let c =
+      Counter.v_labels ~label_names:[ "level"; "src" ] ~help ~namespace
+        ~subsystem "messages_total"
+    in
+    fun lvl src ->
+      let lvl = Logs.level_to_string (Some lvl) in
+      Counter.inc_one @@ Counter.labels c [ lvl; src ]
+end
+
+let pp_timestamp f x =
+  let open Unix in
+  let tm = localtime x in
+  Fmt.pf f "%04d-%02d-%02d %02d:%02d.%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)
+    tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
+
+let reporter =
+  let report src level ~over k msgf =
+    let k _ = over (); k () in
+    let src = Logs.Src.name src in
+    Metrics.inc_messages level src;
+    msgf @@ fun ?header ?tags:_ fmt ->
+    Fmt.kpf k Fmt.stderr ("%a %a %a @[" ^^ fmt ^^ "@]@.")
+      pp_timestamp (Unix.gettimeofday ())
+      Fmt.(styled `Magenta string) (Printf.sprintf "%14s" src)
+      Logs_fmt.pp_header (level, header)
+  in
+  { Logs.report = report }
+
+let init () =
+  Fmt_tty.setup_std_outputs ();
+  Logs.(set_level (Some Info));
+  Logs.set_reporter reporter
+
+let run x =
+  match Lwt_main.run x with
+  | Ok _ as r -> r
+  | Error (`Msg m) as e ->
+    Logs.err (fun f -> f "%a" Fmt.lines m);
+    e

--- a/github/main.ml
+++ b/github/main.ml
@@ -1,0 +1,48 @@
+let solver = Ocaml_ci.Solver_pool.spawn_local ()
+
+let () =
+  Unix.putenv "DOCKER_BUILDKIT" "1";
+  Unix.putenv "PROGRESS_NO_TRUNC" "1"
+  (* Logging.init () *)
+
+let main config mode repo web =
+  let open Current.Syntax in 
+  let repo = Fpath.v repo in
+  let p () = 
+   let+ yaml = Pipeline.generate ~solver repo () in 
+   Format.printf "%s%!" yaml; exit 0 
+  in 
+  let engine = Current.Engine.create ~config p in
+  let site = Current_web.Site.(v ~has_role:allow_all) ~name:"ocaml-ci-github" (Current_web.routes engine) in
+  Lwt_main.run begin
+    Lwt.choose ([
+      Current.Engine.thread engine;
+    ] @ (if web then [ Current_web.run ~mode site ] else []))
+  end
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let repo =
+  Arg.required @@
+  Arg.pos 0 Arg.(some dir) None @@
+  Arg.info
+    ~doc:"The directory containing the .git subdirectory."
+    ~docv:"DIR"
+    []
+
+let web = 
+  Arg.value @@ 
+  Arg.flag @@
+  Arg.info 
+    ~doc:"Also run the webserver so you can see what's going on"
+    ~docv:"WEB"
+    ["web"]
+
+let cmd =
+  let doc = "Test ocaml-ci on a local Git clone" in
+  Term.(const main $ Current.Config.cmdliner $ Current_web.cmdliner $ repo $ web ),
+  Term.info "ocaml-ci-github" ~doc
+
+let () = Term.(exit @@ eval cmd)

--- a/github/op.ml
+++ b/github/op.ml
@@ -1,0 +1,140 @@
+let checkout_pool = Current.Pool.create ~label:"git-clone" 1
+module Git = Current_git
+module Github = Current_github
+module Docker = Current_docker.Default
+module Raw = Current_docker.Raw
+
+type t = Ocaml_ci.Builder.t
+
+
+let commit_locks = Hashtbl.create 1000
+
+let job_to_string j = 
+  Yaml.to_string_exn (Spec.job_to_yaml j)
+
+let job_of_string s = Spec.job_of_yaml (Yaml.of_string_exn s)
+
+module Job_outcome = struct 
+  type t = { variant: string; action : Spec.job }
+
+  let to_yaml {variant; action} = 
+    let open Spec in 
+    `O [("variant", `String variant); ("action", job_to_yaml action)]
+
+  let of_yaml = let open Spec in function 
+    | `O [("variant", `String variant); ("action", yml)] -> { variant ; action = job_of_yaml yml}
+    | _ -> failwith ""
+
+  let marshal t = Yaml.to_string_exn (to_yaml t)
+  let unmarshal s = 
+    of_yaml (Yaml.of_string_exn s)
+end 
+
+let rec with_commit_lock ~job commit variant fn =
+  let open Lwt.Infix in 
+  let key = (Current_git.Commit.hash commit, variant) in
+  match Hashtbl.find_opt commit_locks key with
+  | Some lock ->
+    Current.Job.log job "Waiting for a similar build to finish...";
+    lock >>= fun () ->
+    with_commit_lock ~job commit variant fn
+  | None ->
+    let finished, set_finished = Lwt.wait () in
+    Hashtbl.add commit_locks key finished;
+    Lwt.finalize fn
+      (fun () ->
+         Hashtbl.remove commit_locks key;
+         Lwt.wakeup set_finished ();
+         Lwt.return_unit
+      )
+let id = "ci-build"
+
+module Key = struct
+  type t = {
+    commit : Current_git.Commit.t;            (* The source code to build and test *)
+    repo : Current_github.Repo_id.t;          (* Used to choose a build cache *)
+    label : string;                           (* A unique ID for this build within the commit *)
+    github : Gh.t                (* Github configuration options *)
+  }
+
+  let to_json { commit; label; repo; github } =
+    `Assoc [
+      "commit", `String (Current_git.Commit.hash commit);
+      "repo", `String (Fmt.to_to_string Current_github.Repo_id.pp repo);
+      "label", `String label;
+      "github", Gh.to_yojson github
+    ]
+
+  let digest t = Yojson.Safe.to_string (to_json t)
+end
+
+module Value = struct
+
+  type t = {
+    ty : Ocaml_ci.Spec.ty;
+    base : string;                       (* The image with the OCaml compiler to use. *)
+    variant : Ocaml_ci.Variant.t;             (* Added as a comment in the Dockerfile *)
+  }
+
+  let to_json { base; ty; variant } =
+    `Assoc [
+      "base", `String base;
+      "op", Ocaml_ci.Spec.ty_to_yojson ty;
+      "variant", (Ocaml_ci.Variant.to_yojson variant);
+    ]
+
+  let digest t = Yojson.Safe.to_string (to_json t)
+end
+
+module Outcome = Job_outcome
+
+let or_raise = function
+  | Ok () -> ()
+  | Error (`Msg m) -> raise (Failure m)
+
+let run { Ocaml_ci.Builder.docker_context = _; pool; build_timeout } job
+    { Key.commit; github; _ } { Value.base; variant; ty } =
+  (* let gh = if label = "winmac" then Some github else Some ({ github with winmac = false}) in  *)
+  let build_spec =
+    match ty with
+    | `Opam (`Build, selection, opam_files) -> 
+      Gh.spec ~base ~opam_files ~selection ~winmac:(github.win = true || github.mac = true)
+    | _ -> failwith "Not supported right now"
+  in
+  let gh_workflow = begin
+    if github.win
+    then Spec.workflow_of_spec ~oses:["windows-latest"] ~ovs:github.ovs ~use_docker:false build_spec 
+    else if github.mac then Spec.workflow_of_spec ~oses:["macos-latest"] ~ovs:github.ovs ~use_docker:false build_spec 
+    else Spec.workflow_of_spec ~use_docker:true build_spec end in
+  Current.Job.write job
+    (Fmt.strf "@[<v>Base: %a@,%a@]@."
+        Fmt.string base
+        Ocaml_ci.Spec.pp_summary ty);
+  Current.Job.write job
+    (Fmt.strf "@.\
+                To reproduce locally:@.@.\
+                %a@.\
+                cat > .github/workflows/ocaml-ci.yml <<'END-OF-WORKFLOW'@.\
+                \o033[34m%a\o033[0m@.\
+                END-OF-WORKFLOW@."
+        Current_git.Commit_id.pp_user_clone (Current_git.Commit.id commit)
+        Spec.pp gh_workflow);
+  let open Lwt.Infix in 
+  let workflow = Spec.to_string gh_workflow in
+  Current.Job.start ~timeout:build_timeout ~pool job ~level:Current.Level.Average >>= fun () ->
+  with_commit_lock ~job commit variant @@ fun () ->
+  Current_git.with_checkout ~pool:checkout_pool ~job commit @@ fun dir ->
+  Current.Job.write job (Fmt.strf "Writing Workflow:@.%s@." workflow);
+  Bos.OS.File.write Fpath.(dir / "ocaml-ci.yml") (workflow ^ "\n") |> or_raise;
+  let res : Outcome.t = {variant = base; action =  gh_workflow.jobs} in 
+  Lwt.return (Ok res)
+
+let pp f ({ Key.repo; commit; label; github }, _) =
+  Fmt.pf f "test %a %a (%s) \nGithub Configuration: %a"
+    Current_github.Repo_id.pp repo
+    Current_git.Commit.pp commit
+    label
+    Yojson.Safe.pp (Gh.to_yojson github)
+
+let auto_cancel = true
+let latched = true 

--- a/github/os.ml
+++ b/github/os.ml
@@ -1,0 +1,50 @@
+(* Hopefully replace this will a package *)
+
+module OsVars = Ocaml_ci_api.Worker.Vars
+module DD = Dockerfile_distro
+
+
+let distros = [
+  `Debian `V10; `Alpine `V3_12;
+  `Ubuntu `V18_04; `OpenSUSE `V15_2; `CentOS `V8;
+  `Fedora `V32 ] 
+
+let vars ov = 
+  let get_version distro = 
+    let s = DD.human_readable_string_of_distro distro in 
+      match Astring.String.cuts ~sep:" " s with 
+        | _::v::_ -> v
+        | _ -> failwith "Distro Version Mangled"
+  in
+  let linux = List.map (fun distro -> 
+    List.map (fun arch -> { 
+      OsVars.arch = Ocaml_version.to_opam_arch arch;
+      os = "linux";
+      os_family = DD.human_readable_short_string_of_distro distro |> String.lowercase_ascii;
+      os_distribution = DD.human_readable_short_string_of_distro distro |> String.lowercase_ascii;
+      os_version = get_version distro;
+      ocaml_package = "ocaml";
+      ocaml_version = Ocaml_version.to_string ov;
+      }) 
+    [ `X86_64 ])
+  distros |> List.flatten in 
+    linux @ [
+      {
+        OsVars.arch = Ocaml_version.to_opam_arch `X86_64;
+        os = "macos";
+        os_family = "macos";
+        os_distribution = "homebrew";
+        os_version = "latest";
+        ocaml_package = "ocaml";
+        ocaml_version = Ocaml_version.to_string ov;
+      };
+      {
+        OsVars.arch = Ocaml_version.to_opam_arch `X86_64;
+        os = "win32";
+        os_family = "win32";
+        os_distribution = "windows";
+        os_version = "latest";
+        ocaml_package = "ocaml";
+        ocaml_version = Ocaml_version.to_string ov;
+      }
+    ]

--- a/github/os.mli
+++ b/github/os.mli
@@ -1,0 +1,3 @@
+val vars: Ocaml_version.t -> Ocaml_ci_api.Worker.Vars.t list
+(** [vars ov] is a list of operating system variables along with an ocaml version [ov]
+    that can be fed to the solver *)

--- a/github/pipeline.ml
+++ b/github/pipeline.ml
@@ -1,0 +1,186 @@
+(* PIPELINE
+    1. Get all OS related variables for solver (OS-Vars)
+    2. Solve for each locally without pulling images (Analysis)
+    3. Generate workflow files (Workflows)
+    4. Combine into one big file (Summary)
+*)
+
+open Current.Syntax 
+open Ocaml_ci
+
+module Git = Current_git
+module Github = Current_github
+
+module Ov = Ocaml_version
+module OsVars = Ocaml_ci_api.Worker.Vars 
+
+module GC = Current_cache.Generic(Op)
+
+let get_job_id x =
+  let+ md = Current.Analysis.metadata x in
+  match md with
+  | Some { Current.Metadata.job_id; _ } -> job_id
+  | None -> None
+
+let local_builder = 
+  let build_timeout = Duration.of_min 10 in 
+  let pool = Current.Pool.create ~label:"github" 1 in 
+  { Ocaml_ci.Builder.docker_context = None; pool; build_timeout }
+
+let github_v ~vars ~repo ~spec source = 
+  Current.component "write" |>
+  let> { Spec.variant; ty; _ } = spec
+  and> commit = source
+  and> vars = vars
+  and> repo = repo in
+  match List.find_opt (fun v -> Variant.equal (fst v) variant) vars with 
+  | Some (variant, var) ->
+    let arch = Variant.arch variant 
+    and distro = Variant.distro variant
+    and ocaml_version = Variant.ocaml_version variant |> Ocaml_version.with_just_major_and_minor in begin
+    match Variant.v ~arch ~distro ~ocaml_version with 
+      | Ok variant -> 
+        let ocaml_version = var.OsVars.ocaml_version in 
+        let tag f = 
+          let distro = Variant.distro f in 
+          let version = var.OsVars.os_version in 
+          let ocaml = Variant.ocaml_version f |> Ov.with_just_major_and_minor in 
+        Fmt.strf "%s-%s-ocaml-%s" distro version (Ocaml_version.to_string ~sep:'-' ocaml
+          |> String.map (function | '+' -> '-' | x -> x)) in 
+        let base = "ocaml/opam:" ^ (tag variant) in 
+        let github = begin
+          if var.OsVars.os = "macos" then { Gh.mac = true; win = false; ovs = [ ocaml_version ] }
+          else if var.os = "win32" then { Gh.win = true; mac = false; ovs = [ ocaml_version ] } 
+          else { win = false; mac = false; ovs = [] } end in
+        GC.run local_builder { Op.Key.commit; repo; label = base; github } { Op.Value.base; ty; variant }
+      | Error (`Msg m) -> failwith m 
+    end 
+  | None ->
+    let msg = Fmt.strf "BUG: variant %a is not a supported platform" Variant.pp variant in
+    Current_incr.const (Error (`Msg msg), None)
+
+
+let opam_repository_commit =
+  let repo = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } in
+  Github.Api.Anonymous.head_of repo @@ `Ref "refs/heads/master"
+
+let vars =
+  let variant {Ocaml_ci_api.Worker.Vars.os_distribution=distro; ocaml_version; arch; _ } = 
+    match Variant.v ~arch:(Option.value ~default:`X86_64 @@ Ocaml_version.of_opam_arch arch) ~distro ~ocaml_version:(Ocaml_version.of_string_exn ocaml_version) with 
+      | Ok v -> v 
+      | Error (`Msg m) -> failwith m 
+    in
+  List.map (fun v -> variant v, v) (Os.vars (Ov.of_string_exn "4.11.1")) |> Current.return
+
+let gen_workflows ~repo ~vars ~analysis source = 
+  Current.with_context analysis @@ fun () ->
+    let specs =
+      let+ analysis = Current.state ~hidden:true analysis in
+      match analysis with
+      | Error _ ->
+          (* If we don't have the analysis yet, just use the empty list. *)
+          []
+      | Ok analysis ->
+        match Analyse.Analysis.selections analysis with
+        | `Duniverse _ -> [] (* We'll just not support these for now... *)
+        | `Opam_monorepo (_, _) -> []
+        | `Opam_build selections ->
+            selections |> List.map (fun selection ->
+                let label = Variant.to_string selection.Selection.variant in
+                Spec.opam ~label ~selection ~analysis `Build
+              )
+    in
+    let builds = specs |> Current.list_map (module Spec) (fun spec ->
+      let+ result =  
+          let build = github_v ~vars ~repo ~spec source  in 
+          let+ state = Current.state ~hidden:true build
+          and+ job_id = get_job_id build
+          and+ spec = spec
+          and+ b = build in 
+          let result =
+            state |> Result.map @@ fun _ ->
+            match spec.ty with
+            | `Duniverse _ 
+            | `Opam_monorepo _
+            | `Opam (`Build, _, _) -> `Built
+            | `Opam (`Lint (`Doc|`Opam), _, _) -> `Checked
+            | `Opam_fmt _ -> `Checked
+          in
+          result, Some b, job_id
+      and+ spec = spec in
+      Spec.label spec, result
+    ) in
+    let+ builds = builds
+    and+ analysis_result = Current.state ~hidden:true (Current.map (fun _ -> `Checked) analysis)
+    and+ analysis_id = get_job_id analysis in
+    builds @ [
+      "(analysis)", (analysis_result, None, analysis_id)
+    ]
+
+let list_errors ~ok errs =
+  let groups =  (* Group by error message *)
+    List.sort compare errs |> List.fold_left (fun acc (msg, l) ->
+        match acc with
+        | (m2, ls) :: acc' when m2 = msg -> (m2, l :: ls) :: acc'
+        | _ -> (msg, [l]) :: acc
+      ) []
+  in
+  Error (`Msg (
+      match groups with
+      | [] -> "No builds at all!"
+      | [ msg, _ ] when ok = 0 -> msg (* Everything failed with the same error *)
+      | [ msg, ls ] -> Fmt.strf "%a failed: %s" Fmt.(list ~sep:(unit ", ") string) ls msg
+      | _ ->
+        (* Multiple error messages; just list everything that failed. *)
+        let pp_label f (_, l) = Fmt.string f l in
+        Fmt.strf "%a failed" Fmt.(list ~sep:(unit ", ") pp_label) errs
+    ))
+
+let summarise repo results =
+  let open Workflow in 
+  let dots_to_underscores s = String.(concat "_" (split_on_char '.' s)) in 
+  let job_name f = 
+    match Astring.String.cut ~sep:":" f.Op.Outcome.variant with 
+      | Some (_, name) -> dots_to_underscores name
+      | _ -> failwith "Unknown OS platform name"
+  in
+  let make_yaml (jobs : Op.Outcome.t list) : Yaml.value = 
+    `O (List.map (fun (f : Op.Outcome.t) -> (job_name f, Types.job_to_yaml f.action.job)) jobs) 
+  in  
+  let jobs = results |> List.map (fun (_, job, _) -> match job with Some job -> [job] | None -> []) |> List.flatten in 
+  let t = t (make_yaml jobs) |> with_name "Github OCaml-CI" |> with_on (simple_event ["push"; "pull_request"]) in 
+  let s = Fmt.(str "%a" (Pp.workflow ~drop_null:true (fun a -> a)) t) in
+  if List.length jobs > 0 then begin
+    ignore (Bos.OS.Dir.create Fpath.(repo / ".github" / "workflows" ));
+    (match Bos.OS.File.write Fpath.(repo / ".github" / "workflows" / "ocaml-ci.yml") s with 
+    | Ok _ -> ()
+    | Error (`Msg m) -> failwith m)
+  end;
+  results |> List.fold_left (fun (ok, pending, err, skip) -> function
+      | _, _, Ok `Checked -> (ok, pending, err, skip)  (* Don't count lint checks *)
+      | _, _, Ok `Built -> (ok + 1, pending, err, skip)
+      | l, _, Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m -> (ok, pending, err, (m, l) :: skip)
+      | l, _, Error `Msg m -> (ok, pending, (m, l) :: err, skip)
+      | _, _, Error `Active _ -> (ok, pending + 1, err, skip)
+    ) (0, 0, [], [])
+  |> fun (ok, pending, err, skip) ->
+  if pending > 0 then Error (`Active `Running)
+  else match ok, err, skip with
+    | 0, [], skip -> list_errors ~ok:0 skip (* Everything was skipped - treat skips as errors *)
+    | _, [], _ -> Ok s                      (* No errors and at least one success *)
+    | ok, err, _ -> list_errors ~ok err     (* Some errors found - report *)
+
+
+let generate ~solver repository () = 
+  let r = Git.Local.v repository in 
+  let src = Git.Local.head_commit r in 
+  let repo = Current.return { Github.Repo_id.owner = "local"; name = "test" } 
+  and analysis = Analyse.examine_vars ~solver ~vars ~opam_repository_commit src in 
+  Current.component "summarise" |>
+  let> results = gen_workflows ~vars ~repo ~analysis src in
+  let results =
+    List.map (fun (variant, (build, job, _)) -> variant, job, build) results 
+  in 
+  let result = summarise repository results in 
+  Current_incr.const (result, None)
+

--- a/github/pipeline.mli
+++ b/github/pipeline.mli
@@ -1,0 +1,3 @@
+val generate : 
+  solver:[ `Solver_e52b1d1d3033890c ] Capnp_rpc_lwt.Capability.t ->
+  Fpath.t -> unit -> string Current.t

--- a/github/spec.ml
+++ b/github/spec.ml
@@ -1,0 +1,91 @@
+(* Converting OBuilder Spec to Github Workflow *)
+open Workflow
+open Yaml_util 
+
+
+type ctx = {
+  user : Obuilder_spec.user;
+}
+
+let default_ctx = {
+  user = Obuilder_spec.root;
+}
+
+type job = { job : Types.job; }
+
+type t = job Types.t 
+
+let job_to_yaml t : Yaml.value = `O [ ("job", Types.job_to_yaml t.job) ]
+let job_of_yaml yaml : job = match yaml with 
+  | `O [ ("job", job) ] -> (
+    match Types.job_of_yaml job with 
+      | Ok v -> { job = v }
+      | Error (`Msg m) -> failwith m
+  )
+  | _ -> failwith "Bad yaml"
+
+
+let cp src dest = Format.(fprintf str_formatter "cp %a %s" (pp_print_list ~pp_sep:(fun ppf () -> fprintf ppf "%s" " ") pp_print_string) src dest); Format.flush_str_formatter ()
+
+let working_dir d st = match d with  
+  | Some s -> st |> with_step_workdir s 
+  | None -> st 
+
+let rec of_op wd acc env ctx (ts : Obuilder_spec.op list) = match ts with
+  | (`Comment _) :: xs -> of_op wd acc env ctx xs
+  | (`Workdir x) :: xs -> of_op (Some x) ((step |> with_step_run ("mkdir -p " ^ x)) :: acc) env ctx xs
+  | (`Shell _) :: xs -> of_op wd acc env ctx xs
+  | (`Run { shell; _ }) :: xs -> of_op wd ((step |> with_step_run shell |> working_dir wd) :: acc) env ctx xs 
+  | (`Copy { src; dst; exclude = _ }) :: xs -> of_op wd ((step |> with_step_run @@ cp src dst)::acc) env ctx xs 
+  | (`User (_ as u)) :: xs -> of_op wd acc env { user = u } xs 
+  | (`Env b) :: xs -> of_op wd acc ((fst b, `String (snd b)) :: env) ctx xs 
+  | [] -> (List.rev acc, env, ctx)
+
+let container image = 
+  container 
+  |> with_image image 
+  |> with_options "--user 1000" 
+  |> with_container_env 
+    (simple_kv [
+      ("HOME", `String "/home/opam");
+    ])
+
+let dockerless_worfklow ~oses ~ovs ops =  
+  let matrix =
+    simple_kv
+      [
+        ("operating-system", list string oses);
+        ("ocaml-version", list string ovs);
+      ]
+  in
+  let checkout = { step with uses = Some Conf.checkout } in
+  let setup =
+    step
+    |> with_uses "avsm/setup-ocaml@v1"
+    |> with_with
+         (simple_kv [ ("ocaml-version", string (expr "matrix.ocaml-version")) ]) in 
+  let steps = [ checkout; setup ] @ ops in 
+    job (expr "matrix.operating-system")
+    |> with_strategy (strategy |> with_matrix matrix)
+    |> with_steps steps 
+
+let workflow_of_spec ?(oses=Conf.oses) ?(ovs=["4.11.0"]) ?(use_docker=true) { Obuilder_spec.from; ops } =
+  let (ops', env, _) = of_op None [] [] default_ctx ops in
+  let on = simple_event ["push"; "pull_request"] in 
+  let job = if use_docker then (
+    job "ubuntu-latest" 
+    |> with_steps ops' 
+    |> with_container (container from)
+    |> with_job_env (simple_kv (("HOME", `String "/home/opam") :: env)) 
+    |> with_job_defaults (with_default_run (run |> with_run_workdir "/home/opam"))) 
+  else 
+    dockerless_worfklow ~oses ~ovs ops' 
+    |> with_job_env (simple_kv env)
+    |> with_job_defaults (with_default_run (run |> with_run_shell "bash")) in 
+    t { job } |> with_name "Github Action Workflow" |> with_on on
+
+let pp ppf t = Pp.workflow ~drop_null:true job_to_yaml ppf t
+
+let to_string t = 
+  Pp.workflow ~drop_null:true job_to_yaml Format.str_formatter t;
+  Format.flush_str_formatter ()

--- a/github/spec.mli
+++ b/github/spec.mli
@@ -1,0 +1,19 @@
+open Workflow 
+
+type job = { job : Types.job; }
+
+val job_to_yaml : job -> Yaml.value 
+
+val job_of_yaml : Yaml.value -> job
+
+type t = job Types.t
+
+val pp : Format.formatter -> t -> unit
+
+val to_string : job Types.t -> string
+
+val workflow_of_spec : 
+  ?oses:string list ->
+  ?ovs:string list -> 
+  ?use_docker:bool -> 
+  Obuilder_spec.stage -> job Types.t

--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -313,3 +313,10 @@ let examine ~solver ~platforms ~opam_repository_commit src =
   and> platforms = platforms in
   let platforms = platforms |> List.map (fun { Platform.variant; vars; _ } -> (variant, vars)) in
   Examine_cache.run solver src { Examine.Value.opam_repository_commit; platforms }
+
+let examine_vars ~solver ~vars ~opam_repository_commit src =
+  Current.component "Analyse" |>
+  let> src = src
+  and> opam_repository_commit = opam_repository_commit
+  and> vars = vars in
+  Examine_cache.run solver src { Examine.Value.opam_repository_commit; platforms = vars }

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -27,3 +27,13 @@ val examine :
   Analysis.t Current.t
 (** [examine ~solver ~platforms ~opam_repository_commit src] analyses the source code [src] and selects
     package versions to test using [opam_repository_commit]. *)
+
+val examine_vars :
+  solver:Ocaml_ci_api.Solver.t ->
+  vars:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list Current.t ->
+  opam_repository_commit:Current_git.Commit_id.t Current.t ->
+  Current_git.Commit.t Current.t ->
+  Analysis.t Current.t
+(** [examine_vars ~solver ~vars ~opam_repository_commit src] analyses the source code [src] and selects
+    package versions to test using [opam_repository_commit] -- it cuts out all of the platform information
+    that is required by [examine]. *)


### PR DESCRIPTION
I thought I would just open a draft PR about the `ocaml-ci-github` idea to generate ideas and discussion. It currently isn't quite at the `dune @ci && dune promote` step (shutting down the pipeline gracefully is something I'm not sure how to do) and it copies a lot of the code from `ocaml-ci-local` but I separated it into it's own folder to make it more readable. 

It only adds one thing to the library which is the ability to call the solver using only the OS variables (rather than providing the full `Platform.t`) with the hope that you can bypass the pulling of docker images and just solve for the different platforms to get the `$DEPS` variable. I think the longest thing is clone the opam repository!

Also, [this line of code needs improving](https://github.com/ocurrent/ocaml-ci/compare/master...patricoferris:github?expand=1#diff-4be58fdaac9b93d3349691b12189d777e1115f29543269f17f09674ee7eac864R81) 😅  (a lot!) but it kinda works. The main problem (I think) is that I don't know if you can get the hashes of the docker images w/out pulling them so I ended up just using generic images like `ocaml/opam:ubuntu-18.04-ocaml-4.11`. Ideally this pipeline would have not have to use Docker in order to make it quick.

[Here is an example of it in the real world](https://github.com/patricoferris/ppx_deriving_yaml/actions/runs/412720781). It would be good to also test it on something that solves differently depending on the platform. A part of me does wonder if this really needs the OCurrent pipeline?