### PR TITLE
Don't mkdir current dir in generated Dockerfiles

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -22,12 +22,13 @@ let group_opam_files =
     )
 
 let mkdir dirs =
-  let dirs =
-    dirs
-    |> List.map (fun (dir, _, _) -> Filename.quote (Fpath.to_string dir))
-    |> String.concat " "
+  let dirs = dirs |> List.filter_map (fun (dir, _, _) ->
+      if Fpath.is_current_dir dir then None
+      else Some (Filename.quote (Fpath.to_string dir)))
   in
-  [Obuilder_spec.run "mkdir -p %s" dirs]
+  match dirs with
+  | [] -> []
+  | dirs -> [Obuilder_spec.run "mkdir -p %s" (String.concat " " dirs)]
 
 (* Generate instructions to copy all the files in [items] into the
    image, creating the necessary directories first, and then pin them all. *)


### PR DESCRIPTION
I noticed that the dockerfile was creating the current directory. I suppose that's a mistake. Perhaps the problem could be eliminated before it's reached here (in the `group_opam_files` function?).

See from <https://ci.ocamllabs.io/github/MisterDA/ocurrent/commit/64a208a9021803ddbe443f86d7cf84692450d710/variant/debian-11-4.14>:
```sh
git clone --recursive "https://github.com/MisterDA/ocurrent.git" -b "master" && cd "ocurrent" && git reset --hard 64a208a9
cat > Dockerfile <<'END-OF-DOCKERFILE'
FROM ocaml/opam@sha256:c9b4f14cd425a623c4ed33182b3a845175aa7494578d6997fbb9c71d4f2a8135
# debian-11-4.14
USER 1000:1000
RUN sudo ln -f /usr/bin/opam-2.0 /usr/bin/opam
WORKDIR /src
RUN sudo chown opam /src
RUN cd ~/opam-repository && (git cat-file -e 8270cc5e433a2e14831089f1129059ef1077e5e5 || git fetch origin master) && git reset -q --hard 8270cc5e433a2e14831089f1129059ef1077e5e5 && git log --no-decorate -n1 --oneline && opam update -u
RUN mkdir -p './'
COPY --chown=1000:1000 current_web.opam current_slack.opam current_rpc.opam current_gitlab.opam current_github.opam current_git.opam current_examples.opam current_docker.opam current.opam ./
RUN opam pin add -yn current_web.dev './' && \
    opam pin add -yn current_slack.dev './' && \
    opam pin add -yn current_rpc.dev './' && \
    opam pin add -yn current_gitlab.dev './' && \
    opam pin add -yn current_github.dev './' && \
    opam pin add -yn current_git.dev './' && \
    opam pin add -yn current_examples.dev './' && \
    opam pin add -yn current_docker.dev './' && \
    opam pin add -yn current.dev './'
ENV DEPS="alcotest.1.5.0 alcotest-lwt.1.5.0 angstrom.0.15.0 ansi.0.5.0 asetmap.0.8.1 asn1-combinators.0.2.6 astring.0.8.5 atd.2.9.1 atdgen.2.9.1 atdgen-runtime.2.9.1 base.v0.15.0 base-bigarray.base base-bytes.base base-threads.base base-unix.base base64.3.5.0 bigarray-compat.1.1.0 bigarray-overlap.0.2.1 bigstringaf.0.9.0 biniou.1.2.1 bos.0.2.1 ca-certs.0.2.2 camlp-streams.5.0 capnp.3.5.0 capnp-rpc.1.2.2 capnp-rpc-lwt.1.2.2 capnp-rpc-net.1.2.2 capnp-rpc-unix.1.2.2 cf.0.5.0 cf-lwt.0.5.0 cmdliner.1.1.1 cohttp.5.0.0 cohttp-lwt.5.0.0 cohttp-lwt-unix.5.0.0 conduit.5.1.0 conduit-lwt.5.1.0 conduit-lwt-unix.5.1.0 conf-capnproto.2 conf-git.1.1 conf-gmp.4 conf-gmp-powm-sec.3 conf-graphviz.0.1 conf-libev.4-12 conf-libffi.2.0.0 conf-pkg-config.2 conf-sqlite3.1 conf-which.1 cppo.1.6.9 crunch.3.2.0 csexp.1.5.1 cstruct.6.1.0 cstruct-lwt.6.1.0 cstruct-sexp.6.1.0 csv.2.4 ctypes.0.20.1 ctypes-foreign.0.18.0 current_incr.0.6.0 dockerfile.7.1.0 domain-name.0.4.0 dune.3.3.1 dune-configurator.3.3.1 duration.0.2.0 easy-format.1.3.4 eqaf.0.8 extunix.0.4.1 ezjsonm.1.3.0 fmt.0.9.0 fpath.0.7.3 fsevents.0.3.0 fsevents-lwt.0.3.0 github.4.4.1 github-data.4.4.1 github-unix.4.4.1 gitlab.0.1.5 gitlab-unix.0.1.5 gmap.0.3.0 hex.1.5.0 hkdf.1.0.4 ISO8601.0.2.6 inotify.2.4 integers.0.7.0 ipaddr.5.3.0 ipaddr-sexp.5.3.0 irmin-watcher.0.5.0 jsonm.1.0.1 ke.0.6 logs.0.7.0 lwt.5.5.0 lwt-dllist.1.0.1 macaddr.5.3.0 magic-mime.1.2.0 mdx.2.1.0 menhir.20220210 menhirLib.20220210 menhirSdk.20220210 mirage-clock.4.2.0 mirage-crypto.0.10.6 mirage-crypto-ec.0.10.6 mirage-crypto-pk.0.10.6 mirage-crypto-rng.0.10.6 mirage-flow.3.0.0 mirage-kv.4.0.1 mirage-no-solo5.1 mirage-no-xen.1 mmap.1.2.0 mtime.1.4.0 multipart_form.0.4.1 multipart_form-lwt.0.4.1 num.1.4 ocaml.4.14.0 ocaml-base-compiler.4.14.0 ocaml-compiler-libs.v0.12.4 ocaml-config.2 ocaml-options-vanilla.1 ocaml-syntax-shims.1.0.0 ocaml-version.3.4.0 ocamlbuild.0.14.1 ocamlfind.1.9.5 ocplib-endian.1.2 odoc-parser.1.0.0 parsexp.v0.15.0 pbkdf.1.2.0 pecu.0.6 ppx_cstruct.6.1.0 ppx_derivers.1.2.1 ppx_deriving.5.2.1 ppx_deriving_yojson.3.6.1 ppx_sexp_conv.v0.15.0 ppxlib.0.25.1 prettym.0.0.3 prometheus.1.2 prometheus-app.1.2 ptime.1.0.0 re.1.10.4 res.5.0.1 result.1.5 routes.1.0.0 rresult.0.7.0 seq.base session.0.5.0 session-cohttp.0.5.0 session-cohttp-lwt.0.5.0 sexplib.v0.15.0 sexplib0.v0.15.1 sqlite3.5.1.0 stdint.0.7.0 stdio.v0.15.0 stdlib-shims.0.3.0 stringext.1.6.0 tls.0.15.3 tls-mirage.0.15.3 topkg.1.0.5 tyxml.4.5.0 uchar.0.0.2 unstrctrd.0.3 uri.4.2.0 uri-sexp.4.2.0 uutf.1.0.3 x509.0.16.0 yojson.1.7.0 zarith.1.12"
RUN opam depext --update -y current_web.dev current_slack.dev current_rpc.dev current_gitlab.dev current_github.dev current_git.dev current_examples.dev current_docker.dev current.dev $DEPS
RUN opam install $DEPS
COPY --chown=1000:1000 . /src/
RUN opam exec -- dune build @install @check @runtest && rm -rf _build

END-OF-DOCKERFILE
docker build .
```

The new code prevents a no-op `RUN mkdir -p ./`.