### PR TITLE
services: start the solver in main term

### DIFF
--- a/service/local.ml
+++ b/service/local.ml
@@ -1,13 +1,12 @@
 (* Utility program for testing the CI pipeline on a local repository. *)
 
-let solver = Ocaml_ci.Solver_pool.spawn_local ()
-
 let () =
   Unix.putenv "DOCKER_BUILDKIT" "1";
   Unix.putenv "PROGRESS_NO_TRUNC" "1";
   Prometheus_unix.Logging.init ()
 
 let main config mode repo : ('a, [`Msg of string]) result =
+  let solver = Ocaml_ci.Solver_pool.spawn_local () in
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine = Current.Engine.create ~config (Pipeline.local_test ~solver repo) in
   let site = Current_web.Site.(v ~has_role:allow_all) ~name:"ocaml-ci-local" (Current_web.routes engine) in

--- a/service/main.ml
+++ b/service/main.ml
@@ -40,8 +40,6 @@ module Metrics = struct
     Gauge.set (master "active") (float_of_int active)
 end
 
-let solver = Ocaml_ci.Solver_pool.spawn_local ()
-
 let () =
   Prometheus_unix.Logging.init ();
   Mirage_crypto_rng_unix.initialize ();
@@ -86,6 +84,7 @@ let has_role user = function
 
 let main config mode app capnp_address github_auth submission_uri : ('a, [`Msg of string]) result =
   Lwt_main.run begin
+    let solver = Ocaml_ci.Solver_pool.spawn_local () in
     run_capnp capnp_address >>= fun (vat, rpc_engine_resolver) ->
     let ocluster = Option.map (Capnp_rpc_unix.Vat.import_exn vat) submission_uri in
     let engine = Current.Engine.create ~config (Pipeline.v ?ocluster ~app ~solver) in


### PR DESCRIPTION
If the solver starts uncoditionnally in the top-level, then

    dune exec -- ocaml-ci-local --help

would also start the solver in the background.