### PR TITLE
Run opam-dune-lint to check opam files

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -82,7 +82,7 @@ module Op = struct
       match ty with
       | `Opam (`Build, selection, opam_files) -> Opam_build.spec ~base ~opam_files ~selection
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
-      | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
+      | `Opam (`Lint `Opam, selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files ~selection
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
       | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
       | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -82,7 +82,7 @@ module Op = struct
       match ty with
       | `Opam (`Build, selection, opam_files) -> Opam_build.spec ~base ~opam_files ~selection
       | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
-      | `Opam (`Lint `Opam, _selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files
+      | `Opam (`Lint `Opam, selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files ~selection
       | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
       | `Duniverse opam_files -> Duniverse_build.spec ~base ~repo ~opam_files ~variant
       | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -101,7 +101,7 @@ module Op = struct
                  docker build .@.@."
          Current_git.Commit_id.pp_user_clone commit
          Dockerfile.pp (Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:false build_spec));
-    let spec_str = Fmt.to_to_string Obuilder_spec.pp_stage build_spec in
+    let spec_str = Fmt.to_to_string Obuilder_spec.pp build_spec in
     let action = Cluster_api.Submission.obuilder_build spec_str in
     let src = (Git.Commit_id.repo commit, [Git.Commit_id.hash commit]) in
     let cache_hint = get_cache_hint repo spec in

--- a/lib/duniverse_build.mli
+++ b/lib/duniverse_build.mli
@@ -3,6 +3,6 @@ val spec :
   repo:Current_github.Repo_id.t ->
   opam_files:string list ->
   variant:Variant.t ->
-  Obuilder_spec.stage
+  Obuilder_spec.t
 
 val build_cache : Current_github.Repo_id.t -> Obuilder_spec.Cache.t

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,17 +1,17 @@
 val fmt_spec :
   base:string ->
   ocamlformat_source:Analyse_ocamlformat.source option ->
-  Obuilder_spec.stage
+  Obuilder_spec.t
 (** A build spec that checks the formatting. *)
 
 val doc_spec :
   base:string ->
   opam_files:string list ->
   selection:Selection.t ->
-  Obuilder_spec.stage
+  Obuilder_spec.t
 (** A build spec that checks that the documentation in [./src/] builds without warnings. *)
 
 val opam_lint_spec :
   base:string ->
   opam_files:string list ->
-  Obuilder_spec.stage
+  Obuilder_spec.t

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -14,4 +14,5 @@ val doc_spec :
 val opam_lint_spec :
   base:string ->
   opam_files:string list ->
+  selection:Selection.t ->
   Obuilder_spec.t

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -9,4 +9,4 @@ val spec :
   base:string ->
   opam_files:string list ->
   selection:Selection.t ->
-  Obuilder_spec.stage
+  Obuilder_spec.t

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -25,4 +25,4 @@ val spec :
   repo:Current_github.Repo_id.t ->
   config:config ->
   variant:Variant.t ->
-  Obuilder_spec.stage
+  Obuilder_spec.t

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -82,5 +82,5 @@ let platforms =
       let ovs = List.rev OV.Releases.recent @ OV.Releases.unreleased_betas in
       List.map make_release ovs @ distros
   | `Dev ->
-      let ovs = List.map OV.of_string_exn ["4.10"; "4.11"; "4.03"] in
+      let ovs = List.map OV.of_string_exn ["4.11"; "4.10"; "4.03"] in
       List.map make_release ovs @ [make_release ~arch:`I386 (List.hd ovs)]


### PR DESCRIPTION
This does mean that we have to install dependencies for lint jobs too, but it has the same cache hint and build instructions as odoc, so that work should be shared.