### PR TITLE
Monorepo: add a lint-fmt build

### DIFF
--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -9,7 +9,7 @@ type config = {
 }
 [@@deriving yojson, ord]
 
-let variant_of_config c = c.selection.variant
+let selection_of_config c = c.selection
 
 let only_lockfile_in ~dir =
   let opam_locked = ".opam.locked" in

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -5,7 +5,7 @@ val detect : dir:Fpath.t -> info option
 
 type config [@@deriving yojson, ord]
 
-val variant_of_config : config -> Variant.t
+val selection_of_config : config -> Selection.t
 
 (** Determine configuration for a build
     (which machine to run on, dune version, etc) *)

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -22,7 +22,7 @@ let opam ~label ~selection ~analysis op =
   { label; variant; ty }
 
 let opam_monorepo ~config =
-  let variant = Opam_monorepo.variant_of_config config in
+  let {Selection.variant; _} = Opam_monorepo.selection_of_config config in
   {
     label = Variant.to_string variant;
     variant;

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -83,7 +83,11 @@ let build_with_docker ?ocluster ~repo ~analysis source =
     | Ok analysis ->
       match Analyse.Analysis.selections analysis with
       | `Opam_monorepo config ->
-        [Spec.opam_monorepo ~config]
+        let lint_selection = Opam_monorepo.selection_of_config config in
+        [
+          Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis (`Lint `Fmt);
+          Spec.opam_monorepo ~config
+        ]
       | `Opam_build selections ->
         let lint_selection = List.hd selections in
         let builds =


### PR DESCRIPTION
The lint-doc and lint-opam builds are not supported since they try to pin all opam files.