### PR TITLE
Use https protocol for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	branch = master
 [submodule "ocaml-version"]
 	path = ocaml-version
-	url = git://github.com/ocurrent/ocaml-version.git
+	url = https://github.com/ocurrent/ocaml-version.git
 	branch = master
 [submodule "ocaml-dockerfile"]
 	path = ocaml-dockerfile


### PR DESCRIPTION
The git protocol is not supported anymore. See https://github.blog/2021-09-01-improving-git-protocol-security-github/