### PR TITLE
Constrain obuilder-spec to 0.3

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -37,7 +37,7 @@
   ocaml-ci-api
   ocaml-ci-solver
   ocluster-api
-  obuilder-spec
+  (obuilder-spec (= 0.3))
   conf-libev
   (dockerfile-opam (>= 7.0.0))
   (ocaml-version (>= 3.0.0))

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -25,7 +25,7 @@ depends: [
   "ocaml-ci-api"
   "ocaml-ci-solver"
   "ocluster-api"
-  "obuilder-spec"
+  "obuilder-spec" {= "0.3"}
   "conf-libev"
   "dockerfile-opam" {>= "7.0.0"}
   "ocaml-version" {>= "3.0.0"}


### PR DESCRIPTION
There'll be some changes to obuilder-spec with the Docker backend. As it's not vendored in this repo, add a version constraint to the current released version.