### PR TITLE
Update to latest OCurrent for staleness filtering

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,7 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
-    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#349a243d217f36e7d309aaa821be3ea3390b308b";
+    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#fb2019fc3af925cf4b6cce6061e6846077c6e266";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";
   ]

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -4,6 +4,10 @@ let profile =
   | Some "dev" | None -> `Dev
   | Some x -> Fmt.failwith "Unknown $PROFILE setting %S" x
 
+(* GitHub defines a stale branch as more than 3 months old.
+   Don't bother testing these. *)
+let max_staleness = Duration.of_day 93
+
 module Capnp = struct
   (* Cap'n Proto RPC is enabled by passing --capnp-public-address. These values are hard-coded
      (because they're just internal to the Docker container). *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -172,7 +172,7 @@ let v ?ocluster ~app ~solver () =
   installations |> Current.list_iter ~collapse_key:"org" (module Github.Installation) @@ fun installation ->
   let repos = Github.Installation.repositories installation |> set_active_repos ~installation in
   repos |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo) @@ fun repo ->
-  let refs = Github.Api.Repo.ci_refs repo |> set_active_refs ~repo in
+  let refs = Github.Api.Repo.ci_refs ~staleness:Conf.max_staleness repo |> set_active_refs ~repo in
   refs |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   let analysis = Analyse.examine ~solver ~platforms ~opam_repository_commit src in


### PR DESCRIPTION
Don't test commits that haven't been updated for more than 3 months (except for the repository's default branch, which is always tested).

Also, update opam-dune-lint for ocamlfind fix.