### PR TITLE
Override $HOME and $EMAIL for unit-tests

### DIFF
--- a/test/test.ml
+++ b/test/test.ml
@@ -1,4 +1,8 @@
 let () =
+  Unix.putenv "HOME" "/idontexist";        (* Ignore user's git configuration *)
+  Unix.putenv "GIT_AUTHOR_NAME" "test";
+  Unix.putenv "GIT_COMMITTER_NAME" "test";
+  Unix.putenv "EMAIL" "test@example.com";
   Lwt_main.run
   @@ Alcotest_lwt.run "ocaml-ci"
        [ ("index", Test_index.tests); ("analyse", Test_analyse.tests) ]


### PR DESCRIPTION
Avoids git picking up the user's configuration settings and e.g. trying to sign the test commits.

Fixes #328.