### PR TITLE
Fix solver worker failed: Unexpected end of input

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard 1d088847ed8e4e6329c1f4a79961eb647fac0aea && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard c731a125bc8f1483494f44b5f9a85be92e022f9d && opam update
 COPY --chown=opam \
 	ocurrent/current_ansi.opam \
 	ocurrent/current_docker.opam \

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN opam pin add -yn current_ansi.dev "./ocurrent" && \
     opam pin add -yn dockerfile-opam.dev "./ocaml-dockerfile" && \
     opam pin add -yn ocluster-api.dev "./ocluster"
 COPY --chown=opam ocaml-ci-service.opam ocaml-ci-api.opam ocaml-ci-solver.opam /src/
-RUN opam install -y --deps-only .
+RUN opam-2.1 install -y --deps-only .
 ADD --chown=opam . .
 RUN opam config exec -- dune build ./_build/install/default/bin/ocaml-ci-service
 

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-10-ocaml-4.10 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard 9bbd0b24881972dc797346d711598d22e54edf0b && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard c731a125bc8f1483494f44b5f9a85be92e022f9d && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	ocurrent/current_ansi.opam \

--- a/dune-project
+++ b/dune-project
@@ -57,7 +57,10 @@
   conf-libev
   (opam-0install (>= "0.2"))
   (git-unix (>= 3.2.0))
-  (capnp-rpc-unix (>= 0.7.0))))
+  (capnp-rpc-unix (>= 0.7.0)))
+ (conflicts
+  (carton (< 0.4.2))) ; workaround for mirage/ocaml-git#514
+)
 (package
  (name ocaml-ci-web)
  (synopsis "Web-server frontend for ocaml-ci")

--- a/ocaml-ci-solver.opam
+++ b/ocaml-ci-solver.opam
@@ -19,6 +19,9 @@ depends: [
   "git-unix" {>= "3.2.0"}
   "capnp-rpc-unix" {>= "0.7.0"}
 ]
+conflicts: [
+  "carton" {< "0.4.2"}
+]
 build: [
   ["dune" "subst"] {pinned}
   [


### PR DESCRIPTION
In some cases, the C git client can create pack files that ocaml-git cannot read. See mirage/ocaml-git#514, mirage/ocaml-git#515.

This is fixed in `carton.0.4.2` (an internal dependency of `ocaml-git`). Since we do not directly use it in `ocaml-ci`, this upgrade is done through a `conflicts` clause.

It can be removed once a version of `ocaml-git` is released with a bound to `carton` greater than `0.4.2`.
