### PR TITLE
Removes role permission check for webhooks.

### DIFF
--- a/service/github.ml
+++ b/service/github.ml
@@ -12,9 +12,9 @@ let has_role user = function
            ) -> true
     | _ -> false
 
-let webhook_route ~engine ~get_job_ids ~webhook_secret ~has_role =
-  Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~get_job_ids ~webhook_secret ~has_role)
+let webhook_route ~engine ~get_job_ids ~webhook_secret =
+  Routes.(s "webhooks" / s "github" /? nil @--> Current_github.webhook ~engine ~get_job_ids ~webhook_secret)
 
-let login_route github_auth = Routes.(s "login" /? nil @--> Current_github.Auth.login github_auth) 
+let login_route github_auth = Routes.(s "login" /? nil @--> Current_github.Auth.login github_auth)
 
 let authn github_auth = Option.map Current_github.Auth.make_login_uri github_auth

--- a/service/main.ml
+++ b/service/main.ml
@@ -87,7 +87,7 @@ let main () config mode app capnp_address github_auth submission_uri matrix : ('
     in
     let secure_cookies = github_auth <> None in
     let routes =
-      Github.webhook_route ~engine ~get_job_ids:Index.get_job_ids ~webhook_secret ~has_role ::
+      Github.webhook_route ~engine ~get_job_ids:Index.get_job_ids ~webhook_secret ::
       Github.login_route github_auth ::
       Current_web.routes engine in
     let site = Current_web.Site.v ?authn ~has_role ~secure_cookies ~name:"ocaml-ci" routes in


### PR DESCRIPTION
Pulls in https://github.com/ocurrent/ocurrent/pull/366

> Rationale: After deploying the check_run/suite work, we found that even though GitHub will only show a re-run button if you have write permissions to a repository, there is an additional check in the code on our end that ignores webhook requests unless they are from a member of a hard-coded list. This PR removes that restriction.