### PR TITLE
Set Content-Type with appropriate MIME and UTF-8 encoding

### DIFF
--- a/web-ui/badges.ml
+++ b/web-ui/badges.ml
@@ -54,7 +54,7 @@ module Server = Cohttp_lwt_unix.Server
 let normal_response = Lwt.map (fun x -> `Response x)
 
 let respond_error status body =
-  let headers = Cohttp.Header.init_with "Content-Type" "text/plain" in
+  let headers = Cohttp.Header.init_with "Content-Type" "text/plain; charset=utf-8" in
   Server.respond_error ~status ~headers ~body () |> normal_response
 
 let ( let*! ) x f =
@@ -81,5 +81,6 @@ let handle ~backend ~path =
       let body =
         status |> schema_of_status |> schema_to_yojson |> Yojson.Safe.to_string
       in
-      Server.respond_string ~status:`OK ~body () |> normal_response
+      let headers = Cohttp.Header.init_with "Content-Type" "application/json; charset=utf-8" in
+      Server.respond_string ~status:`OK ~headers ~body () |> normal_response
   | _ -> Server.respond_not_found () |> normal_response

--- a/web-ui/main.ml
+++ b/web-ui/main.ml
@@ -18,7 +18,8 @@ let handle_request ~backend _conn request _body =
   match meth, String.cuts ~sep:"/" ~empty:false path with
   | `GET, ([] | ["index.html"]) ->
     let body = Homepage.render () in
-    Server.respond_string ~status:`OK ~body () |> normal_response
+    let headers = Cohttp.Header.init_with "Content-Type" "text/html; charset=utf-8" in
+    Server.respond_string ~status:`OK ~headers ~body () |> normal_response
   | `GET, ["css"; "style.css"] ->
     Style.get () |> normal_response
   | meth, ("github" :: path) ->

--- a/web-ui/style.ml
+++ b/web-ui/style.ml
@@ -80,6 +80,6 @@ let css = {|
 |} ^ Current_ansi.css ^ Github.css
 
 let get () =
-  let headers = Cohttp.Header.init_with "Content-Type" "text/css" in
+  let headers = Cohttp.Header.init_with "Content-Type" "text/css; charset=utf-8" in
   Server.respond_string ~status:`OK ~headers ~body:css ()
 (*   Server.respond_file ~fname:"style.css" () *)


### PR DESCRIPTION
Set the Content-Type header to `text/html` everywhere `respond_string` seems to be sending html, and specify we're sending UTF-8 too (is that too much?).