### PR TITLE
Always pull opam-repository first when ocamlformat is vendored

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -7,7 +7,7 @@ let install_ocamlformat =
     let opam_file = Filename.concat path "ocamlformat.opam" in
     [
       copy [ opam_file ] ~dst:opam_file;
-      run ~network "opam pin add -k path -n ocamlformat %S" path;
+      run ~network "git -C ~/opam-repository pull origin master && opam update && opam pin add -k path -n ocamlformat %S" path;
       (* Pinned to a directory containing only the .opam file *)
       run ~network "opam depext ocamlformat";
       run ~network ~cache "opam install --deps-only -y ocamlformat";


### PR DESCRIPTION
Detected in https://github.com/ocaml-ppx/ocamlformat/pull/1683
Since a recent package was required, the `(lint-fmt)` step failed with:
```
/src: (run (network host)
           (shell "opam depext ocamlformat"))
# Detecting depexts using vars: arch=x86_64, os=linux, os-distribution=debian, os-family=debian
[ERROR] No solution for ocamlformat: The following dependencies couldn't be met:
          - ocamlformat -> odoc-parser
              unknown package

Command failed: opam list --readonly --external  '--resolve=ocamlformat' returned 20
"/bin/bash" "-c" "opam depext ocamlformat" failed with exit status 20
```
This morally does the same thing as https://github.com/ocurrent/ocaml-ci/pull/305 but for (vendored) ocamlformat instead of opam-dune-lint.