### PR TITLE
Make the (lint-fmt) phase depend on the minimal commit to avoid issues when projects fail because they require a newer dune version

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -34,7 +34,7 @@ let make_build_spec ~base ~repo ~variant ~ty =
     | `Opam (`Build, selection, opam_files) -> Opam_build.spec ~base ~opam_files ~selection
     | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
     | `Opam (`Lint `Opam, selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files ~selection
-    | `Opam_fmt ocamlformat_source -> Lint.fmt_spec ~base ~ocamlformat_source
+    | `Opam_fmt (selection, ocamlformat_source) -> Lint.fmt_spec ~base ~ocamlformat_source ~selection
     | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant
 
 module Op = struct

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -66,7 +66,7 @@ module Op = struct
       match ty with
       | `Opam (`Build, selection, _) -> hash_packages selection.packages
       | `Opam (`Lint (`Doc|`Opam), selection, _) -> hash_packages selection.packages
-      | `Opam_fmt _ -> "ocamlformat"
+      | `Opam_fmt (selection, _) -> "ocamlformat-" ^ selection.Selection.commit
       | `Opam_monorepo _ -> "opam-monorepo-" ^ (Variant.to_string variant)
     in
     Fmt.strf "%s/%s-%s-%a-%s"

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,6 +1,7 @@
 val fmt_spec :
   base:string ->
   ocamlformat_source:Analyse_ocamlformat.source option ->
+  selection:Selection.t ->
   Obuilder_spec.t
 (** A build spec that checks the formatting. *)
 

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -2,7 +2,7 @@ type opam_files = string list [@@deriving to_yojson, ord]
 
 type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * opam_files
-  | `Opam_fmt of Analyse_ocamlformat.source option
+  | `Opam_fmt of Selection.t * Analyse_ocamlformat.source option
   | `Opam_monorepo of Opam_monorepo.config
 ] [@@deriving to_yojson, ord]
 
@@ -17,7 +17,7 @@ let opam ~label ~selection ~analysis op =
   let ty =
     match op with
     | `Build | `Lint (`Doc | `Opam) as x -> `Opam (x, selection, Analyse.Analysis.opam_files analysis)
-    | `Lint `Fmt -> `Opam_fmt (Analyse.Analysis.ocamlformat_source analysis)
+    | `Lint `Fmt -> `Opam_fmt (selection, Analyse.Analysis.ocamlformat_source analysis)
   in
   { label; variant; ty }
 
@@ -37,6 +37,7 @@ let pp_summary f = function
   | `Opam (`Build, _, _) -> Fmt.string f "Opam project build"
   | `Opam (`Lint `Doc, _, _) -> Fmt.string f "Opam project lint documentation"
   | `Opam (`Lint `Opam, _, _) -> Fmt.string f "Opam files lint"
-  | `Opam_fmt v -> Fmt.pf f "ocamlformat version: %a"
-                     Fmt.(option ~none:(unit "none") Analyse_ocamlformat.pp_source) v
+  | `Opam_fmt (_, v) ->
+      Fmt.pf f "ocamlformat version: %a"
+        Fmt.(option ~none:(unit "none") Analyse_ocamlformat.pp_source) v
   | `Opam_monorepo _ -> Fmt.string f "opam-monorepo build"

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -1,6 +1,6 @@
 type ty = [
   | `Opam of [ `Build | `Lint of [ `Doc | `Opam ]] * Selection.t * string list
-  | `Opam_fmt of Analyse_ocamlformat.source option
+  | `Opam_fmt of Selection.t * Analyse_ocamlformat.source option
   | `Opam_monorepo of Opam_monorepo.config
 ] [@@deriving to_yojson, ord]
 


### PR DESCRIPTION
Issue encountered in https://ci.ocamllabs.io/github/ocaml/merlin/commit/122369c769636890ca6b094f4d0595d2522b546b/variant/(lint-fmt)