### PR TITLE
Implement avoid-version in ocaml-ci-solver and fix ocaml-beta support

### DIFF
--- a/solver/dune
+++ b/solver/dune
@@ -3,4 +3,4 @@
   (public_name ocaml-ci-solver)
   (package ocaml-ci-solver)
   (preprocess (pps ppx_deriving.std ppx_deriving_yojson))
-  (libraries lwt.unix ocaml-ci-api ppx_deriving_yojson.runtime opam-0install capnp-rpc-unix git-unix logs.cli))
+  (libraries lwt.unix ocaml-ci-api ppx_deriving_yojson.runtime opam-0install capnp-rpc-unix git-unix logs.cli ocaml-version))

--- a/solver/git_context.ml
+++ b/solver/git_context.ml
@@ -13,6 +13,7 @@ type t = {
   pins : (OpamPackage.Version.t * OpamFile.OPAM.t) OpamPackage.Name.Map.t;
   constraints : OpamFormula.version_constraint OpamTypes.name_map;    (* User-provided constraints *)
   test : OpamPackage.Name.Set.t;
+  with_beta_remote : bool;
 }
 
 let ocaml_beta_pkg = OpamPackage.of_string "ocaml-beta.enabled"
@@ -82,7 +83,7 @@ let candidates t name =
       []
     | Some versions ->
       let versions =
-        if OpamPackage.Name.compare name (OpamPackage.name ocaml_beta_pkg) = 0 then 
+        if t.with_beta_remote && OpamPackage.Name.compare name (OpamPackage.name ocaml_beta_pkg) = 0 then
           OpamPackage.Version.Map.add (OpamPackage.version ocaml_beta_pkg) ocaml_beta_opam versions
         else versions
       in
@@ -148,5 +149,6 @@ let read_packages store commit =
             | Some versions -> OpamPackage.Name.Map.add name versions acc
         ) OpamPackage.Name.Map.empty
 
-let create ?(test=OpamPackage.Name.Set.empty) ?(pins=OpamPackage.Name.Map.empty) ~constraints ~env ~packages () =
-  { env; packages; pins; constraints; test }
+let create ?(test=OpamPackage.Name.Set.empty) ?(pins=OpamPackage.Name.Map.empty)
+           ~constraints ~env ~packages ~with_beta_remote () =
+  { env; packages; pins; constraints; test; with_beta_remote }

--- a/solver/git_context.mli
+++ b/solver/git_context.mli
@@ -12,4 +12,5 @@ val create :
   constraints:OpamFormula.version_constraint OpamPackage.Name.Map.t ->
   env:(string -> OpamVariable.variable_contents option) ->
   packages:OpamFile.OPAM.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t ->
+  with_beta_remote:bool ->
   unit -> t

--- a/solver/solver.ml
+++ b/solver/solver.ml
@@ -40,6 +40,7 @@ let solve ~packages ~pins ~root_pkgs (vars : Worker.Vars.t) =
       ~env:(env vars)
       ~constraints:(OpamPackage.Name.Map.singleton ocaml_package (`Eq, ocaml_version))
       ~test:(OpamPackage.Name.Set.of_list root_pkgs)
+      ~with_beta_remote:(Ocaml_version.(Releases.is_dev (of_string_exn vars.ocaml_version)))
   in
   let t0 = Unix.gettimeofday () in
   let r = Solver.solve context (ocaml_package :: root_pkgs) in


### PR DESCRIPTION
`ocaml-src.4.14.dev` reveals two shortcomings of ocaml-ci's solver which are fixed in this PR:
1. The solver ignores the `avoid-version` flag, which means that it selects `ocaml-src.4.14.dev` rather than `ocaml-src.4.14.0`. The fix is simple (and due to @kit-ty-kate) - simply change the priority order of the candidates so that the ones flagged `avoid-version` appear last, then they're only selected if absolutely necessary.
2. If the `ocaml-beta` package is detected in a solution, previously ocaml-ci-solver always added a fake `ocaml-beta.enabled` package to the universe, but this relies on the underlying docker image having the beta remote enabled. This is only done for the trunk package and for alpha/beta/rc releases of the compiler, so `ocaml-src.4.14.dev` being selected was breaking opam 2.0 builds. Now `ocaml-beta.enabled` is only added if we know the underlying compiler will support it. As it happens, this fix is masked by the `avoid-version` support.