### PR TITLE
Fix opam-dune-lint (port ocurrent/opam-dune-lint#20)

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -56,7 +56,7 @@
   ocaml-ci-api
   conf-libev
   (opam-0install (>= "0.2"))
-  git-unix
+  (git-unix (< 3.0.0))
   (capnp-rpc-unix (>= 0.7.0))))
 (package
  (name ocaml-ci-web)

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,7 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
-    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#9202ee9a34a9e5d31f96a17b002dc7e8d598e0e6";
+    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#4716b96dac97ebd0a6e9deb4f1b0dfe011f4236d";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";
   ]

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,7 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
-    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#fb2019fc3af925cf4b6cce6061e6846077c6e266";
+    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#9202ee9a34a9e5d31f96a17b002dc7e8d598e0e6";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";
   ]

--- a/ocaml-ci-solver.opam
+++ b/ocaml-ci-solver.opam
@@ -16,7 +16,7 @@ depends: [
   "ocaml-ci-api"
   "conf-libev"
   "opam-0install" {>= "0.2"}
-  "git-unix"
+  "git-unix" {< "3.0.0"}
   "capnp-rpc-unix" {>= "0.7.0"}
 ]
 build: [


### PR DESCRIPTION
The `(lint-opam)` step of ocaml-ci will fail until this is merged.

See: ocurrent/opam-dune-lint#20