### PR TITLE
Enable verbose mode on the call to Solver.diagnostics.

### DIFF
--- a/solver/solver.ml
+++ b/solver/solver.ml
@@ -38,7 +38,7 @@ let solve ~packages ~pins ~root_pkgs (vars : Worker.Vars.t) =
     let pkgs = Solver.packages_of_result sels in
     Ok (List.map OpamPackage.to_string pkgs)
   | Error diagnostics ->
-    Error (Solver.diagnostics diagnostics)
+    Error (Solver.diagnostics diagnostics ~verbose:true)
 
 let main commit =
   let packages =


### PR DESCRIPTION
Without the verbose flag, the 0install solver will truncate the
rejects list in the diagnostics output at 5 lines. These go into the job
logs, so there's no need to truncate the info.