### PR TITLE
Fix (opam-lint) again

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,7 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
-    run ~cache ~network "opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#4716b96dac97ebd0a6e9deb4f1b0dfe011f4236d";
+    run ~cache ~network "opam update && opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#4716b96dac97ebd0a6e9deb4f1b0dfe011f4236d";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";
   ]

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,7 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
-    run ~cache ~network "opam update && opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#4716b96dac97ebd0a6e9deb4f1b0dfe011f4236d";
+    run ~cache ~network "git -C opam-repository pull origin master && opam update && opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#4716b96dac97ebd0a6e9deb4f1b0dfe011f4236d";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";
   ]

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,6 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
+    workdir "/home/opam";
     run ~cache ~network "git -C opam-repository pull origin master && opam update && opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#4716b96dac97ebd0a6e9deb4f1b0dfe011f4236d";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";


### PR DESCRIPTION
Fixes an oversight of #299. Sorry about that.

Issue:
```
/: (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
        (network host)
        (shell "opam depext -i opam-dune-lint"))
# Detecting depexts using vars: arch=x86_64, os=linux, os-distribution=debian, os-family=debian
[ERROR] No solution for opam-dune-lint: The following dependencies couldn't be met:
          - opam-dune-lint -> dune-private-libs >= 2.8.0
              no matching version
```
Full log: https://ci.ocamllabs.io/github/ocaml/merlin/commit/fbe27b42c9d1d2305a27945fb327eec41b8ff8c8/variant/(lint-opam)