### PR TITLE
Extend the handling of opam-repository in the solver to use multiple

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -18,14 +18,16 @@ module Selection = struct
   type t = {
     id : string;                        (** The platform ID from the request. *)
     packages : string list;             (** The selected packages ("name.version"). *)
-    commit : string;                    (** A commit in opam-repository to use. *)
+    commits : (string * string) list;   (** The commits in each opam-repository repo to use.
+                                            A pair of the repo URL and the commit hash. *)
   } [@@deriving yojson, ord]
 end
 
 (** A request to select sets of packages for the builds. *)
 module Solve_request = struct
   type t = {
-    opam_repository_commit : string;            (** Commit in opam repository to use. *)
+    opam_repository_commits : (string * string) list;
+    (** Pair of repo URL and commit hash, for each opam-repository to use. *)
     root_pkgs : (string * string) list;         (** Name and contents of top-level opam files. *)
     pinned_pkgs : (string * string) list;       (** Name and contents of other pinned opam files. *)
     platforms : (string * Vars.t) list;         (** Possible build platforms, by ID. *)

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -13,7 +13,7 @@ module Analysis : sig
     solver:Ocaml_ci_api.Solver.t ->
     job:Current.Job.t ->
     platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
-    opam_repository_commit:Current_git.Commit_id.t ->
+    opam_repository_commits:Current_git.Commit_id.t list ->
     Fpath.t ->
     (t, [ `Msg of string ]) result Lwt.t
 end
@@ -21,7 +21,7 @@ end
 val examine :
   solver:Ocaml_ci_api.Solver.t ->
   platforms:Platform.t list Current.t ->
-  opam_repository_commit:Current_git.Commit_id.t Current.t ->
+  opam_repository_commits:Current_git.Commit_id.t list Current.t ->
   Current_git.Commit.t Current.t ->
   Analysis.t Current.t
 (** [examine ~solver ~platforms ~opam_repository_commit src] analyses the source code [src] and selects

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -7,8 +7,12 @@ type t = {
 
 let of_worker w =
   let module W = Ocaml_ci_api.Worker.Selection in
-  let { W.id; packages; commit } = w in
+  let { W.id; packages; commits } = w in
   let variant = Variant.of_string id in
+  (* The primary opam-repository commit is required to be the first in the list.
+     We only pass this one through to the worker because the Docker container
+     for the build has only this one cloned to local storage. *)
+  let commit = List.(hd commits |> snd) in
   { variant; packages; commit }
 
 let remove_package t ~package =

--- a/solver/dune
+++ b/solver/dune
@@ -3,4 +3,4 @@
   (public_name ocaml-ci-solver)
   (package ocaml-ci-solver)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries lwt.unix ocaml-ci-api ppx_deriving_yojson.runtime opam-0install capnp-rpc-unix git-unix))
+  (libraries lwt.unix ocaml-ci-api ppx_deriving_yojson.runtime opam-0install capnp-rpc-unix git-unix str))

--- a/solver/epoch_lock.ml
+++ b/solver/epoch_lock.ml
@@ -1,14 +1,14 @@
 open Lwt.Infix
 
-type 'a t = {
+type ('a, 'key) t = {
   mutable current : [
     | `Idle
     | `Activating of unit Lwt.t                      (* Promise resolves after moving to [`Active] *)
-    | `Active of string * 'a
+    | `Active of 'key * 'a
     | `Draining of unit Lwt.t * unit Lwt_condition.t (* Promise resolves after moving back to [`Active] *)
   ];
   mutable users : int;          (* Zero unless active or draining *)
-  create : string -> 'a Lwt.t;
+  create : 'key -> 'a Lwt.t;
   dispose : 'a -> unit Lwt.t;
 }
 

--- a/solver/epoch_lock.mli
+++ b/solver/epoch_lock.mli
@@ -4,14 +4,14 @@
     The solver uses this to handle updates to opam-repository (each commit is a
     separate epoch). *)
 
-type 'a t
+type ('a, 'key) t
 
-val v : create:(string -> 'a Lwt.t) -> dispose:('a -> unit Lwt.t) -> unit -> 'a t
+val v : create:('key -> 'a Lwt.t) -> dispose:('a -> unit Lwt.t) -> unit -> ('a, 'key) t
 (** [v ~create ~dispose ()] is an epoch lock that calls [create] to start a new epoch
     and [dispose] to finish one. A new epoch doesn't start until the old one has been
     disposed. *)
 
-val with_epoch : 'a t -> string -> ('a -> 'b Lwt.t) -> 'b Lwt.t
+val with_epoch : ('a, 'key) t -> 'key -> ('a -> 'b Lwt.t) -> 'b Lwt.t
 (** [with_epoch t epoch fn] runs [fn v] with the [v] for [epoch].
     If we are already in [epoch], [fn] runs immediately.
     If we are already in another epoch then we wait for all users in the

--- a/solver/git_context.ml
+++ b/solver/git_context.ml
@@ -116,7 +116,7 @@ let read_versions store (entry : Store.Value.Tree.entry) =
       ) OpamPackage.Version.Map.empty
     >|= fun versions -> Some versions
 
-let read_packages store commit =
+let read_packages ?(acc = OpamPackage.Name.Map.empty) store commit =
   Search.find store commit (`Commit (`Path ["packages"])) >>= function
   | None -> Fmt.failwith "Failed to find packages directory!"
   | Some tree_hash ->
@@ -132,7 +132,7 @@ let read_packages store commit =
             read_versions store entry >|= function
             | None -> acc
             | Some versions -> OpamPackage.Name.Map.add name versions acc
-        ) OpamPackage.Name.Map.empty
+        ) acc
 
 let create ?(test=OpamPackage.Name.Set.empty) ?(pins=OpamPackage.Name.Map.empty) ~constraints ~env ~packages () =
   { env; packages; pins; constraints; test }

--- a/solver/git_context.mli
+++ b/solver/git_context.mli
@@ -1,6 +1,7 @@
 include Opam_0install.S.CONTEXT
 
 val read_packages :
+  ?acc:OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t ->
   Git_unix.Store.t ->
   Git_unix.Store.Hash.t ->
   OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t Lwt.t

--- a/solver/main.ml
+++ b/solver/main.ml
@@ -44,12 +44,12 @@ let () =
   match Sys.argv with
   | [| prog |] ->
     Lwt_main.run begin
-      let create_worker hash =
-        let cmd = ("", [| prog; "--worker"; Git_unix.Store.Hash.to_hex hash |]) in
+      let create_worker commits =
+        let cmd = ("", [| prog; "--worker"; Remote_commit.list_to_string commits |]) in
         Lwt_process.open_process cmd
       in
       Service.v ~n_workers ~create_worker >>= fun service ->
       export service ~on:Lwt_unix.stdin
     end
-  | [| _prog; "--worker"; hash |] -> Solver.main (Git_unix.Store.Hash.of_hex hash)
+  | [| _prog; "--worker"; commits_str |] -> Solver.main (Remote_commit.list_of_string_or_fail commits_str)
   | args -> Fmt.failwith "Usage: ocaml-ci-solver (got %a)" Fmt.(array (quote string)) args

--- a/solver/opam_repository.ml
+++ b/solver/opam_repository.ml
@@ -3,24 +3,69 @@ open Lwt.Infix
 module Log = Ocaml_ci_api.Solver.Log
 module Store = Git_unix.Store
 
-let clone_path = "opam-repository"
+let default_repo_url = "https://github.com/ocaml/opam-repository.git"
 
-let open_store () =
-  let path = Fpath.v clone_path in
-  Git_unix.Store.v ~dotgit:path path >|= function
-  | Ok x -> x
-  | Error e -> Fmt.failwith "Failed to open opam-repository: %a" Store.pp_error e
+let sanitize_re = Str.regexp "[^A-Za-z-]"
+let git_ext_re = Str.regexp "\\.git$"
 
-let clone () =
-  begin match Unix.lstat clone_path with
+let rec mkdir_p path =
+  try Unix.mkdir path 0o700 with
+  | Unix.Unix_error (EEXIST, _, _) -> ()
+  | Unix.Unix_error (ENOENT, _, _) ->
+      let parent = Filename.dirname path in
+      mkdir_p parent;
+      Unix.mkdir path 0o700
+
+let repo_url_to_clone_path repo_url =
+  (* The unit tests pass "opam-repository" as repo_url to refer to a local clone *)
+  if repo_url = "opam-repository"
+  then
+    Fpath.v "opam-repository"
+  else
+    let uri = Uri.of_string repo_url in
+    let sane_host = match Uri.host uri with
+                    | Some host -> Str.global_replace sanitize_re "_" host
+                    | None -> "no_host"
+    in
+    let sane_path = Uri.(path uri |> pct_decode |> Str.global_replace git_ext_re "" |> Str.global_replace sanitize_re "_") in
+    Fpath.(v sane_host / sane_path)
+
+let clone ?(repo_url = default_repo_url) () =
+  let clone_path = repo_url_to_clone_path repo_url in
+  let clone_parent = Fpath.parent clone_path |> Fpath.to_string in
+  let clone_path_str = Fpath.to_string clone_path in
+  begin match Unix.lstat clone_path_str with
     | Unix.{ st_kind = S_DIR; _ } -> Lwt.return_unit
-    | _ -> Fmt.failwith "%S is not a directory!" clone_path
-    | exception Unix.Unix_error(Unix.ENOENT, _, "opam-repository") ->
-      Process.exec ("", [| "git"; "clone"; "--bare"; "https://github.com/ocaml/opam-repository.git"; clone_path |])
+    | _ -> Fmt.failwith "%S is not a directory!" clone_path_str
+    | exception Unix.Unix_error(Unix.ENOENT, _, _) ->
+      mkdir_p clone_parent;
+      Process.exec ("", [| "git"; "clone"; "--bare"; repo_url; clone_path_str |])
   end
 
-let oldest_commit_with ~from pkgs =
-  let from = Store.Hash.to_hex from in
+let open_store ?(repo_url = default_repo_url) () =
+  clone ~repo_url () >>= fun () ->
+  let path = repo_url_to_clone_path repo_url in
+  Git_unix.Store.v ~dotgit:path path >|= function
+  | Ok x -> x
+  | Error e -> Fmt.failwith "Failed to open %a: %a" Fpath.pp path Store.pp_error e
+
+let is_path_in_repo repo_url path =
+  let clone_path = repo_url_to_clone_path repo_url in
+  match Unix.lstat Fpath.(clone_path / path |> to_string) with
+  | _ -> true
+  | exception _ -> false
+
+let partition_paths_by_repo commits paths =
+  commits |> List.map (fun (repo_url, hash) ->
+    ((repo_url, hash), paths |> List.filter (is_path_in_repo repo_url)))
+
+let oldest_commit_with ~repo_url ~from paths =
+  let clone_path = repo_url_to_clone_path repo_url |> Fpath.to_string in
+  let cmd = "git" :: "-C" :: clone_path :: "log" :: "-n" :: "1" :: "--format=format:%H" :: from :: "--" :: paths in
+  let cmd = ("", Array.of_list cmd) in
+  Process.pread cmd >|= String.trim
+
+let oldest_commits_with ~from pkgs =
   let paths =
     pkgs |> List.map (fun pkg ->
         let name = OpamPackage.name_to_string pkg in
@@ -28,9 +73,12 @@ let oldest_commit_with ~from pkgs =
         Printf.sprintf "packages/%s/%s.%s" name name version
       )
   in
-  let cmd = "git" :: "-C" :: clone_path :: "log" :: "-n" :: "1" :: "--format=format:%H" :: from :: "--" :: paths in
-  let cmd = ("", Array.of_list cmd) in
-  Process.pread cmd >|= String.trim
+  partition_paths_by_repo from paths |> Lwt_list.map_p (fun ((repo_url, hash), paths) ->
+    Lwt.bind
+      (oldest_commit_with ~repo_url ~from:hash paths)
+      (fun commit -> Lwt.return (repo_url, commit))
+  )
 
-let fetch () =
+let fetch ?(repo_url = default_repo_url) () =
+  let clone_path = repo_url_to_clone_path repo_url |> Fpath.to_string in
   Process.exec ("", [| "git"; "-C"; clone_path; "fetch"; "origin"|])

--- a/solver/opam_repository.mli
+++ b/solver/opam_repository.mli
@@ -1,12 +1,17 @@
-val open_store : unit -> Git_unix.Store.t Lwt.t
+val open_store : ?repo_url:string -> unit -> Git_unix.Store.t Lwt.t
+(** Open the local clone of the repo at the given URL.
+    If the local clone does not yet exist, this clones it first.
+    If repo_url is unspecified, it defaults to ocaml/opam-repository on GitHub. *)
 
-val clone : unit -> unit Lwt.t
-(** [clone ()] ensures that "./opam-repository" exists. If not, it clones it. *)
+val clone : ?repo_url:string -> unit -> unit Lwt.t
+(** [clone ()] ensures that a local clone of the specified repo exists. If not, it clones it.
+    If repo_url is unspecified, it defaults to ocaml/opam-repository on GitHub. *)
 
-val oldest_commit_with : from:Git_unix.Store.Hash.t -> OpamPackage.t list -> string Lwt.t
-(** Use "git-log" to find the oldest commit with these package versions.
+val oldest_commits_with : from:(string * string) list -> OpamPackage.t list -> (string * string) list Lwt.t
+(** Use "git-log" to find the oldest commits with these package versions.
     This avoids invalidating the Docker build cache on every update to opam-repository.
-    @param from The commit at which to begin the search. *)
+    @param from The repo_url and commit hash for each opam_repository at which to
+                begin the search. *)
 
-val fetch : unit -> unit Lwt.t
+val fetch : ?repo_url:string -> unit -> unit Lwt.t
 (* Does a "git fetch origin" to update the store. *)

--- a/solver/remote_commit.ml
+++ b/solver/remote_commit.ml
@@ -1,0 +1,30 @@
+type t = {
+  repo : string;
+  hash : string
+} [@@deriving yojson]
+
+let v ~repo ~hash =
+  { repo; hash }
+
+let repo x = x.repo
+let hash x = x.hash
+
+let pp f {repo; hash} =
+  Fmt.pf f "%s (%s)" repo hash
+
+let to_string checkout =
+  to_yojson checkout |> Yojson.Safe.to_string
+
+let of_string str =
+  Yojson.Safe.from_string str |> of_yojson
+
+let list_to_string checkouts =
+  `List (List.map to_yojson checkouts) |> Yojson.Safe.to_string
+
+let of_yojson_or_fail json =
+  match of_yojson json with
+  | Ok x -> x
+  | Error ex -> failwith ex
+
+let list_of_string_or_fail str =
+  List.map of_yojson_or_fail Yojson.Safe.(from_string str |> Util.to_list)

--- a/solver/service.mli
+++ b/solver/service.mli
@@ -1,6 +1,6 @@
 val v :
   n_workers:int ->
-  create_worker:(Git_unix.Store.Hash.t -> Lwt_process.process) ->
+  create_worker:(Remote_commit.t list -> Lwt_process.process) ->
   Ocaml_ci_api.Solver.t Lwt.t
 (** [v ~n_workers ~create_worker] is a solver service that distributes work to up to
     [n_workers] subprocesses, using [create_worker hash] to spawn new workers. *)

--- a/solver/solver.mli
+++ b/solver/solver.mli
@@ -1,3 +1,3 @@
-val main : Git_unix.Store.Hash.t -> unit
+val main : Remote_commit.t list -> unit
 (** [main hash] runs a worker process that reads requests from stdin and writes results to stdout,
-    using commit [hash] in opam-repository. *)
+    using the given commit(s) from opam-repository repos. *)

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -28,13 +28,13 @@ module Analysis = struct
   [@@deriving eq, yojson]
 
 
-  let of_dir ~switch ~job ~platforms ~solver_dir ~opam_repository_commit d =
+  let of_dir ~switch ~job ~platforms ~solver_dir ~opam_repository_commits d =
     let solver = Ocaml_ci.Solver_pool.spawn_local ~solver_dir () in
     Lwt_switch.add_hook (Some switch) (fun () ->
         Capnp_rpc_lwt.Capability.dec_ref solver;
         Lwt.return_unit
       );
-    of_dir ~solver ~job ~platforms ~opam_repository_commit d
+    of_dir ~solver ~job ~platforms ~opam_repository_commits d
     |> Lwt_result.map (fun t ->
            {
              opam_files = opam_files t;
@@ -116,7 +116,7 @@ let expect_test name ~project ~expected =
           ~gref:"master"
       in
       Lwt_switch.with_switch (fun switch ->
-          Analysis.of_dir ~switch ~job ~platforms:Test_platforms.v ~solver_dir ~opam_repository_commit
+          Analysis.of_dir ~switch ~job ~platforms:Test_platforms.v ~solver_dir ~opam_repository_commits:[opam_repository_commit]
             (Fpath.v root)
         )
       >|= (function


### PR DESCRIPTION
such repos.

This allows us to handle the case where some packages in the build are
declared in a separate repo, e.g. ocaml-multicore/multicore-opam.

This extends Opam_repository to accept a repo URL with each call,
and to infer a local directory name based on that URL. This means that
it no longer is hardcoded to use opam-repository as the local clone
name, nor to use the GitHub ocaml/opam-repository as the only repo.

This adds the ability to call oldest_commits_with across multiple repos,
with the semantics that we partition the packages based on which repo
we find them in, and return the oldest commit for each partitioned set.

This extends the solver service to handle multiple opam-repos. To do
this, the API to the service has been changed to pass a
(string * string) list in place of the old opam-repository commit. We
no longer clone opam-repository when the solver service is started, and
instead wait until the first request arrives. To support this,
Opam_repository.open_store will now clone the repo if the local clone
does not yet exist.

This adds a helper module Remote_commit, which is *very* similar to
Current_git.commit_id. It felt wrong to have solver depend on an
Ocurrent plugin, so I added this new module, but I feel like this could be
cleaned up and we could have a utility module somewhere common (maybe even
ocaml-git should be providing this).

This adds a dependency on Str from ocaml-ci-solver, to use a regexp for
sanitizing the repo URL into a local directory name.

Note that all of this doesn't change the way that Opam_build handles
opam-repository.  Our current Docker containers for multicore have
the primary opam-repository cloned locally and registered with opam
through a file: URL, but the multicore repo is registered as a
git://github.com URL. This means that Opam_build retains its
special-case code for refreshing ~/opam-repository inside the container,
and all other refreshing is handled by opam.

Signed-off-by: Ewan Mellor <ewan@tarides.com>