### PR TITLE
Report state on a Matrix server

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "ocaml-dockerfile"]
 	path = ocaml-dockerfile
 	url = https://github.com/avsm/ocaml-dockerfile.git
+[submodule "ocaml-matrix"]
+	path = ocaml-matrix
+	url = https://github.com/clecat/ocaml-matrix.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,12 @@ COPY --chown=opam \
 COPY --chown=opam \
 	ocaml-dockerfile/dockerfile*.opam \
 	/src/ocaml-dockerfile/
+COPY --chown=opam \
+	ocaml-matrix/matrix-client.opam \
+	ocaml-matrix/matrix-common.opam \
+	ocaml-matrix/matrix-ctos.opam \
+	ocaml-matrix/matrix-current.opam \
+	/src/ocaml-matrix/
 WORKDIR /src
 RUN opam pin add -yn current_docker.dev "./ocurrent" && \
     opam pin add -yn current_github.dev "./ocurrent" && \
@@ -32,6 +38,10 @@ RUN opam pin add -yn current_docker.dev "./ocurrent" && \
     opam pin add -yn ocaml-version.dev "./ocaml-version" && \
     opam pin add -yn dockerfile.dev "./ocaml-dockerfile" && \
     opam pin add -yn dockerfile-opam.dev "./ocaml-dockerfile" && \
+	opam pin add -yn matrix-client.dev "./ocaml-matrix" && \
+	opam pin add -yn matrix-common.dev "./ocaml-matrix" && \
+	opam pin add -yn matrix-ctos.dev "./ocaml-matrix" && \
+	opam pin add -yn matrix-current.dev "./ocaml-matrix" && \
     opam pin add -yn ocluster-api.dev "./ocluster"
 COPY --chown=opam ocaml-ci-service.opam ocaml-ci-api.opam ocaml-ci-solver.opam /src/
 RUN opam-2.1 install -y --deps-only .

--- a/dune
+++ b/dune
@@ -1,2 +1,11 @@
 (dirs :standard \ var)
-(vendored_dirs capnp-ocaml capnp-rpc ocurrent opam-0install-solver ocluster ocaml-version ocaml-dockerfile)
+
+(vendored_dirs
+ capnp-ocaml
+ capnp-rpc
+ ocurrent
+ opam-0install-solver
+ ocluster
+ ocaml-version
+ ocaml-dockerfile
+ ocaml-matrix)

--- a/dune-project
+++ b/dune-project
@@ -41,6 +41,7 @@
   conf-libev
   (dockerfile-opam (>= 7.0.0))
   (ocaml-version (>= 3.0.0))
+  matrix-client
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))))
 (package

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -29,6 +29,7 @@ depends: [
   "conf-libev"
   "dockerfile-opam" {>= "7.0.0"}
   "ocaml-version" {>= "3.0.0"}
+  "matrix-client"
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
 ]

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -8,6 +8,11 @@ let profile =
    Don't bother testing these. *)
 let max_staleness = Duration.of_day 93
 
+(* List of admins for rooms managed by the CI bot. *)
+let matrix_admins = [
+  "@avsm:recoil.org"
+]
+
 module Capnp = struct
   (* Cap'n Proto RPC is enabled by passing --capnp-public-address. These values are hard-coded
      (because they're just internal to the Docker container). *)

--- a/service/dune
+++ b/service/dune
@@ -12,6 +12,7 @@
             ocluster-api
             capnp-rpc-unix
             mirage-crypto-rng.unix
+            matrix-current
             ocaml_ci
             ocaml-ci-api
             prometheus-app.unix)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -59,6 +59,137 @@ let github_status_of_state ~head result results =
   | Error (`Msg m) ->
      Github.Api.CheckRunStatus.v ~url (`Completed (`Failure m)) ~summary
 
+module Matrix = struct
+  (*
+  Structure of a message
+
+  ```
+  <h1> ❌ PR <a>#37</a></h1>
+  <ul>
+    <li> ✅ <b>analysis</b>: <a>passed</a> </li>
+    <li> ✅ <b>debian-10-4.12_arm32</b>: <a>passed</a> </li>
+    <li> ✅ <b>lint</b>: <a>passed</a> </li>
+    <li> ❌ <b>lint-fmt</b>: <a>failed</a> <blockquote>...</blockquote> </li>
+  </ul>
+  *)
+
+  let parse_git_ref ref = match String.split_on_char '/' ref with
+  | ["refs"; "heads"; b] -> `Branch b
+  | ["refs"; "pull"; p; "head"] -> `PR p
+  | _ -> failwith ("Failed to parse git ref: " ^ ref)
+
+  let result_symbol =
+    function
+    | Ok `Checked | Ok `Built-> "✅"
+    | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m ->
+      "¯\\_(ツ)_/¯"
+    | Error `Msg _ -> "❌"
+    | Error `Active _ -> "🟠"
+
+  module Html = struct
+
+    let pp_message_job ~head f (variant, (build, _)) =
+      let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
+      let hash = Github.Api.Commit.hash head in
+      let job_ci_url = url_variant ~owner ~name ~hash ~variant in
+      let result =
+        match build with
+        | Ok `Checked | Ok `Built->
+          "passed"
+        | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m ->
+          "skipped"
+        | Error `Msg m ->
+          "failed <blockquote>"^m^"</blockquote>"
+        | Error `Active _ ->
+          "active"
+      in
+      Fmt.pf f "%s <b><a href='%s'>%s</a></b>: %s" (result_symbol build) job_ci_url variant result
+
+    let pp_heading f head =
+      let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
+      let hash = head |> Github.Api.Commit.id |> Git.Commit_id.hash in
+      let ci_url = url ~owner ~name ~hash in
+      let hash = String.sub hash 0 7 in
+      match head |> Github.Api.Commit.id |> Git.Commit_id.gref |> parse_git_ref with 
+      | `PR p -> Fmt.pf f "PR <a href='https://github.com/%s/%s/pull/%s'>#%s</a>: job <a href='%a'><code><small>%s</small></code></a>" owner name p p Uri.pp ci_url hash
+      | `Branch b -> Fmt.pf f "Branch <a href='https://github.com/%s/%s/tree/%s'>%s</a>: job <a href='%a'><code><small>%s</small></code></a>" owner name b b Uri.pp ci_url hash
+
+    let pp_message_full ~head result f results =
+      let pp_message_job ~head f = Fmt.pf f "<li>%a</li>" (pp_message_job ~head) in 
+      Fmt.pf f "<h1>%s %a</h1> <ul>%a</ul>" 
+        (result_symbol result) 
+        pp_heading head 
+        (Fmt.list (pp_message_job ~head)) (List.sort (fun (x, _) (y,_) -> String.compare x y) results)
+
+  end
+
+  module Plain = struct 
+
+    let pp_message_job ~head f (variant, (build, _)) =
+      let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
+      let hash = Github.Api.Commit.hash head in
+      let job_ci_url = url_variant ~owner ~name ~hash ~variant in
+      let result = 
+        match build with
+        | Ok `Checked | Ok `Built->
+          "passed"
+        | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m ->
+          "skipped" 
+        | Error `Msg m ->
+          "failed: "^m
+        | Error `Active _ ->
+          "active"
+      in
+      Fmt.pf f "%s %s (%s): %s" (result_symbol build) variant job_ci_url result
+
+    let pp_heading f head =
+      let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
+      let hash = head |> Github.Api.Commit.id |> Git.Commit_id.hash in
+      let ci_url = url ~owner ~name ~hash in
+      let hash = String.sub hash 0 7 in
+      match head |> Github.Api.Commit.id |> Git.Commit_id.gref |> parse_git_ref with 
+      | `PR p -> Fmt.pf f "PR #%s (https://github.com/%s/%s/pull/%s): job %s (%a))" p owner name p hash Uri.pp ci_url
+      | `Branch b -> Fmt.pf f "Branch %s (https://github.com/%s/%s/tree/%s): job %s (%a))" b owner name b hash Uri.pp ci_url
+
+    let pp_message_full ~head result f results =
+      let pp_message_job ~head f = Fmt.pf f "- %a" (pp_message_job ~head) in 
+      Fmt.pf f "%s %a:\n%a" 
+        (result_symbol result) 
+        pp_heading head 
+        (Fmt.list ~sep:Fmt.(const string "\n") (pp_message_job ~head)) (List.sort (fun (x, _) (y,_) -> String.compare x y) results)
+
+  end
+
+  (* In order not to spam the channel on each CI update, we send a full message 
+     only when the final result is known. *)
+  let message_of_state ~head result results =
+    let+ head = head
+    and+ result = result
+    and+ results = results
+    in
+    let result = Result.map (fun () -> `Checked) result in
+    let open Matrix_common.Events.Event_content.Message in
+    let body, formatted_body = match result with 
+      | Ok _ | Error (`Msg _) -> 
+        Fmt.to_to_string (Plain.pp_message_full ~head result) results,
+        Fmt.to_to_string (Html.pp_message_full ~head result) results
+      | _ -> 
+        Fmt.str "🟠 %a" (Plain.pp_heading) head,
+        Fmt.str "<h2>🟠 %a</h2>" (Html.pp_heading) head
+    in
+    (Text (Text.make ~body ~format:"org.matrix.custom.html" ~formatted_body ()))
+
+  let get_room ~repo matrix = 
+    let alias =
+      let+ repo = repo in
+      let id = Github.Api.Repo.id repo in
+      (* we rely on the fact that allowed Github repository names is a subset of allowed Matrix channel names. *)
+      "ocaml-ci/" ^ id.owner ^ "/" ^ id.name
+    in 
+    Option.map (fun context -> Matrix_current.Room.make context ~alias ()) matrix 
+  
+end
+
 let set_active_installations installations =
   let+ installations = installations in
   installations
@@ -191,7 +322,7 @@ let local_test ~solver repo () =
   in
   Current_incr.const (result, None)
 
-let v ?ocluster ~app ~solver () =
+let v ?ocluster ?matrix ~app ~solver () =
   let ocluster = Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster in
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->
@@ -200,6 +331,7 @@ let v ?ocluster ~app ~solver () =
   let repos = Github.Installation.repositories installation |> set_active_repos ~installation in
   repos |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo) @@ fun repo ->
   let refs = Github.Api.Repo.ci_refs ~staleness:Conf.max_staleness repo |> set_active_refs ~repo in
+  let matrix_room = Matrix.get_room ~repo matrix in
   refs |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
   let src = Git.fetch (Current.map Github.Api.Commit.id head) in
   let analysis = Analyse.examine ~solver ~platforms ~opam_repository_commit src in
@@ -230,5 +362,18 @@ let v ?ocluster ~app ~solver () =
     builds
     |> github_status_of_state ~head summary
     |> Github.Api.CheckRun.set_status head "ocaml-ci"
+  and set_matrix_status =
+    match matrix, matrix_room with 
+    | None, None -> Current.return ()
+    | Some context, Some room -> 
+      let key =
+        let+ head = head in
+        Github.Api.Commit.id head
+        |> Git.Commit_id.digest
+      in
+      builds 
+      |> Matrix.message_of_state ~head summary
+      |> Matrix_current.post context ~key ~room
+    | _ -> assert false
   in
-  Current.all [index; set_github_status]
+  Current.all [index; set_github_status; set_matrix_status]

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -110,31 +110,31 @@ module Matrix = struct
       let hash = head |> Github.Api.Commit.id |> Git.Commit_id.hash in
       let ci_url = url ~owner ~name ~hash in
       let hash = String.sub hash 0 7 in
-      match head |> Github.Api.Commit.id |> Git.Commit_id.gref |> parse_git_ref with 
+      match head |> Github.Api.Commit.id |> Git.Commit_id.gref |> parse_git_ref with
       | `PR p -> Fmt.pf f "PR <a href='https://github.com/%s/%s/pull/%s'>#%s</a>: job <a href='%a'><code><small>%s</small></code></a>" owner name p p Uri.pp ci_url hash
       | `Branch b -> Fmt.pf f "Branch <a href='https://github.com/%s/%s/tree/%s'>%s</a>: job <a href='%a'><code><small>%s</small></code></a>" owner name b b Uri.pp ci_url hash
 
     let pp_message_full ~head result f results =
-      let pp_message_job ~head f = Fmt.pf f "<li>%a</li>" (pp_message_job ~head) in 
-      Fmt.pf f "<h1>%s %a</h1> <ul>%a</ul>" 
-        (result_symbol result) 
-        pp_heading head 
+      let pp_message_job ~head f = Fmt.pf f "<li>%a</li>" (pp_message_job ~head) in
+      Fmt.pf f "<h1>%s %a</h1> <ul>%a</ul>"
+        (result_symbol result)
+        pp_heading head
         (Fmt.list (pp_message_job ~head)) (List.sort (fun (x, _) (y,_) -> String.compare x y) results)
 
   end
 
-  module Plain = struct 
+  module Plain = struct
 
     let pp_message_job ~head f (variant, (build, _)) =
       let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
       let hash = Github.Api.Commit.hash head in
       let job_ci_url = url_variant ~owner ~name ~hash ~variant in
-      let result = 
+      let result =
         match build with
         | Ok `Checked | Ok `Built->
           "passed"
         | Error `Msg m when Astring.String.is_prefix ~affix:"[SKIP]" m ->
-          "skipped" 
+          "skipped"
         | Error `Msg m ->
           "failed: "^m
         | Error `Active _ ->
@@ -147,20 +147,20 @@ module Matrix = struct
       let hash = head |> Github.Api.Commit.id |> Git.Commit_id.hash in
       let ci_url = url ~owner ~name ~hash in
       let hash = String.sub hash 0 7 in
-      match head |> Github.Api.Commit.id |> Git.Commit_id.gref |> parse_git_ref with 
+      match head |> Github.Api.Commit.id |> Git.Commit_id.gref |> parse_git_ref with
       | `PR p -> Fmt.pf f "PR #%s (https://github.com/%s/%s/pull/%s): job %s (%a))" p owner name p hash Uri.pp ci_url
       | `Branch b -> Fmt.pf f "Branch %s (https://github.com/%s/%s/tree/%s): job %s (%a))" b owner name b hash Uri.pp ci_url
 
     let pp_message_full ~head result f results =
-      let pp_message_job ~head f = Fmt.pf f "- %a" (pp_message_job ~head) in 
-      Fmt.pf f "%s %a:\n%a" 
-        (result_symbol result) 
-        pp_heading head 
+      let pp_message_job ~head f = Fmt.pf f "- %a" (pp_message_job ~head) in
+      Fmt.pf f "%s %a:\n%a"
+        (result_symbol result)
+        pp_heading head
         (Fmt.list ~sep:Fmt.(const string "\n") (pp_message_job ~head)) (List.sort (fun (x, _) (y,_) -> String.compare x y) results)
 
   end
 
-  (* In order not to spam the channel on each CI update, we send a full message 
+  (* In order not to spam the channel on each CI update, we send a full message
      only when the final result is known. *)
   let message_of_state ~head result results =
     let+ head = head
@@ -169,38 +169,52 @@ module Matrix = struct
     in
     let result = Result.map (fun () -> `Checked) result in
     let open Matrix_common.Events.Event_content.Message in
-    let body, formatted_body = match result with 
-      | Ok _ | Error (`Msg _) -> 
+    let body, formatted_body = match result with
+      | Ok _ | Error (`Msg _) ->
         Fmt.to_to_string (Plain.pp_message_full ~head result) results,
         Fmt.to_to_string (Html.pp_message_full ~head result) results
-      | _ -> 
+      | _ ->
         Fmt.str "🟠 %a" (Plain.pp_heading) head,
         Fmt.str "<h2>🟠 %a</h2>" (Html.pp_heading) head
     in
     (Text (Text.make ~body ~format:"org.matrix.custom.html" ~formatted_body ()))
 
+(* power levels (https://matrix.org/docs/spec/client_server/latest#m-room-power-levels)
+   any user is 0
+   bot user is 100 (creator of the room)
+   any user in Conf.matrix_admins is 100
+
+   anyone can send any kind of message event
+   power level >50 to send state events (including to change power_levels)
+*)
+  let power_level_content_override =
+    let admins = Conf.matrix_admins |> List.map (fun admin -> (admin, 100)) in
+    let users = admins in
+    Current.return @@
+    Matrix_common.Events.Event_content.Power_levels.make ~users ()
+
   let get_room_for ~alias =
-    function 
-    | None -> None 
-    | Some context -> Some (Matrix_current.Room.make context ~alias ())
+    function
+    | None -> None
+    | Some context -> Some (Matrix_current.Room.make context ~alias ~power_level_content_override ())
 
   let get_org_room ~installation =
     let alias =
       let+ installation = installation in
       let account = Github.Installation.account installation in
       "ocaml-ci/" ^ account
-    in 
+    in
     get_room_for ~alias
 
-  let get_room ~repo = 
+  let get_room ~repo =
     let alias =
       let+ repo = repo in
       let id = Github.Api.Repo.id repo in
       (* we rely on the fact that allowed Github repository names is a subset of allowed Matrix channel names. *)
       "ocaml-ci/" ^ id.owner ^ "/" ^ id.name
-    in 
+    in
     get_room_for ~alias
-  
+
 end
 
 let set_active_installations installations =
@@ -377,9 +391,9 @@ let v ?ocluster ?matrix ~app ~solver () =
     |> github_status_of_state ~head summary
     |> Github.Api.CheckRun.set_status head "ocaml-ci"
   and set_matrix_status =
-    match matrix, matrix_room, matrix_org_room with 
+    match matrix, matrix_room, matrix_org_room with
     | None, None, None -> Current.return ()
-    | Some context, Some room, Some org_room -> 
+    | Some context, Some room, Some org_room ->
       let key =
         let+ head = head in
         Github.Api.Commit.id head

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -188,7 +188,7 @@ module Matrix = struct
    power level >50 to send state events (including to change power_levels)
 *)
   let power_level_content_override =
-    let admins = Conf.matrix_admins |> List.map (fun admin -> (admin, 100)) in
+    let admins = ("@ocaml-ci:ocamllabs.io" :: Conf.matrix_admins) |> List.map (fun admin -> (admin, 100)) in
     let users = admins in
     Current.return @@
     Matrix_common.Events.Event_content.Power_levels.make ~users ()

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -3,6 +3,7 @@ val local_test : solver:Ocaml_ci_api.Solver.t -> Current_git.Local.t -> unit -> 
 
 val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
+  ?matrix:Matrix_current.context ->
   app:Current_github.App.t ->
   solver:Ocaml_ci_api.Solver.t ->
   unit -> unit Current.t

--- a/stack.yml
+++ b/stack.yml
@@ -9,10 +9,12 @@ secrets:
     external: true
   ocaml-ci-submission.cap:
     external: true
+  matrix-pass:
+    external: true
 services:
   ci:
     image: ocurrent/ocaml-ci-service:live
-    command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-allowlist "talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,roburio,misterda,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci.ocamllabs.io:8102 --github-oauth /run/secrets/ocaml-ci-oauth --submission-service /run/secrets/ocaml-ci-submission.cap
+    command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-allowlist "talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,roburio,misterda,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV" --confirm above-average --confirm-auto-release 120 --capnp-address=tcp:ci.ocamllabs.io:8102 --github-oauth /run/secrets/ocaml-ci-oauth --submission-service /run/secrets/ocaml-ci-submission.cap --matrix-passfile /run/secrets/matrix-pass --matrix-user ocaml-ci --matrix-host=matrix.ocamllabs.io
     environment:
       - "CI_PROFILE=production"
       - "DOCKER_BUILDKIT=1"
@@ -27,6 +29,7 @@ services:
       - 'ocaml-ci-oauth'
       - 'ocaml-ci-github-key'
       - 'ocaml-ci-submission.cap'
+      - 'matrix-pass'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
   web:


### PR DESCRIPTION
This PR adds a way for the CI to publish its status on a Matrix server using a bot account. 

The credentials are passed using command line arguments: `--matrix-user`, `--matrix-host`, `--matrix-passfile`. If one of the arguments is not available, then the Matrix publication is disabled.

For each project, a read-only room is created: for example `#ocurrent/ocaml-ci:matrix.ocamllabs.io`. So as a warning, **this bot will create many rooms on the server**, maybe we should use a separate server for that purpose.

The message is styled using a subset of HTML, and currently looks like this:
![Screenshot 2021-08-31 at 12-34-56 Element TheLortex ocurrent](https://user-images.githubusercontent.com/966015/131503296-475c7fb3-b722-4912-b103-dc93e350883a.png)