### PR TITLE
Remove hxd pin, update git-unix pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-11-ocaml-4.13 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin -q master && git reset --hard ae6aff50030492f9b7eed0cf952fdca40f4cf125 && opam update
+RUN cd ~/opam-repository && git pull origin -q master && git reset --hard d811dfbb1b8dd5497c24d29bb56a7b7cb5d6a25f && opam update
 COPY --chown=opam \
 	ocurrent/current_docker.opam \
 	ocurrent/current_github.opam \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-11-ocaml-4.13 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git pull origin master && git reset --hard ae6aff50030492f9b7eed0cf952fdca40f4cf125 && opam update
+RUN cd ~/opam-repository && git pull origin master && git reset --hard d811dfbb1b8dd5497c24d29bb56a7b7cb5d6a25f && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/

--- a/ocaml-ci-solver.opam
+++ b/ocaml-ci-solver.opam
@@ -38,6 +38,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 pin-depends: [
-  ["hxd.0.3.1" "git+https://github.com/dinosaure/hxd.git#4d3c4b35d74cbd9782d12a8d13a7d047db17e182"]
-  ["git-unix.3.8.0" "git+https://github.com/MisterDA/ocaml-git.git#d52aa79f782d3654e3661778811888554d99e337"]
+  ["git-unix.3.8.0" "git+https://github.com/mirage/ocaml-git.git#36dc0aa323968e2459e5e6137e2f98c2c09f4d74"]
 ]

--- a/ocaml-ci-solver.opam.template
+++ b/ocaml-ci-solver.opam.template
@@ -1,4 +1,3 @@
 pin-depends: [
-  ["hxd.0.3.1" "git+https://github.com/dinosaure/hxd.git#4d3c4b35d74cbd9782d12a8d13a7d047db17e182"]
-  ["git-unix.3.8.0" "git+https://github.com/MisterDA/ocaml-git.git#d52aa79f782d3654e3661778811888554d99e337"]
+  ["git-unix.3.8.0" "git+https://github.com/mirage/ocaml-git.git#36dc0aa323968e2459e5e6137e2f98c2c09f4d74"]
 ]


### PR DESCRIPTION
git-unix merged support for cmdliner.1.1.0, so we can remove the hxd pin and pin git-unix to the current master.