### PR TITLE
Fix lint-fmt issues

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -182,6 +182,28 @@ module Analysis = struct
       and+ ys = lwt_result_list_mapm ~f xs in
       y::ys
 
+  let opam_dep_file packages =
+    let lines =
+      [ {|opam-version: "2.0"|}; {|depends: [|} ]
+      @ List.map (fun (pkg, ver) -> Printf.sprintf {|  "%s" %s|} pkg ver) packages
+      @ [ {|]|} ]
+    in
+    lines |> List.map (fun s -> s ^ "\n") |> String.concat ""
+
+  let exactly v = Printf.sprintf {|{ = "%s" }|} v
+
+  let find_opam_repo_commit_for_ocamlformat ~solve ~platforms version =
+    let ( let+ ) = Lwt_result.Infix.( >|= ) in
+    let deps_for_ocamlformat =
+      ( "deps_for_ocamlformat.opam"
+      , opam_dep_file [("ocamlformat", exactly version)])
+    in
+    let+ workers =
+      solve ~root_pkgs:[deps_for_ocamlformat] ~pinned_pkgs:[] ~platforms
+    in
+    let selection = List.hd workers in
+    selection.Selection.commit
+
   let of_dir ~solver ~job ~platforms ~opam_repository_commit dir =
     let solve = solve ~opam_repository_commit ~job ~solver in
     let ty = type_of_dir dir in
@@ -215,7 +237,10 @@ module Analysis = struct
             else None
         )
     in
-    Analyse_ocamlformat.get_ocamlformat_source job ~opam_files ~root:dir >>!= fun ocamlformat_source ->
+    let find_opam_repo_commit = find_opam_repo_commit_for_ocamlformat ~solve ~platforms in
+    Analyse_ocamlformat.get_ocamlformat_source
+      job ~opam_files ~root:dir ~find_opam_repo_commit
+    >>!= fun ocamlformat_source ->
     if opam_files = [] then Lwt_result.fail (`Msg "No opam files found!")
     else if List.filter is_toplevel opam_files = [] then Lwt_result.fail (`Msg "No top-level opam files found!")
     else (

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -2,6 +2,7 @@ module Analysis : sig
   type t [@@deriving yojson]
 
   val opam_files : t -> string list
+  val ocamlformat_selection : t -> Selection.t option
   val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
   val selections : t -> [

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,10 +1,15 @@
 type source =
-  | Opam of { version : string } (** Should install OCamlformat from Opam. *)
+  | Opam of { version : string ; opam_repo_commit : string } (** Should install OCamlformat from Opam. *)
   | Vendored of { path : string } (** OCamlformat is vendored. [path] is relative to the project's root. *)
 [@@deriving yojson, eq, ord]
 
 val pp_source : source Fmt.t
 
-val get_ocamlformat_source : Current.Job.t -> opam_files:string list -> root:Fpath.t -> (source option, [ `Msg of string]) Lwt_result.t
+val get_ocamlformat_source :
+  Current.Job.t ->
+  opam_files:string list ->
+  root:Fpath.t ->
+  find_opam_repo_commit: (string -> (string, [`Msg of string]) Lwt_result.t) ->
+  (source option, [ `Msg of string]) Lwt_result.t
 (** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -9,7 +9,7 @@ val get_ocamlformat_source :
   Current.Job.t ->
   opam_files:string list ->
   root:Fpath.t ->
-  find_opam_repo_commit: (string -> (string, [`Msg of string]) Lwt_result.t) ->
-  (source option, [ `Msg of string]) Lwt_result.t
+  find_opam_repo_commit: (string -> ((string * Selection.t), [`Msg of string]) Lwt_result.t) ->
+  ((source option * Selection.t option), [ `Msg of string]) Lwt_result.t
 (** Detect the required version of OCamlformat or if it's vendored.
     Vendored OCamlformat is detected by looking at file names in [opam_files]. *)

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -28,7 +28,7 @@ let fmt_spec ~base ~ocamlformat_source ~selection =
   let open Obuilder_spec in
   let { Selection.packages = _; commit; variant = _; only_packages = _ } = selection in
   let commit =
-    Option.value ~default:selection.Selection.commit
+    Option.value ~default:commit
     (commit_from_ocamlformat_source ocamlformat_source)
   in
   let cache = [ Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" ] in

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -15,12 +15,22 @@ let install_ocamlformat =
       run ~network "opam depext ocamlformat";
       run ~network ~cache "opam install --deps-only -y ocamlformat";
     ]
-  | Opam { version } ->
+  | Opam { version; _ } ->
     [ run ~network ~cache "opam depext -i ocamlformat=%s" version ]
+
+let commit_from_ocamlformat_source ocamlformat_source =
+  let open Analyse_ocamlformat in
+  match ocamlformat_source with
+  | None | Some Vendored _ -> None
+  | Some Opam { opam_repo_commit; _ } -> Some opam_repo_commit
 
 let fmt_spec ~base ~ocamlformat_source ~selection =
   let open Obuilder_spec in
   let { Selection.packages = _; commit; variant = _; only_packages = _ } = selection in
+  let commit =
+    Option.value ~default:selection.Selection.commit
+    (commit_from_ocamlformat_source ocamlformat_source)
+  in
   let cache = [ Obuilder_spec.Cache.v Opam_build.download_cache ~target:"/home/opam/.opam/download-cache" ] in
   let network = ["host"] in
   stage ~from:base @@ [

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -116,6 +116,11 @@ let build_with_docker ?ocluster ~repo ~analysis source =
         :: List.map (fun config -> Spec.opam_monorepo ~config) builds
       | `Opam_build selections ->
         let lint_selection = List.hd selections in
+        let lint_ocamlformat = 
+            (match Analyse.Analysis.ocamlformat_selection analysis with
+                | None -> lint_selection 
+                | Some selection -> selection)
+        in
         let builds =
           selections
           |> Selection.filter_duplicate_opam_versions
@@ -125,7 +130,7 @@ let build_with_docker ?ocluster ~repo ~analysis source =
              )
         and lint =
           [
-            Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis (`Lint `Fmt);
+            Spec.opam ~label:"(lint-fmt)" ~selection:lint_ocamlformat ~analysis (`Lint `Fmt);
             Spec.opam ~label:"(lint-doc)" ~selection:lint_selection ~analysis (`Lint `Doc);
             Spec.opam ~label:"(lint-opam)" ~selection:lint_selection ~analysis (`Lint `Opam);
           ]

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -8,7 +8,7 @@ module Analysis = struct
   include Ocaml_ci.Analyse.Analysis
 
   type ocamlformat_source = Ocaml_ci.Analyse_ocamlformat.source =
-    | Opam of { version : string }
+    | Opam of { version : string; opam_repo_commit : string }
     | Vendored of { path : string }
   [@@deriving yojson, eq]
 
@@ -179,7 +179,7 @@ let test_simple =
         { ocaml_version = "4.10"; only_packages = [] };
         { ocaml_version = "4.09"; only_packages = [] }
       ];
-      ocamlformat_source = Some (Opam { version = "0.12" });
+      ocamlformat_source = Some (Opam { version = "0.12"; opam_repo_commit = "abc" });
     }
   in
   expect_test "simple" ~project ~expected

--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -7,10 +7,19 @@ let () =
 module Analysis = struct
   include Ocaml_ci.Analyse.Analysis
 
-  type ocamlformat_source = Ocaml_ci.Analyse_ocamlformat.source =
-    | Opam of { version : string; opam_repo_commit : string }
+  type ocamlformat_source_type =
+    | Opam of { version : string }
     | Vendored of { path : string }
   [@@deriving yojson, eq]
+
+  let ocamlformat_source_type (t:t) =
+    let osrc = ocamlformat_source t in
+    Option.map
+      (fun (osrc : Ocaml_ci.Analyse_ocamlformat.source) ->
+         match osrc with
+         | Opam { version; opam_repo_commit = _ } -> Opam { version }
+         | Vendored { path } -> Vendored { path })
+      osrc
 
   let set_equality = Alcotest.(equal (slist string String.compare))
 
@@ -39,7 +48,7 @@ module Analysis = struct
     opam_files : string list; [@equal set_equality]
     selection_type : string;
     selections : selection list;
-    ocamlformat_source : ocamlformat_source option;
+    ocamlformat_source_type : ocamlformat_source_type option;
   }
   [@@deriving eq, yojson]
 
@@ -55,7 +64,7 @@ module Analysis = struct
              opam_files = opam_files t;
              selection_type = selection_type t;
              selections = selections t;
-             ocamlformat_source = ocamlformat_source t;
+             ocamlformat_source_type = ocamlformat_source_type t;
            })
 
   let t : t Alcotest.testable =
@@ -104,6 +113,7 @@ let expect_test name ~project ~expected =
                 dummy_package "logs" [ "1.0" ];
                 dummy_package "alcotest" [ "1.0" ];
                 dummy_package "opam-monorepo" [ "0.1.0" ];
+                dummy_package "ocamlformat" [ "0.12" ];
               ];
           ];
       let opam_repository = Fpath.v repo in
@@ -179,7 +189,7 @@ let test_simple =
         { ocaml_version = "4.10"; only_packages = [] };
         { ocaml_version = "4.09"; only_packages = [] }
       ];
-      ocamlformat_source = Some (Opam { version = "0.12"; opam_repo_commit = "abc" });
+      ocamlformat_source_type = Some (Opam { version = "0.12" });
     }
   in
   expect_test "simple" ~project ~expected
@@ -211,7 +221,7 @@ let test_multiple_opam =
         { ocaml_version = "4.10"; only_packages = [] };
         { ocaml_version = "4.09"; only_packages = [] }
       ];
-      ocamlformat_source = None;
+      ocamlformat_source_type = None;
     }
   in
   expect_test "multiple_opam" ~project ~expected
@@ -235,7 +245,7 @@ let test_filter_packages =
         { ocaml_version = "4.10"; only_packages = [] };
         { ocaml_version = "4.09"; only_packages = ["example.dev"] };
       ];
-      ocamlformat_source = None;
+      ocamlformat_source_type = None;
     }
   in
   expect_test "filter_packages" ~project ~expected
@@ -267,7 +277,7 @@ let test_opam_monorepo =
       opam_files = [ "example.opam" ];
       selection_type = "opam-monorepo";
       selections = [];
-      ocamlformat_source = None;
+      ocamlformat_source_type = None;
     }
   in
   expect_test "opam-monorepo" ~project ~expected
@@ -289,7 +299,7 @@ let test_opam_monorepo_no_version =
       selections = [
         { ocaml_version = "4.10"; only_packages = [] };
       ];
-      ocamlformat_source = None;
+      ocamlformat_source_type = None;
     }
   in
   expect_test "opam-monorepo-no-version" ~project ~expected
@@ -308,7 +318,7 @@ let test_ocamlformat_self =
         { ocaml_version = "4.10"; only_packages = [] };
         { ocaml_version = "4.09"; only_packages = [] };
       ];
-      ocamlformat_source = Some (Vendored { path = "." });
+      ocamlformat_source_type = Some (Vendored { path = "." });
     }
   in
   expect_test "ocamlformat_self" ~project ~expected


### PR DESCRIPTION
Hi,
This PR is the continuation of the work done on #403 to solve #398:
* First, it rebases the work over master to make it up to date. 
* Thanks to the important help from @TheLortex, it adds another fix that uses @NathanReb solution to solve #383. It uses the solution computed by the solver to work on the latest compiler version that works with `ocamlformat`.

The idea is to get the selection computed to choose the image we want to build our image on.

PS: Another solution might be added in the future to support the `with-tool` field suggested by @dra27. But this is not something this PR intends to fix.
