### PR TITLE
Add opam-2.1 builds

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -30,8 +30,9 @@ let rec with_commit_lock ~job commit variant fn =
 
 let make_build_spec ~base ~repo ~variant ~ty =
     let base = Raw.Image.hash base in
+    let opam_version = Variant.opam_version variant in
     match ty with
-    | `Opam (`Build, selection, opam_files) -> Opam_build.spec ~base ~opam_files ~selection
+    | `Opam (`Build, selection, opam_files) -> Opam_build.spec ~base ~opam_files ~selection ~opam_version
     | `Opam (`Lint `Doc, selection, opam_files) -> Lint.doc_spec ~base ~opam_files ~selection
     | `Opam (`Lint `Opam, selection, opam_files) -> Lint.opam_lint_spec ~base ~opam_files ~selection
     | `Opam_fmt (selection, ocamlformat_source) -> Lint.fmt_spec ~base ~ocamlformat_source ~selection

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -1,3 +1,6 @@
+(* Use opam-2.1 to lint the packages *)
+let opam_version = `V2_1
+
 let install_ocamlformat =
   let open Obuilder_spec in
   let cache = [ Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" ] in
@@ -44,7 +47,7 @@ let doc_spec ~base ~opam_files ~selection =
   stage ~from:base @@
     comment "%s" (Fmt.str "%a" Variant.pp selection.Selection.variant) ::
     user ~uid:1000 ~gid:1000 ::
-    Opam_build.install_project_deps ~opam_files ~selection @ [
+    Opam_build.install_project_deps ~opam_version ~opam_files ~selection @ [
       (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
       (* conf-m4 is a work-around for https://github.com/ocaml-opam/opam-depext/pull/132 *)
       run ~network ~cache "opam depext -i conf-m4 && opam depext -i dune 'odoc>=1.5.0'";
@@ -71,7 +74,7 @@ let opam_lint_spec ~base ~opam_files ~selection =
     ~from:base @@
     comment "%s" (Fmt.str "%a" Variant.pp selection.Selection.variant) ::
     user ~uid:1000 ~gid:1000 ::
-    Opam_build.install_project_deps ~opam_files ~selection @ [
+    Opam_build.install_project_deps ~opam_version ~opam_files ~selection @ [
       workdir "/src";
       copy ["."] ~dst:"/src/";
       run "opam lint %s" (String.concat " " opam_files);

--- a/lib/opam_build.mli
+++ b/lib/opam_build.mli
@@ -1,12 +1,14 @@
 val download_cache : string
 
 val install_project_deps :
+  opam_version:Opam_version.t ->
   opam_files:string list ->
   selection:Selection.t ->
   Obuilder_spec.op list
 
 val spec :
   base:string ->
+  opam_version:Opam_version.t ->
   opam_files:string list ->
   selection:Selection.t ->
   Obuilder_spec.t

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -184,7 +184,7 @@ let spec ~base ~repo ~config ~variant =
   stage ~from:base
   @@ [ comment "%s" (Variant.to_string variant); user ~uid:1000 ~gid:1000 ]
   @ initialize_switch ~network switch_type
-  @ Opam_build.install_project_deps ~opam_files:[] ~selection
+  @ Opam_build.install_project_deps ~opam_version:`V2_1 ~opam_files:[] ~selection
   @ [
       workdir "/src";
       run "sudo chown opam /src";

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -1,0 +1,14 @@
+type t = [`V2_0 | `V2_1] [@@deriving ord,yojson, eq]
+
+let to_string = function `V2_0 -> "2.0" | `V2_1 ->  "2.1"
+
+let to_string_with_patch = function `V2_0 -> "2.0.10" | `V2_1 ->  "2.1.2"
+
+let pp = Fmt.of_to_string to_string
+
+let default = `V2_0
+
+let of_string = function
+  | "2.0" -> Ok `V2_0
+  | "2.1" -> Ok `V2_1
+  | s -> Error (`Msg (s ^ ": invalid opam version"))

--- a/lib/opam_version.mli
+++ b/lib/opam_version.mli
@@ -1,0 +1,7 @@
+type t = [`V2_0 | `V2_1]  [@@deriving ord,yojson,eq]
+
+val pp: t Fmt.t
+val to_string: t -> string
+val to_string_with_patch: t -> string
+val default: t
+val of_string: string -> (t, [`Msg of string]) result

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -30,6 +30,7 @@ val get :
   distro:string ->
   ocaml_version:Ocaml_version.t ->
   host_base:Current_docker.Raw.Image.t Current.t ->
+  opam_version:Opam_version.t ->
   Current_docker.Raw.Image.t Current.t ->
   t Current.t
 (** [get ~label ~builder ~variant ~host_base base] creates a [t] by getting the opam variables from [host_base]
@@ -41,5 +42,6 @@ val pull :
   builder:Builder.t ->
   distro:string ->
   ocaml_version:Ocaml_version.t ->
+  opam_version:Opam_version.t ->
   Current_docker.Raw.Image.t Current.t
 (** [pull ~schedule ~builder ~distro ~ocaml_version] pulls "ocaml/opam:{distro}-ocaml-{version}" on [schedule]. *)

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -8,3 +8,5 @@ type t = {
 val of_worker : Ocaml_ci_api.Worker.Selection.t -> t
 
 val remove_package : t -> package:string -> t
+
+val filter_duplicate_opam_versions : t list -> t list

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -27,18 +27,20 @@ type t = {
   distro: string;
   ocaml_version: Ocaml_version.t;
   arch: Ocaml_version.arch;
+  opam_version: Opam_version.t;
 } [@@deriving yojson, ord, eq]
 
-let v ~arch ~distro ~ocaml_version =
+let v ~arch ~distro ~ocaml_version ~opam_version =
   (* Just check we understand all the variants first *)
   match Ocaml_version.Configure_options.of_t ocaml_version with
-  | Ok _ -> Ok { arch; distro; ocaml_version }
+  | Ok _ -> Ok { arch; distro; ocaml_version; opam_version }
   | Error e -> Error e
 
 let arch { arch; _ } = arch
 let distro { distro; _ } = distro
 let ocaml_version { ocaml_version; _ } = ocaml_version
 let with_ocaml_version ocaml_version t = { t with ocaml_version }
+let opam_version t = t.opam_version
 
 let id { distro; ocaml_version; _ } =
   Fmt.str "%s-%a" distro Ocaml_version.pp ocaml_version
@@ -53,20 +55,30 @@ let id_of_string s =
   | None -> None
 
 let pp f t =
-  Fmt.pf f "%s%s" (id t)
+  Fmt.pf f "%s%s%s" (id t)
     (match t.arch with
      | `X86_64 -> ""
      | a -> "_" ^ (Ocaml_version.to_opam_arch a))
+    (match t.opam_version with
+     | `V2_0 -> ""
+     | v -> "_opam-" ^ (Opam_version.to_string v))
 
 let to_string =
   Fmt.str "%a" pp
 
 let of_string s =
-  let id, arch =
+  let id, arch, opam_version =
    match Astring.String.cut ~sep:"_" s with
-   | None -> s, `X86_64
-   | Some (s, a) -> s, (Ocaml_version.of_opam_arch a |> Option.value ~default:`X86_64)
+   | None -> s, `X86_64, Opam_version.default
+   | Some (s, a) ->
+      let arch a = Ocaml_version.of_opam_arch a |> Option.value ~default:`X86_64 in
+      match Astring.String.cut ~rev:true ~sep:"_opam-" a with
+      | None -> s, arch a, Opam_version.default
+      | Some (a, v) ->
+         match Opam_version.of_string v with
+         | Ok v -> s, arch a, v
+         | Error _ -> s, arch a, Opam_version.default
   in
   match id_of_string id with
   | None -> raise (Failure ("internal error: unknown variant " ^ id))
-  | Some (distro, ocaml_version) -> { arch; distro; ocaml_version }
+  | Some (distro, ocaml_version) -> { arch; distro; ocaml_version; opam_version }

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -2,12 +2,14 @@ type t [@@deriving eq,ord,yojson]
 
 val v : arch:Ocaml_version.arch ->
         distro:string -> ocaml_version:Ocaml_version.t ->
+        opam_version:Opam_version.t ->
         (t, [> `Msg of string ]) result
 
 val arch : t -> Ocaml_version.arch
 val distro : t -> string
 val ocaml_version : t -> Ocaml_version.t
 val with_ocaml_version : Ocaml_version.t -> t -> t
+val opam_version : t -> Opam_version.t
 
 val id : t -> string
 val docker_tag : t -> string

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -55,6 +55,7 @@ type platform = {
   distro : string;
   ocaml_version : OV.t;
   arch: OV.arch;
+  opam_version: Ocaml_ci.Opam_version.t;
 }
 
 let pool_of_arch = function
@@ -63,9 +64,10 @@ let pool_of_arch = function
 | `S390x -> "linux-s390x"
 | `Ppc64le -> "linux-ppc64"
 
-let platforms =
+let platforms opam_version =
   let v ?(arch=`X86_64) label distro ocaml_version =
-    { arch; label; builder = Builders.local; pool = pool_of_arch arch; distro; ocaml_version }
+    { arch; label; builder = Builders.local; pool = pool_of_arch arch; distro;
+      ocaml_version; opam_version }
   in
   let master_distro = DD.resolve_alias DD.master_distro in
   let make_distro distro =

--- a/test/test_platforms.ml
+++ b/test/test_platforms.ml
@@ -11,7 +11,8 @@ let debian_10_vars ocaml_package ocaml_version =
   }
 
 let var distro ov =
-  Ocaml_ci.Variant.v ~arch:`X86_64 ~distro ~ocaml_version:(Ocaml_version.of_string_exn ov) |>
+  Ocaml_ci.Variant.v ~arch:`X86_64 ~distro
+    ~ocaml_version:(Ocaml_version.of_string_exn ov) ~opam_version:`V2_0 |>
   function Ok v -> v | Error (`Msg m) -> failwith m
 
 let v = [


### PR DESCRIPTION
To avoid the multiplication of build targets, only build using 2.1 if
that's the only supported target, otherwise keep using 2.0.