### PR TITLE
Update to latest opam-dune-lint

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -51,7 +51,7 @@ let install_opam_dune_lint ~cache ~network ~base =
   let open Obuilder_spec in
   stage ~from:base [
     user ~uid:1000 ~gid:1000;
-    run ~cache ~network "git -C ~/opam-repository pull origin master && opam update && opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#cee939bea06b2411008798e9e2d067114a190616";
+    run ~cache ~network "git -C ~/opam-repository pull origin master && opam update && opam pin add -yn opam-dune-lint.dev https://github.com/ocurrent/opam-dune-lint.git#a431a1128b9564d1b3d08b8bee2977be47bc6b6b";
     run ~cache ~network "opam depext -i opam-dune-lint";
     run "sudo cp $(opam exec -- which opam-dune-lint) /usr/local/bin/";
   ]


### PR DESCRIPTION
Includes quotes in output for easy cut-and-paste, and handles projects with no `(depends)` at all in their dune-project file.