### PR TITLE
Hack: convert ocaml-ci-web to eio

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,7 +1,20 @@
-FROM ocaml/opam:debian-11-ocaml-5.0@sha256:2496a816275da522c21630f23be61e625e6a0f880883fb093306e4005ea1e52a
+FROM ocaml/opam:debian-11-ocaml-5.0@sha256:2496a816275da522c21630f23be61e625e6a0f880883fb093306e4005ea1e52a AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard bf63beadbea0c69b499037cd707fd607ed844f0d && opam update
-RUN opam repo add alpha git://github.com/kit-ty-kate/opam-alpha-repository.git
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard c6a0807ecfd0373688e2ae9823c00a800087fcf8 && opam update
+RUN opam repo add alpha https://github.com/kit-ty-kate/opam-alpha-repository.git
+RUN opam pin -yn http.5.5.0 https://github.com/mirage/ocaml-cohttp.git#08e796d45add02893a559411aa83d2196d1b86e4 && \
+    opam pin -yn cohttp.5.5.0 https://github.com/mirage/ocaml-cohttp.git#08e796d45add02893a559411aa83d2196d1b86e4 && \
+    opam pin -yn cohttp-eio.5.5.0 https://github.com/mirage/ocaml-cohttp.git#08e796d45add02893a559411aa83d2196d1b86e4 && \
+    opam pin -yn cohttp-lwt.5.5.0 https://github.com/mirage/ocaml-cohttp.git#08e796d45add02893a559411aa83d2196d1b86e4 && \
+    opam pin -yn cohttp-lwt-unix.5.5.0 https://github.com/mirage/ocaml-cohttp.git#08e796d45add02893a559411aa83d2196d1b86e4 && \
+    opam pin -yn eio.dev https://github.com/ocaml-multicore/eio.git#ff5e2bf33eec1194c0bae989e9290a0f5abd42cf && \
+    opam pin -yn eio_linux.dev https://github.com/ocaml-multicore/eio.git#ff5e2bf33eec1194c0bae989e9290a0f5abd42cf && \
+    opam pin -yn eio_luv.dev https://github.com/ocaml-multicore/eio.git#ff5e2bf33eec1194c0bae989e9290a0f5abd42cf && \
+    opam pin -yn eio_main.dev https://github.com/ocaml-multicore/eio.git#ff5e2bf33eec1194c0bae989e9290a0f5abd42cf && \
+    opam pin -yn capnp-rpc.1.2.2 https://github.com/talex5/capnp-rpc.git#f5c0c355dccdab083f80d55f7c2bb7480fc86eed && \
+    opam pin -yn capnp-rpc-lwt.1.2.2 https://github.com/talex5/capnp-rpc.git#f5c0c355dccdab083f80d55f7c2bb7480fc86eed && \
+    opam pin -yn capnp-rpc-net.1.2.2 https://github.com/talex5/capnp-rpc.git#f5c0c355dccdab083f80d55f7c2bb7480fc86eed && \
+    opam pin -yn capnp-rpc-unix.1.2.2 https://github.com/talex5/capnp-rpc.git#f5c0c355dccdab083f80d55f7c2bb7480fc86eed
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,7 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:dfbdc8f0ec1a3c22223f4cff461b3cd70df2acce7d9318b0e8802ffbfe3a1e93 AS build
+FROM ocaml/opam:debian-11-ocaml-5.0@sha256:2496a816275da522c21630f23be61e625e6a0f880883fb093306e4005ea1e52a
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch origin master && git reset --hard 881d9e99992589cdefeef4a2da690e4b13d57b2e && opam update
+RUN cd ~/opam-repository && git fetch origin master && git reset --hard bf63beadbea0c69b499037cd707fd607ed844f0d && opam update
+RUN opam repo add alpha git://github.com/kit-ty-kate/opam-alpha-repository.git
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/

--- a/api/client.ml
+++ b/api/client.ml
@@ -51,7 +51,7 @@ module CI = struct
     let open Raw.Client.CI.Orgs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
-    |> Lwt_result.map Results.orgs_get_list
+    |> Result.map Results.orgs_get_list
 end
 
 module Org = struct
@@ -72,7 +72,7 @@ module Org = struct
     let open Raw.Client.Org.Repos in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
-    |> Lwt_result.map (fun result ->
+    |> Result.map (fun result ->
         Results.repos_get_list result
         |> List.map @@ fun repo ->
         let name = Raw.Reader.RepoInfo.name_get repo in
@@ -87,7 +87,7 @@ module Repo = struct
   let refs t =
     let open Raw.Client.Repo.Refs in
     let request = Capability.Request.create_no_args () in
-    Capability.call_for_value t method_id request |> Lwt_result.map @@ fun jobs ->
+    Capability.call_for_value t method_id request |> Result.map @@ fun jobs ->
     Results.refs_get_list jobs
     |> List.fold_left (fun acc slot ->
         let gref = Raw.Reader.RefInfo.ref_get slot in
@@ -122,7 +122,7 @@ module Commit = struct
     let open Raw.Client.Commit.Jobs in
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
-    |> Lwt_result.map @@ fun jobs ->
+    |> Result.map @@ fun jobs ->
     Results.jobs_get_list jobs |> List.map (fun job ->
         let variant = Raw.Reader.JobInfo.variant_get job in
         let state = Raw.Reader.JobInfo.state_get job in
@@ -133,11 +133,11 @@ module Commit = struct
   let refs t =
     let open Raw.Client.Commit.Refs in
     let request = Capability.Request.create_no_args () in
-    Capability.call_for_value t method_id request |> Lwt_result.map Results.refs_get_list
+    Capability.call_for_value t method_id request |> Result.map Results.refs_get_list
 
   let ( >> ) f g x = g (f x)
 
-  let (>>=) = Lwt_result.bind_result
+  let (>>=) = Result.bind
 
   let status t =
     let open Raw.Client.Commit.Status in

--- a/api/client.mli
+++ b/api/client.mli
@@ -30,15 +30,15 @@ module Commit : sig
   type t = Raw.Client.Commit.t Capability.t
   (** A single commit being tested. *)
 
-  val jobs : t -> (job_info list, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
+  val jobs : t -> (job_info list, [> `Capnp of Capnp_rpc.Error.t ]) Result.t
 
   val job_of_variant : t -> variant -> Current_rpc.Job.t
   (** [job_of_variant t] is the (most recent) OCurrent job for this variant. *)
 
-  val refs : t -> (git_ref list, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
+  val refs : t -> (git_ref list, [> `Capnp of Capnp_rpc.Error.t ]) Result.t
   (** [refs t] is the list of Git references that have this commit as their head. *)
 
-  val status : t -> ([ `Not_started | `Pending | `Failed | `Passed ], [> `Capnp of Capnp_rpc.Error.t | `Msg of string]) Lwt_result.t
+  val status : t -> ([ `Not_started | `Pending | `Failed | `Passed ], [> `Capnp of Capnp_rpc.Error.t | `Msg of string]) Result.t
   (** [status t] is the result of the most-recent 'summarise' step on this commit. *)
 end
 
@@ -46,7 +46,7 @@ module Repo : sig
   type t = Raw.Client.Repo.t Capability.t
   (** A GitHub repository that is tested by ocaml-ci. *)
 
-  val refs : t -> ((git_hash * Build_status.t) Ref_map.t, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
+  val refs : t -> ((git_hash * Build_status.t) Ref_map.t, [> `Capnp of Capnp_rpc.Error.t ]) Result.t
   (** [refs t] returns the known Git references (branches and pull requests) that ocaml-ci
       is monitoring, along with the current head of each one. *)
 
@@ -70,7 +70,7 @@ module Org : sig
   (** [repo t name] is the GitHub organisation at "https://github.com/$owner/$name".
       It returns an error if ocaml-ci doesn't know about this repository. *)
 
-  val repos : t -> (repo_info list, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
+  val repos : t -> (repo_info list, [> `Capnp of Capnp_rpc.Error.t ]) Result.t
 end
 
 module CI : sig
@@ -81,5 +81,5 @@ module CI : sig
   (** [org t owner] is the GitHub organisation at "https://github.com/$owner".
       It returns an error if ocaml-ci doesn't know about this organisation. *)
 
-  val orgs : t -> (string list, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
+  val orgs : t -> (string list, [> `Capnp of Capnp_rpc.Error.t ]) Result.t
 end

--- a/dune-project
+++ b/dune-project
@@ -93,7 +93,7 @@
   (prometheus-app (>= 1.0))
   (cmdliner (>= 1.1.0))
   lwt
-  (cohttp-lwt-unix (>= 2.2.0))
+  (cohttp-eio (>= 2.2.0))
   eio_main
   lwt_eio
   tyxml

--- a/dune-project
+++ b/dune-project
@@ -94,6 +94,8 @@
   (cmdliner (>= 1.1.0))
   lwt
   (cohttp-lwt-unix (>= 2.2.0))
+  eio_main
+  lwt_eio
   tyxml
   (capnp-rpc-unix (>= 1.2))
   ocaml-ci-api

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -16,7 +16,7 @@ depends: [
   "prometheus-app" {>= "1.0"}
   "cmdliner" {>= "1.1.0"}
   "lwt"
-  "cohttp-lwt-unix" {>= "2.2.0"}
+  "cohttp-eio" {>= "2.2.0"}
   "eio_main"
   "lwt_eio"
   "tyxml"

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -17,6 +17,8 @@ depends: [
   "cmdliner" {>= "1.1.0"}
   "lwt"
   "cohttp-lwt-unix" {>= "2.2.0"}
+  "eio_main"
+  "lwt_eio"
   "tyxml"
   "capnp-rpc-unix" {>= "1.2"}
   "ocaml-ci-api"

--- a/web-ui/backend.ml
+++ b/web-ui/backend.ml
@@ -1,5 +1,5 @@
+open Eio.Std
 open Capnp_rpc_lwt
-open Lwt.Infix
 
 let retry_delay = 5.0   (* Time to wait after a failed connection before retrying. *)
 
@@ -16,47 +16,49 @@ end
 
 type t = {
   sr : Ocaml_ci_api.Raw.Client.CI.t Sturdy_ref.t;
-  mutable ci : Ocaml_ci_api.Client.CI.t Lwt.t;
-  mutable last_failed : float;
+  mutable ci : (Ocaml_ci_api.Client.CI.t, Capnp_rpc.Exception.t) result Promise.t;
+  mutable last_attempt : float;
 }
 
-let rec reconnect t =
-  Prometheus.Gauge.set Metrics.backend_down 1.0;
+let rate_limit t =
   let now = Unix.gettimeofday () in
-  let delay = t.last_failed +. retry_delay -. now in
-  t.last_failed <- now;
-  Lwt.async (fun () ->
-      begin if delay > 0.0 then Lwt_unix.sleep delay else Lwt.return_unit end
-      >>= fun () ->
-      Log.info (fun f -> f "Reconnecting to backend");
-      let ci =
-        try Sturdy_ref.connect_exn t.sr
-        with ex -> Lwt.fail ex    (* (just in case) *)
-      in
-      t.ci <- ci;
-      monitor t;
-      Lwt.return_unit
-    )
-and monitor t =
-  Lwt.on_any t.ci
-    (fun ci ->
-       (* Connected OK - now watch for failure. *)
-       Prometheus.Gauge.set Metrics.backend_down 0.0;
-       ci |> Capability.when_broken @@ fun ex ->
-       Log.warn (fun f -> f "Lost connection to backend: %a" Capnp_rpc.Exception.pp ex);
-       reconnect t
-    )
-    (fun ex ->
-       (* Failed to connect. *)
-       Log.warn (fun f -> f "Failed to connect to backend: %a" Fmt.exn ex);
-       reconnect t
-    )
+  let delay = t.last_attempt +. retry_delay -. now in
+  if delay > 0.0 then Eio_unix.sleep delay;
+  t.last_attempt <- Unix.gettimeofday ()
 
-let make sr =
-  let ci = Sturdy_ref.connect_exn sr in
-  let t = { sr; ci; last_failed = 0.0 } in
+let await_broken cap =
+  let p, r = Promise.create () in
+  Capability.when_broken (Promise.resolve r) cap;
+  Promise.await p
+
+let rec connect t resolver =
   Prometheus.Gauge.set Metrics.backend_down 1.0;
-  monitor t;
+  rate_limit t;
+  Log.info (fun f -> f "Connecting to backend");
+  let ci = Sturdy_ref.connect t.sr in
+  Promise.resolve resolver ci;
+  match ci with
+  | Error ex ->
+    Log.warn (fun f -> f "Failed to connect to backend: %a" Capnp_rpc.Exception.pp ex);
+    reconnect t
+  | Ok ci ->
+    (* Connected OK - now watch for failure. *)
+    Prometheus.Gauge.set Metrics.backend_down 0.0;
+    let ex = await_broken ci in
+    Log.warn (fun f -> f "Lost connection to backend: %a" Capnp_rpc.Exception.pp ex);
+    reconnect t
+and reconnect t =
+  let ci, r = Promise.create () in
+  t.ci <- ci;
+  connect t r
+
+let make ~sw sr =
+  let ci, r = Promise.create () in
+  let t = { sr; ci; last_attempt = 0.0 } in
+  Fiber.fork_daemon ~sw (fun () -> connect t r);
   t
 
-let ci t = t.ci
+let ci t =
+  match Promise.await t.ci with
+  | Ok x -> x
+  | Error e -> Fmt.failwith "%a" Capnp_rpc.Exception.pp e

--- a/web-ui/backend.mli
+++ b/web-ui/backend.mli
@@ -1,7 +1,8 @@
+open Eio.Std
 open Capnp_rpc_lwt
 
 type t
 
-val make : Ocaml_ci_api.Raw.Client.CI.t Sturdy_ref.t -> t
+val make : sw:Switch.t -> Ocaml_ci_api.Raw.Client.CI.t Sturdy_ref.t -> t
 
-val ci : t -> Ocaml_ci_api.Client.CI.t Lwt.t
+val ci : t -> Ocaml_ci_api.Client.CI.t

--- a/web-ui/badges.mli
+++ b/web-ui/badges.mli
@@ -1,4 +1,4 @@
 val handle :
   backend:Backend.t ->
   path:string list ->
-  Cohttp_lwt_unix.Server.response_action Lwt.t
+  Cohttp_eio.Server.response

--- a/web-ui/dune
+++ b/web-ui/dune
@@ -10,6 +10,8 @@
   (public_name ocaml-ci-web)
   (package ocaml-ci-web)
   (libraries lwt.unix
+             eio_main
+             lwt_eio
              logs.cli
              logs.fmt
              fmt.tty

--- a/web-ui/dune
+++ b/web-ui/dune
@@ -17,6 +17,7 @@
              fmt.tty
              ansi
              cohttp-lwt-unix
+             cohttp-eio
              tyxml
              prometheus-app.unix
              ocaml-ci-api

--- a/web-ui/github.mli
+++ b/web-ui/github.mli
@@ -1,3 +1,1 @@
-val handle :
-  backend:Backend.t -> meth:Cohttp.Code.meth -> string list ->
-  Cohttp_lwt_unix.Server.response_action Lwt.t
+val handle : backend:Backend.t -> Http.Method.t -> string list -> Cohttp_eio.Server.response


### PR DESCRIPTION
This is just a hack to test Eio. It's using Eio versions of cohttp and capnp-rpc.

The Prometheus library is still lwt, and it uses lwt_eio for that.

Note: there are some problems in cohttp-eio; see https://github.com/mirage/ocaml-cohttp/issues/913 and https://github.com/mirage/ocaml-cohttp/issues/883. There's some extra code to work around that a bit.