### PR TITLE
Test the opam file as well

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -97,6 +97,7 @@ let spec ~base ~opam_files ~selection =
     user ~uid:1000 ~gid:1000 ::
     install_project_deps ~opam_files ~selection @ [
       copy ["."] ~dst:"/src/";
-      run "opam exec -- dune build @install @runtest && rm -rf _build"
+      run "opam exec -- dune build @install @runtest && rm -rf _build";
+      run "opam install .";
     ]
   )


### PR DESCRIPTION
The content of the opam file is never tested by ocaml-ci. Several users have had the issue in the past where `dune build` works fine but `dune build -p <pkg>` does not (e.g. merlin's testsuite)