### PR TITLE
lint-fmt: grant network access to opam pin

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -7,7 +7,7 @@ let install_ocamlformat =
     let opam_file = Filename.concat path "ocamlformat.opam" in
     [
       copy [ opam_file ] ~dst:opam_file;
-      run "opam pin add -k path -n ocamlformat %S" path;
+      run ~network "opam pin add -k path -n ocamlformat %S" path;
       (* Pinned to a directory containing only the .opam file *)
       run ~network "opam depext ocamlformat";
       run ~network ~cache "opam install --deps-only -y ocamlformat";


### PR DESCRIPTION
This happens in the case where ocamlformat is vendored.
If its opam file contains `pin-depends`, it needs network access to be installed.