### PR TITLE
Make the opam-monorepo runs more reliable by removing any non-cached downloads

### DIFF
--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -154,7 +154,7 @@ let install_depexts ~network ~cache ~package ~lock_file_version =
   match lock_file_version with
   | V0_1 ->
       [
-        run ~network ~cache "opam pin -n add %s . --locked" package;
+        run ~network ~cache "opam pin -n add %s . --locked --ignore-pin-depends" package;
         run ~network ~cache "opam depext --update -y %s" package;
         run ~network ~cache "opam pin -n remove %s" package;
       ]


### PR DESCRIPTION
The pin-depends do not have any checksums, thus opam when pinning the target package will re-download the archives everytime regardless of whether or not it is in the download-cache or not (as it cannot check if the archive is correct without a checksum)
Examples of network failure can be found here: https://ci.ocamllabs.io/github/realworldocaml/book/commit/6f826a4d14fd0de721ff850b37e60148522fd956/variant/debian-10-4.10
Related to https://github.com/ocaml/opam/issues/4737

This PR should fix this by simply not downloading any of the pin-depends' archives.
I haven't tested this as I do not have the time right now, but if someone else is confident, feel free to merge.