### PR TITLE
For each variant, only build compatible packages

### DIFF
--- a/api/worker.ml
+++ b/api/worker.ml
@@ -18,6 +18,7 @@ end
 module Selection = struct
   type t = {
     id : string;                        (** The platform ID from the request. *)
+    compat_pkgs : string list;          (** Local root packages compatible with the platform. *)
     packages : string list;             (** The selected packages ("name.version"). *)
     commit : string;                    (** A commit in opam-repository to use. *)
   } [@@deriving yojson, ord]

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -20,7 +20,7 @@ let install_ocamlformat =
 
 let fmt_spec ~base ~ocamlformat_source ~selection =
   let open Obuilder_spec in
-  let { Selection.packages = _; commit; variant = _ } = selection in
+  let { Selection.packages = _; commit; variant = _; only_packages = _ } = selection in
   let cache = [ Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" ] in
   let network = ["host"] in
   stage ~from:base @@ [

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -2,14 +2,19 @@
 type t = {
   variant : Variant.t;                (** The variant image to build on. *)
   packages : string list;             (** The selected packages ("name.version"). *)
+  only_packages : string list [@default []];  (** Local root packages to include (empty to include all). *)
   commit : string;                    (** A commit in opam-repository to use. *)
 } [@@deriving yojson, ord]
 
-let of_worker w =
+let of_worker ~root_pkgs w =
   let module W = Ocaml_ci_api.Worker.Selection in
-  let { W.id; packages; commit } = w in
+  let { W.id; compat_pkgs; packages; commit } = w in
   let variant = Variant.of_string id in
-  { variant; packages; commit }
+  let only_packages =
+    if root_pkgs = compat_pkgs then []
+    else compat_pkgs
+  in
+  { variant; only_packages; packages; commit }
 
 let remove_package t ~package =
   {

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -2,10 +2,11 @@
 type t = {
   variant : Variant.t;                (** The variant image to build on. *)
   packages : string list;             (** The selected packages ("name.version"). *)
+  only_packages : string list [@default []];  (** Local root packages to include (empty to include all). *)
   commit : string;                    (** A commit in opam-repository to use. *)
 } [@@deriving yojson, ord]
 
-val of_worker : Ocaml_ci_api.Worker.Selection.t -> t
+val of_worker : root_pkgs:string list -> Ocaml_ci_api.Worker.Selection.t -> t
 
 val remove_package : t -> package:string -> t
 

--- a/test/gen_project.ml
+++ b/test/gen_project.ml
@@ -45,7 +45,7 @@ depends: []
 synopsis: "Example project generated for testing purposes"
 |}
 
-let opam ppf =
+let opam ?(ocaml={|{>= "4.09"}|}) ppf =
   Fmt.pf ppf
     {|opam-version: "2.0"
 maintainer:   "Camelus Bactrianus"
@@ -62,7 +62,7 @@ build: [
 ]
 
 depends: [
-  "ocaml"   {>= "4.09"}
+  "ocaml"   %s
   "dune"
   "fmt"
   "logs"
@@ -70,7 +70,7 @@ depends: [
 ]
 
 synopsis: "Example project generated for testing purposes"
-|}
+|} ocaml
 
 let ocamlformat ~version ppf =
   Fmt.pf ppf {|version = %s

--- a/test/gen_project.mli
+++ b/test/gen_project.mli
@@ -15,8 +15,9 @@ val opam_monorepo_lock_file : monorepo_version:string option -> contents
 (** Contents of an example [.opam.locked] file for opam-monorepo.
     [monorepo_version] will populate a [x-opam-monorepo-version] field. *)
 
-val opam : contents
-(** Contents of an example [.opam] file *)
+val opam : ?ocaml:string -> contents
+(** Contents of an example [.opam] file
+    @param ocaml Version constraint on OCaml. *)
 
 val ocamlformat : version:string -> contents
 (** Contents of a [.ocamlformat] file with a particular version *)

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -14,19 +14,34 @@ module Analysis = struct
 
   let set_equality = Alcotest.(equal (slist string String.compare))
 
+  type selection = {
+    ocaml_version : string;
+    only_packages : string list [@default []];
+  }
+  [@@deriving yojson, eq]
+
   let selection_type (t:t) =
     match selections t with
     | `Opam_monorepo _ -> "opam-monorepo"
     | `Opam_build _ -> "opam"
 
+  let selection (t:Ocaml_ci.Selection.t) =
+    let ocaml_version = Ocaml_version.to_string (Ocaml_ci.Variant.ocaml_version t.variant) in
+    { ocaml_version; only_packages = t.only_packages }
+
+  let selections (t:t) =
+    match selections t with
+    | `Opam_monorepo _ -> []
+    | `Opam_build s -> List.map selection s
+
   (* Make the [t] type concrete from the observable fields for easier testing *)
   type t = {
     opam_files : string list; [@equal set_equality]
     selection_type : string;
+    selections : selection list;
     ocamlformat_source : ocamlformat_source option;
   }
   [@@deriving eq, yojson]
-
 
   let of_dir ~switch ~job ~platforms ~solver_dir ~opam_repository_commit d =
     let solver = Ocaml_ci.Solver_pool.spawn_local ~solver_dir () in
@@ -39,6 +54,7 @@ module Analysis = struct
            {
              opam_files = opam_files t;
              selection_type = selection_type t;
+             selections = selections t;
              ocamlformat_source = ocamlformat_source t;
            })
 
@@ -61,6 +77,8 @@ let unwrap_result ~job = function
     end;
     print_endline "---end job log---";
     failwith m
+
+let error_t = Alcotest.of_pp (fun f (`Msg m) -> Fmt.string f m)
 
 let expect_test name ~project ~expected =
   Alcotest_lwt.test_case name `Quick (fun _switch () ->
@@ -119,21 +137,21 @@ let expect_test name ~project ~expected =
           Analysis.of_dir ~switch ~job ~platforms:Test_platforms.v ~solver_dir ~opam_repository_commit
             (Fpath.v root)
         )
-      >|= (function
-            | Ok o -> o
-            | Error (`Msg e) ->
-                let path =
-                  Current.Job.(log_path (id job))
-                  |> Result.get_ok |> Fpath.to_string
-                in
-                let ch = open_in_bin path in
-                let len = in_channel_length ch in
-                let log = really_input_string ch len in
-                close_in ch;
-                Printf.printf "Log:\n%s\n%!" log;
-                Alcotest.failf "Analysis stage failed: %s" e)
-      >|= Alcotest.(check Analysis.t) name expected
-      >|= fun () ->
+      >|= fun result ->
+      begin match result, expected with
+      | Error _, Ok _ ->
+        let path =
+          Current.Job.(log_path (id job))
+          |> Result.get_ok |> Fpath.to_string
+        in
+        let ch = open_in_bin path in
+        let len = in_channel_length ch in
+        let log = really_input_string ch len in
+        close_in ch;
+        Printf.printf "Log:\n%s\n%!" log;
+      | _ -> ()
+      end;
+      Alcotest.(check (result Analysis.t error_t)) name expected result;
       Gc.full_major ()
     )
 
@@ -154,9 +172,13 @@ let test_simple =
   in
   let expected =
     let open Analysis in
-    {
+    Ok {
       opam_files = [ "example.opam" ];
       selection_type = "opam";
+      selections = [
+        { ocaml_version = "4.10"; only_packages = [] };
+        { ocaml_version = "4.09"; only_packages = [] }
+      ];
       ocamlformat_source = Some (Opam { version = "0.12" });
     }
   in
@@ -182,13 +204,53 @@ let test_multiple_opam =
   in
   let expected =
     let open Analysis in
-    {
+    Ok {
       opam_files = [ "example.opam"; "example-foo.opam"; "example-bar.opam" ];
       selection_type = "opam";
+      selections = [
+        { ocaml_version = "4.10"; only_packages = [] };
+        { ocaml_version = "4.09"; only_packages = [] }
+      ];
       ocamlformat_source = None;
     }
   in
   expect_test "multiple_opam" ~project ~expected
+
+(* There are two packages, but they support different versions of OCaml.
+   Test each package on the platforms where it makes sense. *)
+let test_filter_packages =
+  let project =
+    let open Gen_project in
+    [
+      File ("example.opam", opam);
+      File ("example-new.opam", opam ~ocaml:{|{ >= "4.10" }|});
+    ]
+  in
+  let expected =
+    let open Analysis in
+    Ok {
+      opam_files = [ "example-new.opam"; "example.opam" ];
+      selection_type = "opam";
+      selections = [
+        { ocaml_version = "4.10"; only_packages = [] };
+        { ocaml_version = "4.09"; only_packages = ["example.dev"] };
+      ];
+      ocamlformat_source = None;
+    }
+  in
+  expect_test "filter_packages" ~project ~expected
+
+(* One packge doesn't work on *any* version of OCaml. Report that as an error. *)
+let test_filter_packages_no_solution =
+  let project =
+    let open Gen_project in
+    [
+      File ("example.opam", opam);
+      File ("example-new.opam", opam ~ocaml:{|{ >= "5.0" }|});
+    ]
+  in
+  let expected = Error (`Msg {|No solution found for "example-new.dev" on any supported platform|}) in
+  expect_test "filter_packages_no_solution" ~project ~expected
 
 let test_opam_monorepo =
   let project =
@@ -201,9 +263,10 @@ let test_opam_monorepo =
   in
   let expected =
     let open Analysis in
-    {
+    Ok {
       opam_files = [ "example.opam" ];
       selection_type = "opam-monorepo";
+      selections = [];
       ocamlformat_source = None;
     }
   in
@@ -220,9 +283,12 @@ let test_opam_monorepo_no_version =
   in
   let expected =
     let open Analysis in
-    {
+    Ok {
       opam_files = [ "example.opam" ];
       selection_type = "opam";
+      selections = [
+        { ocaml_version = "4.10"; only_packages = [] };
+      ];
       ocamlformat_source = None;
     }
   in
@@ -235,9 +301,13 @@ let test_ocamlformat_self =
   in
   let expected =
     let open Analysis in
-    {
+    Ok {
       opam_files = [ "ocamlformat.opam" ];
       selection_type = "opam";
+      selections = [
+        { ocaml_version = "4.10"; only_packages = [] };
+        { ocaml_version = "4.09"; only_packages = [] };
+      ];
       ocamlformat_source = Some (Vendored { path = "." });
     }
   in
@@ -247,6 +317,8 @@ let tests =
   [
     test_simple;
     test_multiple_opam;
+    test_filter_packages;
+    test_filter_packages_no_solution;
     test_opam_monorepo;
     test_opam_monorepo_no_version;
     test_ocamlformat_self;


### PR DESCRIPTION
This checks each local .opam file for an explicit constraint on the version of `ocaml`. If it doesn't match the platform, the package is skipped.

This is useful when different packages in a repository work on different versions of OCaml. For example, `prometheus` works on OCaml 4.03, but `prometheus-app` requires 4.08. Previously, this prevented testing on 4.03 at all.

The opam build uses `dune --only-packages` to build just the compatible subset.

Fixes #297. I tried testing this on the [prometheus](https://github.com/mirage/prometheus) repository, but hit https://github.com/ocaml/dune/issues/5621, so I don't know how easy it will be to support this.

It should be fairly easy to extend this to match `base-domains` too, which would allow merging eio support packages in existing libraries without preventing testing the other packages on older compilers (/cc @bikallem).