### PR TITLE
Update dependencies

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -34,7 +34,7 @@
  (synopsis "Test OCaml projects on GitHub")
  (conflicts (ocaml-migrate-parsetree (= "1.7.1")))
  (depends
-  (prometheus-app (>= 1.0))
+  (prometheus-app (and (>= 1.0) (< 1.2)))
   (ppx_sexp_conv (>= v0.14.1))
   (ppx_deriving_yojson (>= 3.6.1))
   (ppx_deriving (>= 5.1))
@@ -90,7 +90,7 @@
   (fmt (>= 0.8.9))
   current_rpc
   (ansi (>= 0.5.0))
-  (prometheus-app (>= 1.0))
+  (prometheus-app (and (>= 1.0) (< 1.2)))
   (cmdliner (>= 1.1.0))
   lwt
   (cohttp-lwt-unix (>= 2.2.0))

--- a/dune-project
+++ b/dune-project
@@ -57,7 +57,6 @@
   (conf-libev (<> :os "win32"))
   (dockerfile-opam (>= 7.0.0))
   (ocaml-version (>= 3.0.0))
-  matrix-current
   (alcotest (and (>= 1.0.0) :with-test))
   (alcotest-lwt (and (>= 1.0.1) :with-test))))
 (package

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/ocurrent/ocaml-ci"
 bug-reports: "https://github.com/ocurrent/ocaml-ci/issues"
 depends: [
   "dune" {>= "3.0"}
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
   "ppx_sexp_conv" {>= "v0.14.1"}
   "ppx_deriving_yojson" {>= "3.6.1"}
   "ppx_deriving" {>= "5.1"}

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -30,7 +30,6 @@ depends: [
   "conf-libev" {os != "win32"}
   "dockerfile-opam" {>= "7.0.0"}
   "ocaml-version" {>= "3.0.0"}
-  "matrix-current"
   "alcotest" {>= "1.0.0" & with-test}
   "alcotest-lwt" {>= "1.0.1" & with-test}
   "odoc" {with-doc}

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -13,7 +13,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "current_rpc"
   "ansi" {>= "0.5.0"}
-  "prometheus-app" {>= "1.0"}
+  "prometheus-app" {>= "1.0" & < "1.2"}
   "cmdliner" {>= "1.1.0"}
   "lwt"
   "cohttp-lwt-unix" {>= "2.2.0"}


### PR DESCRIPTION
This PR is a temporary fix to make the CI works with `Prometheus`. It also removes `matrix-current` from the dependencies as it is a git submodule now.