### PR TITLE
Add 4.13 to dev builds

### DIFF
--- a/service/conf.ml
+++ b/service/conf.ml
@@ -94,5 +94,5 @@ let platforms =
       let ovs = List.rev OV.Releases.recent @ OV.Releases.unreleased_betas in
       List.map make_release ovs @ distros
   | `Dev ->
-      let ovs = List.map OV.of_string_exn ["4.12"; "4.11"; "4.03"] in
+      let ovs = List.map OV.of_string_exn ["4.13"; "4.12"; "4.03"] in
       List.map make_release ovs @ [make_release ~arch:`I386 (List.hd ovs)]


### PR DESCRIPTION
Now that 4.13 is out, this allows local testing.
