### PR TITLE
Set ocaml-ci-service cmdliner's name to ocaml-ci-service

### DIFF
--- a/service/main.ml
+++ b/service/main.ml
@@ -133,6 +133,6 @@ let cmd =
   Term.(term_result (const main $ Current.Config.cmdliner $ Current_web.cmdliner $
                      Current_github.App.cmdliner $ capnp_address $ Current_github.Auth.cmdliner $ submission_service $
                      Matrix_current.cmdliner)),
-  Term.info "ocaml-ci" ~doc
+  Term.info "ocaml-ci-service" ~doc
 
 let () = Term.(exit @@ eval cmd)


### PR DESCRIPTION
`"ocaml-ci"` alone is the name of the client, the installed executable name is `"ocaml-ci-service"`, so set cmdliner's name to `"ocaml-ci-service"` to avoid me getting confused.