### PR TITLE
Do not rebuild jobs that trigger other jobs

### DIFF
--- a/web-ui/controller/github.ml
+++ b/web-ui/controller/github.ml
@@ -118,13 +118,16 @@ let rebuild_steps ~rebuild_failed_only ~org ~repo ~hash request ci =
   let rebuild_many commit job_infos =
     let go job_info commit success failed =
       let variant = job_info.Client.variant in
-      let job = Client.Commit.job_of_variant commit variant in
-      Capability.with_ref (Current_rpc.Job.rebuild job) @@ fun new_job ->
-      Capability.await_settled new_job >>= function
-      | Ok () -> Lwt.return (job_info :: success, failed)
-      | Error ex ->
-          Dream.log "Error rebuilding job: %a" Capnp_rpc.Exception.pp ex;
-          Lwt.return (success, succ failed)
+      if variant = "(analysis)" then (* Do not rebuild analysis -- this triggers other jobs *)
+        Lwt.return (success, failed)
+      else
+        let job = Client.Commit.job_of_variant commit variant in
+        Capability.with_ref (Current_rpc.Job.rebuild job) @@ fun new_job ->
+        Capability.await_settled new_job >>= function
+        | Ok () -> Lwt.return (job_info :: success, failed)
+        | Error ex ->
+            Dream.log "Error rebuilding job: %a" Capnp_rpc.Exception.pp ex;
+            Lwt.return (success, succ failed)
     in
     let init = ([], 0) in
         let f (success, failed) (job_info : Client.job_info) =

--- a/web-ui/controller/github.ml
+++ b/web-ui/controller/github.ml
@@ -130,14 +130,14 @@ let rebuild_steps ~rebuild_failed_only ~org ~repo ~hash request ci =
             Lwt.return (success, succ failed)
     in
     let init = ([], 0) in
-        let f (success, failed) (job_info : Client.job_info) =
-        if rebuild_failed_only then
-          match job_info.outcome with
-          | Active | NotStarted | Passed -> Lwt.return (success, failed)
-          | Aborted | Failed _ | Undefined _ -> go job_info commit success failed
-        else go job_info commit success failed
+    let f (success, failed) (job_info : Client.job_info) =
+      if rebuild_failed_only then
+        match job_info.outcome with
+        | Active | NotStarted | Passed -> Lwt.return (success, failed)
+        | Aborted | Failed _ | Undefined _ -> go job_info commit success failed
+      else go job_info commit success failed
     in
-    Lwt_list.fold_left_s f init  job_infos
+    Lwt_list.fold_left_s f init job_infos
   in
   Capability.with_ref (Client.CI.org ci org) @@ fun org_cap ->
   Capability.with_ref (Client.Org.repo org_cap repo) @@ fun repo_cap ->


### PR DESCRIPTION
The fact that we are incorrectly rebuilding the `analysis` step came up today when we were going over the redesign of ocaml-ci. 

It reminded me that I had seen [this commit on opam-repo-ci](https://github.com/ocurrent/opam-repo-ci/commit/4d6563d9f72ab440153ad6e9b294a10e29a75d21) by @kit-ty-kate and thus this change. 