### PR TITLE
monorepo: remove support for 0.1 lockfiles

### DIFF
--- a/test/test_analyse.ml
+++ b/test/test_analyse.ml
@@ -112,7 +112,7 @@ let expect_test name ~project ~expected =
                 dummy_package "fmt" [ "1.0" ];
                 dummy_package "logs" [ "1.0" ];
                 dummy_package "alcotest" [ "1.0" ];
-                dummy_package "opam-monorepo" [ "0.1.0" ];
+                dummy_package "opam-monorepo" [ "0.2.6" ];
                 dummy_package "ocamlformat" [ "0.12" ];
               ];
           ];
@@ -267,7 +267,7 @@ let test_opam_monorepo =
     let open Gen_project in
     [ File ("example.opam", opam_monorepo_spec_file);
       File ("example.opam.locked",
-            opam_monorepo_lock_file ~monorepo_version:(Some "0.1"));
+            opam_monorepo_lock_file ~monorepo_version:(Some "0.2"));
       File ("dune-project", empty_file);
     ]
   in


### PR DESCRIPTION
These are not used anymore.
