### PR TITLE
Add missing depexts update with opam 2.1

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -79,7 +79,7 @@ let install_project_deps ~opam_version ~opam_files ~selection =
   let non_root_pkgs = String.concat " " non_root_pkgs in
   let opam_depext = match opam_version with
     | `V2_0 -> run ~network ~cache "opam depext --update -y %s $DEPS" root_pkgs
-    | `V2_1 -> run ~network ~cache "opam install --cli=2.1 --depext-only -y %s $DEPS" root_pkgs
+    | `V2_1 -> run ~network ~cache "opam update --depexts && opam install --cli=2.1 --depext-only -y %s $DEPS" root_pkgs
   in
   (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
      [shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]] else [])


### PR DESCRIPTION
otherwise build can randomly fails with e.g.
```
<><> Handling external dependencies <><><><><><><><><><><><><><><><><><><><><><>
Let opam run your package manager to install the required system packages?
(answer 'n' for other options) [Y/n] y
+ /usr/bin/sudo "apt-get" "install" "-qq" "-yy" "pkg-config"
[ERROR] System package install failed with exit code 100 at command:
            sudo apt-get install -qq -yy pkg-config
- E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/g/glib2.0/libglib2.0-0_2.71.0-2_amd64.deb  404  Not Found [IP: 2001:67c:1360:8001::24 80]
- E: Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/g/glib2.0/libglib2.0-data_2.71.0-2_all.deb  404  Not Found [IP: 2001:67c:1360:8001::24 80]
- E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
You can retry with '--assume-depexts' to skip this check, or run 'opam option depext=false' to permanently disable handling of system packages altogether.
"/bin/bash" "-c" "opam install $DEPS" failed with exit status 10
```
There is nothing else to do with opam 2.0 as it already uses the `--update` argument to `opam depext`.