### PR TITLE
Opam monorepo 0.2 support

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -22,34 +22,34 @@ let group_opam_files =
     )
 
 let mkdir dirs =
-  if dirs = [] then
-    []
-  else
-    let dirs =
-      dirs
-      |> List.map (fun (dir, _, _) -> Filename.quote (Fpath.to_string dir))
-      |> String.concat " "
-    in
-    [Obuilder_spec.run "mkdir -p %s" dirs]
+  let dirs =
+    dirs
+    |> List.map (fun (dir, _, _) -> Filename.quote (Fpath.to_string dir))
+    |> String.concat " "
+  in
+  [Obuilder_spec.run "mkdir -p %s" dirs]
 
 (* Generate instructions to copy all the files in [items] into the
    image, creating the necessary directories first, and then pin them all. *)
 let pin_opam_files ~network groups =
-  let open Obuilder_spec in
-  mkdir groups @ (
-    groups |> List.map (fun (dir, files, _) ->
-        copy files ~dst:(Fpath.to_string dir)
-      )
-  ) @ [
-    groups |> List.concat_map (fun (dir, _, pkgs) ->
-        pkgs
-        |> List.map (fun pkg ->
-            Printf.sprintf "opam pin add -yn %s %s" pkg (Filename.quote (Fpath.to_string dir))
-          )
-      )
-    |> String.concat " && \n"
-    |> run ~network "%s"
-  ]
+  if groups = [] then
+    []
+  else
+    let open Obuilder_spec in
+    mkdir groups @ (
+      groups |> List.map (fun (dir, files, _) ->
+          copy files ~dst:(Fpath.to_string dir)
+        )
+    ) @ [
+      groups |> List.concat_map (fun (dir, _, pkgs) ->
+          pkgs
+          |> List.map (fun pkg ->
+              Printf.sprintf "opam pin add -yn %s %s" pkg (Filename.quote (Fpath.to_string dir))
+            )
+        )
+      |> String.concat " && \n"
+      |> run ~network "%s"
+    ]
 
 (* Get the packages directly in "." *)
 let rec get_root_opam_packages = function

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -1,13 +1,15 @@
 type info = string * OpamFile.OPAM.t
 
+type lock_file_version = V0_1 [@@deriving yojson, ord]
+
 type config = {
   package : string;
-  selection : Selection.t
+  selection : Selection.t;
+  lock_file_version : lock_file_version;
 }
 [@@deriving yojson, ord]
 
-let variant_of_config c =
-  c.selection.variant
+let variant_of_config c = c.selection.variant
 
 let only_lockfile_in ~dir =
   let opam_locked = ".opam.locked" in
@@ -64,9 +66,11 @@ let opam_monorepo_dep_version ~lock_file ~package =
   |> List.assoc (OpamPackage.Name.of_string package)
   |> version_of_equal_constraint
 
-let plugin_version = function
-  | "0.1" -> "0.1.0"
-  | v -> Printf.ksprintf failwith "unknown opam-monorepo version %S" v
+let lock_file_version_of_string = function
+  | "0.1" -> V0_1
+  | v -> Printf.ksprintf failwith "unknown x-opam-monorepo-version %S" v
+
+let plugin_version = function V0_1 -> "0.1.0"
 
 let opam_dep_file packages =
   let lines =
@@ -82,9 +86,11 @@ let selection ~info:(package, lock_file) ~platforms ~solve =
   let open Lwt_result.Infix in
   let ocaml_version = opam_monorepo_dep_version ~lock_file ~package:"ocaml" in
   let dune_version = opam_monorepo_dep_version ~lock_file ~package:"dune" in
-  let monorepo_version =
-    x_opam_monorepo_version lock_file |> Option.get |> plugin_version
+  let lock_file_version =
+    x_opam_monorepo_version lock_file
+    |> Option.get |> lock_file_version_of_string
   in
+  let monorepo_version = plugin_version lock_file_version in
   let deps_package = "opam-monorepo-deps.dev" in
   let root_pkgs =
     [
@@ -99,27 +105,28 @@ let selection ~info:(package, lock_file) ~platforms ~solve =
   in
   let platforms =
     let version = Ocaml_version.of_string_exn ocaml_version in
-    platforms |> List.filter (fun (_, vars) ->
-        Platform.compiler_matches_major_and_minor ~version vars
-      )
+    platforms
+    |> List.filter (fun (_, vars) ->
+           Platform.compiler_matches_major_and_minor ~version vars)
   in
-  solve ~root_pkgs ~pinned_pkgs:[] ~platforms
-  >|= fun workers ->
+  solve ~root_pkgs ~pinned_pkgs:[] ~platforms >|= fun workers ->
   let selection =
     List.hd workers |> Selection.remove_package ~package:deps_package
   in
-  `Opam_monorepo { package; selection }
+  `Opam_monorepo { package; selection; lock_file_version }
 
-let install_depexts ~network ~cache ~package =
+let install_depexts ~network ~cache ~package ~lock_file_version =
   let open Obuilder_spec in
-  [
-    run ~network ~cache "opam pin -n add %s . --locked" package;
-    run ~network ~cache "opam depext --update -y %s" package;
-    run ~network ~cache "opam pin -n remove %s" package;
-  ]
+  match lock_file_version with
+  | V0_1 ->
+      [
+        run ~network ~cache "opam pin -n add %s . --locked" package;
+        run ~network ~cache "opam depext --update -y %s" package;
+        run ~network ~cache "opam pin -n remove %s" package;
+      ]
 
 let spec ~base ~repo ~config ~variant =
-  let { package; selection } = config in
+  let { package; selection; lock_file_version } = config in
   let opam_file = package ^ ".opam" in
   let lock_file = package ^ ".opam.locked" in
   let download_cache =
@@ -139,6 +146,7 @@ let spec ~base ~repo ~config ~variant =
       copy [ dune_project; opam_file; lock_file ] ~dst:"/src/";
     ]
   @ install_depexts ~network ~cache:[ download_cache ] ~package
+      ~lock_file_version
   @ [
       run ~network ~cache:[ download_cache ] "opam exec -- opam monorepo pull";
       copy [ "." ] ~dst:"/src/";


### PR DESCRIPTION
This is the same as 0.1 except that transitive depexts are present in the lock file:
    
- they can be listed directly by parsing the lock file, with no access to opam-repository
- the "pull" command of 0.1.0 is not affected by this. So it is possible to install the 0.1.0 plugin and rewrite the version in the lock file so that it does not exit with an error.

Closes #282 