### PR TITLE
monorepo: do not crash if lockfiles share variant

### DIFF
--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -16,6 +16,8 @@ type config = {
 }
 [@@deriving yojson, ord]
 
+let label c = c.lock_file_path
+
 let selection_of_config c = c.selection
 
 let opam_locked = ".opam.locked"

--- a/lib/opam_monorepo.mli
+++ b/lib/opam_monorepo.mli
@@ -5,6 +5,8 @@ val detect : dir:Fpath.t -> info list option
 
 type config [@@deriving yojson, ord]
 
+val label : config -> string
+
 val selection_of_config : config -> Selection.t
 
 (** Determine configuration for a build

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -21,13 +21,23 @@ let opam ~label ~selection ~analysis op =
   in
   { label; variant; ty }
 
-let opam_monorepo ~config =
-  let {Selection.variant; _} = Opam_monorepo.selection_of_config config in
-  {
-    label = Variant.to_string variant;
-    variant;
-    ty = `Opam_monorepo config
-  }
+let opam_monorepo builds =
+  let multi = List.compare_length_with builds 2 >= 0 in
+  List.map
+    (fun config ->
+       let {Selection.variant; _} = Opam_monorepo.selection_of_config config in
+       let label = if multi then
+           Opam_monorepo.label config
+         else
+           Variant.to_string variant
+       in
+       {
+         label;
+         variant;
+         ty = `Opam_monorepo config
+       }
+    )
+    builds
 
 let pp f t = Fmt.string f t.label
 

--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -17,7 +17,7 @@ val opam :
   [ `Build | `Lint of [ `Doc | `Fmt | `Opam ] ] ->
   t
 
-val opam_monorepo : config:Opam_monorepo.config -> t
+val opam_monorepo : Opam_monorepo.config list -> t list
 
 val pp : t Fmt.t
 val compare : t -> t -> int

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -113,7 +113,7 @@ let build_with_docker ?ocluster ~repo ~analysis source =
       | `Opam_monorepo builds ->
         let lint_selection = Opam_monorepo.selection_of_config (List.hd builds) in
         Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis (`Lint `Fmt)
-        :: List.map (fun config -> Spec.opam_monorepo ~config) builds
+        :: Spec.opam_monorepo builds
       | `Opam_build selections ->
         let lint_selection = List.hd selections in
         let builds =


### PR DESCRIPTION
Since #378, we create several builds when there are several lockfiles. Unfortunately, if they use the same variant, this creates an ocurrent graph that is invalid because several sibling nodes have the same label (and this crashes the server).

To address this, this commit changes the labels when there are several lockfiles and use the path to the lockfile.
