### PR TITLE
Remove use of git: protocol in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	branch = master
 [submodule "ocaml-version"]
 	path = ocaml-version
-	url = git://github.com/ocurrent/ocaml-version.git
+	url = https://github.com/ocurrent/ocaml-version.git
 	branch = master
 [submodule "ocaml-dockerfile"]
 	path = ocaml-dockerfile


### PR DESCRIPTION
GitHub no longer supports it.