### PR TITLE
WIP: Fix opam-repo commit selection for lint-fmt

### DIFF
--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,10 +1,15 @@
 type source =
-  | Opam of { version : string } (** Should install OCamlformat from Opam. *)
+  | Opam of { version : string ; opam_repo_commit : string } (** Should install OCamlformat from Opam. *)
   | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative to the project's root. *)
 [@@deriving yojson, eq, ord]
 
 val pp_source : source Fmt.t
 
-val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> root:Fpath.t -> (source option, [ `Msg of string]) Lwt_result.t
+val get_ocamlformat_source :
+  Current.Job.t ->
+  opam_files:string list ->
+  root:Fpath.t ->
+  find_opam_repo_commit: (string -> (string, [`Msg of string]) Lwt_result.t) ->
+  (source option, [ `Msg of string]) Lwt_result.t
 (** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -8,7 +8,7 @@ module Analysis = struct
   include Ocaml_ci.Analyse.Analysis
 
   type ocamlformat_source = Ocaml_ci.Analyse_ocamlformat.source =
-    | Opam of { version : string }
+    | Opam of { version : string; opam_repo_commit : string }
     | Vendored of { path : string }
   [@@deriving yojson, eq]
 
@@ -157,7 +157,7 @@ let test_simple =
     {
       opam_files = [ "example.opam" ];
       selection_type = "opam";
-      ocamlformat_source = Some (Opam { version = "0.12" });
+      ocamlformat_source = Some (Opam { version = "0.12"; opam_repo_commit = "abc" });
     }
   in
   expect_test "simple" ~project ~expected


### PR DESCRIPTION
Fixes #398 

This is still work in progress but a bit of feedback on this would be greatly appreciated!

CC@emillon who was my pair programming partner on this and who wrote the nice summary below:

## Ways to improve this / future work

### Making it correct

At the moment we just pick the first solution and hope that it will be compatible with the worker that is selected for the lint-fmt job (first in the list of solutions for the main build), but that is not guaranteed.

We can return the whole selection (where we return just a commit), and use that instead of the first compatible worker. That scheme is also used for other kinds of lint builds (opam and doc) so they would need to be adjusted. This seems to be the best solution but requires more work.

Some older versions of ocamlformat could have a different behavior depending on the version of ocaml they have been compiled with. This is not the case with recent versions of ocaml and ocamlformat, but if we want to support that we would need to select the worker with most recent compiler (from the list of compatible ones).

The candidate implementation calls the solver for all platforms and only returns the first one. This is slow (see below) but in the case we keep the "use first worker for lint builds" strategy, it is possible just call the solver once by first. No guarantee that it always works.

### Making it faster

If the solution needs to call the solver on all platform and just pick one,  it is possible to change the solver API so that rather than querying for solves on all platforms, waiting for all the results and using `List.hd`, we instead pass a flag asking for early return of the first solution (akin to using`LIMIT 1` in SQL rather than `List.hd`).


Finally, if the function that maps ocamlformat+dune version to`opam-repository` commit is too expensive to compute (it's at least an extra solver call in the analysis phase, possibly more), we can cache it separately by altering the pipeline a bit:

```
    opam-repo -----------------> analyse-fmt -> lint-fmt
              -,             ,->
               |             |
               '-->         -'
         repo ----> analyse ---> build
```

In this new pipeline, analyse returns (for the formatting part) only the parsed ocamlformat and dune constraints instead of the `opam-repository` commit to use. And a new node (`analyse-fmt`) matches these constraints against the current state of `opam-repository`. This part is computed and cached separately.

### Code TODOs

- [x] Fix the test suite
- [ ] there's a spec line that is specific to `ocaml < 4.08` in formatting jobs. We could probably drop this.
- [ ] more generally it looks like this part is about installing packages from opam after resetting opam-repository to a known version. there is already code to do that
- [ ] deduplicate the opam file generation function