### PR TITLE
Build dune @check target too

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -97,6 +97,6 @@ let spec ~base ~opam_files ~selection =
     user ~uid:1000 ~gid:1000 ::
     install_project_deps ~opam_files ~selection @ [
       copy ["."] ~dst:"/src/";
-      run "opam exec -- dune build @install @runtest && rm -rf _build"
+      run "opam exec -- dune build @install @check @runtest && rm -rf _build"
     ]
   )


### PR DESCRIPTION
This is useful to typecheck code that isn't tested or installed (e.g. examples and benchmarks).