### PR TITLE
monorepo: create one build per lockfile

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -6,7 +6,7 @@ module Analysis : sig
 
   val selections : t -> [
       | `Opam_build of Selection.t list
-      | `Opam_monorepo of Opam_monorepo.config
+      | `Opam_monorepo of Opam_monorepo.config list
     ]
 
   val of_dir :

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -1,7 +1,7 @@
 type info
 
 (** Detect whether a project uses opam-monorepo or something else. *)
-val detect : dir:Fpath.t -> info option
+val detect : dir:Fpath.t -> info list option
 
 type config [@@deriving yojson, ord]
 
@@ -17,7 +17,7 @@ val selection :
      pinned_pkgs:(string * string) list ->
      platforms:(Variant.t * Ocaml_ci_api.Worker.Vars.t) list ->
      (Selection.t list, Rresult.R.msg) Lwt_result.t) ->
-  ([> `Opam_monorepo of config ], Rresult.R.msg) Lwt_result.t
+  (config, Rresult.R.msg) Lwt_result.t
 
 (** Describe build steps *)
 val spec :

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -265,12 +265,10 @@ let build_with_docker ?ocluster ~repo ~analysis source =
         []
     | Ok analysis ->
       match Analyse.Analysis.selections analysis with
-      | `Opam_monorepo config ->
-        let lint_selection = Opam_monorepo.selection_of_config config in
-        [
-          Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis (`Lint `Fmt);
-          Spec.opam_monorepo ~config
-        ]
+      | `Opam_monorepo builds ->
+        let lint_selection = Opam_monorepo.selection_of_config (List.hd builds) in
+        Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis (`Lint `Fmt)
+        :: List.map (fun config -> Spec.opam_monorepo ~config) builds
       | `Opam_build selections ->
         let lint_selection = List.hd selections in
         let builds =


### PR DESCRIPTION
Since opam-monorepo 0.2.4, it is possible to choose the lockfile path:
<https://github.com/ocamllabs/opam-monorepo/releases/tag/0.2.4>

This allows workflows with several lock files to build different configurations.

A natural use case for this is to create different builds using different ocaml versions (an "expert mode" equivalent of normal, opam-based builds).

But it also makes it possible to create tests based on different versions of a dependency. For example, create one lock file for base 0.13 and one lock file for base 0.14.

This PR enhances opam-monorepo support so that it creates one build per lock file.

Previously, opam-monorepo builds would detect:

- dune-project
- an opam file
- a corresponding lock file

and generate one build.

However, the opam file is not being used in the build. So instead, we just detect the dune-project file and all the lock files. The semantics for a single build are not changed.
