### PR TITLE
Update ocamlformat version (no-op, no reformat)

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,2 +1,2 @@
-version = 0.15.0
+version = 0.17.0
 disable = true


### PR DESCRIPTION
This is almost a no-op as ocamlformat is disabled, but makes all the
tests go green on OCaml 4.12 as ocamlformat.0.15 requires < 4.12. This
just statisfies the Opam solver.

(At least that's what I'm hoping for, let's see how the CI actually reacts)