### PR TITLE
monorepo: support exact compiler version

### DIFF
--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -26,6 +26,10 @@ let compiler_matches_major_and_minor vars ~version =
   Ocaml_version.equal vars_version
     (Ocaml_version.with_just_major_and_minor version)
 
+let set_compiler_version vars ~version =
+  let ocaml_version = Ocaml_version.to_string version in
+  { vars with Worker.Vars.ocaml_version }
+
 module Query = struct
   let id = "opam-vars"
 

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -17,6 +17,11 @@ val compiler_matches_major_and_minor : Ocaml_ci_api.Worker.Vars.t -> version:Oca
     version in [vars] matches [version], considering only the major and minor
     parts of the version number. *)
 
+val set_compiler_version :
+  Ocaml_ci_api.Worker.Vars.t ->
+  version:Ocaml_version.t ->
+  Ocaml_ci_api.Worker.Vars.t
+
 val get :
   arch:Ocaml_version.arch ->
   label:string ->


### PR DESCRIPTION
When the exact compiler version (down to the patch level) is available in a base image, it is used. However, if it is not (for example the base image has 4.10.2 but the project has 4.10.1 in its lockfile), it would fail.

This adds a fallback mechanism for this situation by using the closest base image (4.10 in the example) and creating a switch with the exact version.

Closes #281