### PR TITLE
Persist refs in the build index.

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -1,8 +1,7 @@
 let src = Logs.Src.create "ocaml_ci.index" ~doc:"ocaml-ci indexer"
+
 module Log = (val Logs.src_log src : Logs.LOG)
-
 module Db = Current.Db
-
 module Job_map = Astring.String.Map
 
 type t = {
@@ -11,10 +10,13 @@ type t = {
   get_jobs : Sqlite3.stmt;
   get_job : Sqlite3.stmt;
   get_job_ids : Sqlite3.stmt;
+  get_commits_job_ids_for_ref : Sqlite3.stmt;
   full_hash : Sqlite3.stmt;
 }
 
-type job_state = [`Not_started | `Active | `Failed of string | `Passed | `Aborted ] [@@deriving show]
+type job_state =
+  [ `Not_started | `Active | `Failed of string | `Passed | `Aborted ]
+[@@deriving show]
 
 type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
 
@@ -27,10 +29,20 @@ let is_valid_hash hash =
   let open Astring in
   String.length hash >= 6 && String.for_all Char.Ascii.is_alphanum hash
 
-let db = lazy (
-  let db = Lazy.force Current.Db.v in
-  Current_cache.Db.init ();
-  Sqlite3.exec db {|
+let db =
+  lazy
+    (let db = Lazy.force Current.Db.v in
+     Current_cache.Db.init ();
+     let gref_col_does_not_exist =
+       let q =
+         Sqlite3.prepare db
+           "SELECT count(*) FROM pragma_table_info('ci_build_index') WHERE \
+            name='gref'"
+       in
+       Db.query_one q [] = Sqlite3.Data.[ INT 0L ]
+     in
+     Sqlite3.exec db
+       {|
 CREATE TABLE IF NOT EXISTS ci_build_index (
   owner     TEXT NOT NULL,
   name      TEXT NOT NULL,
@@ -38,41 +50,78 @@ CREATE TABLE IF NOT EXISTS ci_build_index (
   variant   TEXT NOT NULL,
   job_id    TEXT,
   PRIMARY KEY (owner, name, hash, variant)
-)|} |> or_fail "create table";
-  let record_job = Sqlite3.prepare db "INSERT OR REPLACE INTO ci_build_index \
-                                     (owner, name, hash, variant, job_id) \
-                                     VALUES (?, ?, ?, ?, ?)" in
-  let remove = Sqlite3.prepare db "DELETE FROM ci_build_index \
-                                     WHERE owner = ? AND name = ? AND hash = ? AND variant = ?" in
-  let get_jobs = Sqlite3.prepare db "SELECT ci_build_index.variant, ci_build_index.job_id, cache.ok, cache.outcome \
-                                     FROM ci_build_index \
-                                     LEFT JOIN cache ON ci_build_index.job_id = cache.job_id \
-                                     WHERE ci_build_index.owner = ? AND ci_build_index.name = ? AND ci_build_index.hash = ?" in
-  let get_job = Sqlite3.prepare db "SELECT job_id FROM ci_build_index \
-                                     WHERE owner = ? AND name = ? AND hash = ? AND variant = ?" in
-  let get_job_ids = Sqlite3.prepare db "SELECT variant, job_id FROM ci_build_index \
-                                     WHERE owner = ? AND name = ? AND hash = ?" in
-  let full_hash = Sqlite3.prepare db "SELECT DISTINCT hash FROM ci_build_index \
-                                      WHERE owner = ? AND name = ? AND hash LIKE ?" in
-      {
-        record_job;
-        remove;
-        get_jobs;
-        get_job;
-        get_job_ids;
-        full_hash
-      }
-)
+)|}
+     |> or_fail "create table";
+     if gref_col_does_not_exist then
+       let () = Log.info (fun f -> f "ADDING gref col to ci_build_index.") in
+       Sqlite3.exec db
+         {|
+ALTER TABLE ci_build_index
+  ADD COLUMN gref TEXT NOT NULL DEFAULT "-"
+    |}
+       |> or_fail "alter table"
+     else Log.info (fun f -> f "gref col detected.");
+     let record_job =
+       Sqlite3.prepare db
+         "INSERT OR REPLACE INTO ci_build_index \
+          (owner, name, hash, variant, gref, job_id) \
+          VALUES (?, ?, ?, ?, ?, ?)"
+     and remove =
+       Sqlite3.prepare db
+         "DELETE FROM ci_build_index \
+          WHERE owner = ? AND name = ? AND hash = ? \
+          AND variant = ?"
+     and get_jobs =
+       Sqlite3.prepare db
+         "SELECT ci_build_index.variant, ci_build_index.job_id, cache.ok, cache.outcome \
+          FROM ci_build_index \
+          LEFT JOIN cache ON ci_build_index.job_id = cache.job_id \
+          WHERE ci_build_index.owner = ? AND ci_build_index.name = ? AND ci_build_index.hash = ?"
+     and get_job =
+       Sqlite3.prepare db
+         "SELECT job_id FROM ci_build_index \
+          WHERE owner = ? AND name = ? AND hash = ? AND variant = ?"
+     and get_job_ids =
+       Sqlite3.prepare db
+         "SELECT variant, job_id FROM ci_build_index \
+          WHERE owner = ? AND name = ? AND hash = ?"
+     and get_commits_job_ids_for_ref =
+       Sqlite3.prepare db
+         "SELECT variant, hash, job_id FROM ci_build_index \
+          WHERE owner = ? AND name = ? AND gref = ?"
+     and full_hash =
+       Sqlite3.prepare db
+         "SELECT DISTINCT hash FROM ci_build_index \
+          WHERE owner = ? AND name = ? AND hash LIKE ?"
+     in
+     {
+       record_job;
+       remove;
+       get_jobs;
+       get_job;
+       get_job_ids;
+       get_commits_job_ids_for_ref;
+       full_hash;
+     })
 
 let init () = ignore (Lazy.force db)
 
 let get_job_ids_with_variant t ~owner ~name ~hash =
   Db.query t.get_job_ids Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
   |> List.map @@ function
-  | Sqlite3.Data.[ TEXT variant; NULL ] -> variant, None
-  | Sqlite3.Data.[ TEXT variant; TEXT id ] -> variant, Some id
-  | row -> Fmt.failwith "get_job_ids: invalid row %a" Db.dump_row row
+     | Sqlite3.Data.[ TEXT variant; NULL ] -> (variant, None)
+     | Sqlite3.Data.[ TEXT variant; TEXT id ] -> (variant, Some id)
+     | row -> Fmt.failwith "get_job_ids: invalid row %a" Db.dump_row row
 
+let get_build_history ~owner ~name ~gref =
+  let t = Lazy.force db in
+  Db.query t.get_commits_job_ids_for_ref
+    Sqlite3.Data.[ TEXT owner; TEXT name; TEXT gref ]
+  |> List.map @@ function
+     | Sqlite3.Data.[ TEXT variant; TEXT hash; NULL ] -> (variant, hash, None)
+     | Sqlite3.Data.[ TEXT variant; TEXT hash; TEXT id ] ->
+         (variant, hash, Some id)
+     | row -> Fmt.failwith "get_build_history: invalid row %a" Db.dump_row row
 
 module Status_cache = struct
   let cache = Hashtbl.create 1_000
@@ -85,86 +134,111 @@ module Status_cache = struct
     Hashtbl.add cache (owner, name, hash) status
 
   let find ~owner ~name ~hash : elt =
-    Hashtbl.find_opt cache (owner, name, hash)
-    |> function
-      | Some s -> s
-      | None -> `Not_started
+    Hashtbl.find_opt cache (owner, name, hash) |> function
+    | Some s -> s
+    | None -> `Not_started
 end
 
 let get_status = Status_cache.find
 
-let record ~repo ~hash ~status jobs =
+let record ~repo ~hash ~status ~gref jobs =
   let { Repo_id.owner; name } = repo in
   let t = Lazy.force db in
   let () = Status_cache.add ~owner ~name ~hash status in
   let jobs = Job_map.of_list jobs in
-  let previous = get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list in
+  let previous =
+    get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list
+  in
   let merge variant prev job =
     let set job_id =
-      Log.info (fun f -> f "@[<h>Index.record %s/%s %s %s -> %a@]"
-                   owner name (Astring.String.with_range ~len:6 hash) variant Fmt.(option ~none:(any "-") string) job_id);
+      Log.info (fun f ->
+          f "@[<h>Index.record %s/%s %s %s -> %a@]" owner name
+            (Astring.String.with_range ~len:6 hash)
+            variant
+            Fmt.(option ~none:(any "-") string)
+            job_id);
       match job_id with
-      | None -> Db.exec t.record_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant; NULL ]
-      | Some id -> Db.exec t.record_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT id ]
+      | None ->
+          Db.exec t.record_job
+            Sqlite3.Data.
+              [ TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT gref; NULL ]
+      | Some id ->
+          Db.exec t.record_job
+            Sqlite3.Data.
+              [
+                TEXT owner;
+                TEXT name;
+                TEXT hash;
+                TEXT variant;
+                TEXT gref;
+                TEXT id;
+              ]
     in
     let update j1 j2 =
-      match j1, j2 with
+      match (j1, j2) with
       | Some j1, Some j2 when j1 = j2 -> ()
       | None, None -> ()
       | _, j2 -> set j2
     in
     let remove () =
-      Log.info (fun f -> f "@[<h>Index.record %s/%s %s %s REMOVED@]"
-                   owner name (Astring.String.with_range ~len:6 hash) variant);
-      Db.exec t.remove Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
+      Log.info (fun f ->
+          f "@[<h>Index.record %s/%s %s %s REMOVED@]" owner name
+            (Astring.String.with_range ~len:6 hash)
+            variant);
+      Db.exec t.remove
+        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
     in
-    begin match prev, job with
-      | Some j1, Some j2 -> update j1 j2
-      | None, Some j2 -> set j2
-      | Some _, None -> remove ()
-      | None, None -> assert false
-    end;
+    (match (prev, job) with
+    | Some j1, Some j2 -> update j1 j2
+    | None, Some j2 -> set j2
+    | Some _, None -> remove ()
+    | None, None -> assert false);
     None
   in
-  let _ : [`Empty] Job_map.t = Job_map.merge merge previous jobs in
+  let (_ : [ `Empty ] Job_map.t) = Job_map.merge merge previous jobs in
   ()
 
 let get_full_hash ~owner ~name short_hash =
   let t = Lazy.force db in
-  if is_valid_hash short_hash then (
-    match Db.query t.full_hash Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ] with
+  if is_valid_hash short_hash then
+    match
+      Db.query t.full_hash
+        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ]
+    with
     | [] -> Error `Unknown
-    | [Sqlite3.Data.[ TEXT hash ]] -> Ok hash
-    | [_] -> failwith "full_hash: invalid result!"
+    | [ Sqlite3.Data.[ TEXT hash ] ] -> Ok hash
+    | [ _ ] -> failwith "full_hash: invalid result!"
     | _ :: _ :: _ -> Error `Ambiguous
-  ) else Error `Invalid
+  else Error `Invalid
 
 let get_jobs ~owner ~name hash =
   let t = Lazy.force db in
   Db.query t.get_jobs Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
   |> List.map @@ function
-  | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
-    let outcome = if Current.Job.lookup_running job_id = None then `Aborted else `Active in
-    variant, outcome
-  | Sqlite3.Data.[ TEXT variant; TEXT _; INT ok; BLOB outcome ] ->
-    let outcome =
-      if ok = 1L then `Passed else `Failed outcome
-    in
-    variant, outcome
-  | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] ->
-    variant, `Not_started
-  | row ->
-    Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
+     | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
+         let outcome =
+           if Current.Job.lookup_running job_id = None then `Aborted
+           else `Active
+         in
+         (variant, outcome)
+     | Sqlite3.Data.[ TEXT variant; TEXT _; INT ok; BLOB outcome ] ->
+         let outcome = if ok = 1L then `Passed else `Failed outcome in
+         (variant, outcome)
+     | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] -> (variant, `Not_started)
+     | row -> Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
 
 let get_job ~owner ~name ~hash ~variant =
   let t = Lazy.force db in
-  match Db.query_some t.get_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ] with
+  match
+    Db.query_some t.get_job
+      Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
+  with
   | None -> Error `No_such_variant
   | Some Sqlite3.Data.[ TEXT id ] -> Ok (Some id)
   | Some Sqlite3.Data.[ NULL ] -> Ok None
   | _ -> failwith "get_job: invalid result!"
 
-let get_job_ids  ~owner ~name ~hash =
+let get_job_ids ~owner ~name ~hash =
   let t = Lazy.force db in
   get_job_ids_with_variant t ~owner ~name ~hash |> List.filter_map snd
 
@@ -178,8 +252,12 @@ module Owner_map = Map.Make(String)
 module Repo_set = Set.Make(String)
 
 let active_repos = ref Owner_map.empty
-let set_active_repos ~owner x = active_repos := Owner_map.add owner x !active_repos
-let get_active_repos ~owner = Owner_map.find_opt owner !active_repos |> Option.value ~default:Repo_set.empty
+
+let set_active_repos ~owner x =
+  active_repos := Owner_map.add owner x !active_repos
+
+let get_active_repos ~owner =
+  Owner_map.find_opt owner !active_repos |> Option.value ~default:Repo_set.empty
 
 module Repo_map = Map.Make(Repo_id)
 module Ref_map = Map.Make(String)

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -146,93 +146,67 @@ let record ~repo ~hash ~status ~gref jobs =
   let t = Lazy.force db in
   let () = Status_cache.add ~owner ~name ~hash status in
   let jobs = Job_map.of_list jobs in
-  let previous =
-    get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list
-  in
+  let previous = get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list in
   let merge variant prev job =
     let set job_id =
-      Log.info (fun f ->
-          f "@[<h>Index.record %s/%s %s %s -> %a@]" owner name
-            (Astring.String.with_range ~len:6 hash)
-            variant
-            Fmt.(option ~none:(any "-") string)
-            job_id);
+      Log.info (fun f -> f "@[<h>Index.record %s/%s %s %s -> %a@]"
+                  owner name (Astring.String.with_range ~len:6 hash) variant Fmt.(option ~none:(any "-") string) job_id);
       match job_id with
-      | None ->
-          Db.exec t.record_job
-            Sqlite3.Data.
-              [ TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT gref; NULL ]
-      | Some id ->
-          Db.exec t.record_job
-            Sqlite3.Data.
-              [
-                TEXT owner;
-                TEXT name;
-                TEXT hash;
-                TEXT variant;
-                TEXT gref;
-                TEXT id;
-              ]
+      | None -> Db.exec t.record_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT gref; NULL ]
+      | Some id -> Db.exec t.record_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT gref; TEXT id ]
     in
     let update j1 j2 =
-      match (j1, j2) with
+      match j1, j2 with
       | Some j1, Some j2 when j1 = j2 -> ()
       | None, None -> ()
       | _, j2 -> set j2
     in
     let remove () =
-      Log.info (fun f ->
-          f "@[<h>Index.record %s/%s %s %s REMOVED@]" owner name
-            (Astring.String.with_range ~len:6 hash)
-            variant);
-      Db.exec t.remove
-        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
+      Log.info (fun f -> f "@[<h>Index.record %s/%s %s %s REMOVED@]"
+                   owner name (Astring.String.with_range ~len:6 hash) variant);
+      Db.exec t.remove Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
     in
-    (match (prev, job) with
-    | Some j1, Some j2 -> update j1 j2
-    | None, Some j2 -> set j2
-    | Some _, None -> remove ()
-    | None, None -> assert false);
+    begin match prev, job with
+      | Some j1, Some j2 -> update j1 j2
+      | None, Some j2 -> set j2
+      | Some _, None -> remove ()
+      | None, None -> assert false
+    end;
     None
   in
-  let (_ : [ `Empty ] Job_map.t) = Job_map.merge merge previous jobs in
+  let _ : [`Empty] Job_map.t = Job_map.merge merge previous jobs in
   ()
 
 let get_full_hash ~owner ~name short_hash =
   let t = Lazy.force db in
-  if is_valid_hash short_hash then
-    match
-      Db.query t.full_hash
-        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ]
-    with
+  if is_valid_hash short_hash then (
+    match Db.query t.full_hash Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ] with
     | [] -> Error `Unknown
     | [ Sqlite3.Data.[ TEXT hash ] ] -> Ok hash
     | [ _ ] -> failwith "full_hash: invalid result!"
     | _ :: _ :: _ -> Error `Ambiguous
-  else Error `Invalid
+  ) else Error `Invalid
 
 let get_jobs ~owner ~name hash =
   let t = Lazy.force db in
   Db.query t.get_jobs Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
   |> List.map @@ function
-     | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
-         let outcome =
-           if Current.Job.lookup_running job_id = None then `Aborted
-           else `Active
-         in
-         (variant, outcome)
-     | Sqlite3.Data.[ TEXT variant; TEXT _; INT ok; BLOB outcome ] ->
-         let outcome = if ok = 1L then `Passed else `Failed outcome in
-         (variant, outcome)
-     | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] -> (variant, `Not_started)
-     | row -> Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
+  | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
+    let outcome = if Current.Job.lookup_running job_id = None then `Aborted else `Active in
+    variant, outcome
+  | Sqlite3.Data.[ TEXT variant; TEXT _; INT ok; BLOB outcome ] ->
+    let outcome =
+      if ok = 1L then `Passed else `Failed outcome
+    in
+    variant, outcome
+  | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] ->
+    variant, `Not_started
+  | row ->
+    Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
 
 let get_job ~owner ~name ~hash ~variant =
   let t = Lazy.force db in
-  match
-    Db.query_some t.get_job
-      Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
-  with
+  match Db.query_some t.get_job Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ] with
   | None -> Error `No_such_variant
   | Some Sqlite3.Data.[ TEXT id ] -> Ok (Some id)
   | Some Sqlite3.Data.[ NULL ] -> Ok None
@@ -252,12 +226,8 @@ module Owner_map = Map.Make(String)
 module Repo_set = Set.Make(String)
 
 let active_repos = ref Owner_map.empty
-
-let set_active_repos ~owner x =
-  active_repos := Owner_map.add owner x !active_repos
-
-let get_active_repos ~owner =
-  Owner_map.find_opt owner !active_repos |> Option.value ~default:Repo_set.empty
+let set_active_repos ~owner x = active_repos := Owner_map.add owner x !active_repos
+let get_active_repos ~owner = Owner_map.find_opt owner !active_repos |> Option.value ~default:Repo_set.empty
 
 module Repo_map = Map.Make(Repo_id)
 module Ref_map = Map.Make(String)

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -14,9 +14,10 @@ val record :
   repo:Repo_id.t ->
   hash:string ->
   status:build_status ->
+  gref:string ->
   (string * Current.job_id option) list ->
   unit
-(** [record ~repo ~hash jobs] updates the entry for [repo, hash] to point at [jobs]. *)
+(** [record ~repo ~hash ~gref jobs] updates the entry for [repo, hash] to point at [jobs]. *)
 
 val get_jobs : owner:string -> name:string -> string -> (string * job_state) list
 (** [get_jobs ~owner ~name commit] is the last known set of OCurrent jobs for hash [commit] in repository [owner/name]. *)
@@ -25,6 +26,10 @@ val get_job : owner:string -> name:string -> hash:string -> variant:string -> (s
 (** [get_job ~owner ~name ~variant] is the last known job ID for this combination. *)
 
 val get_job_ids: owner:string -> name:string -> hash:string -> string list
+
+val get_build_history : owner:string -> name:string -> gref:string -> (string * string * string option) list
+(** [get_build_history ~owner ~name ~gref] is a list of builds for the branch gref of the repo identfied by (owner, name) 
+    The builds are identified by triples (variant, hash, Some job_id) *)
 
 val get_status:
   owner:string ->

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -2,31 +2,103 @@ module Index = Ocaml_ci.Index
 module Ref_map = Index.Ref_map
 
 let jobs =
-  let state f (variant, state) = Fmt.pf f "%s:%a" variant Index.pp_job_state state in
-  Alcotest.testable (Fmt.Dump.list state) (=)
+  let state f (variant, state) =
+    Fmt.pf f "%s:%a" variant Index.pp_job_state state
+  in
+  Alcotest.testable (Fmt.Dump.list state) ( = )
 
-let test_simple () =
+let commits_jobs =
+  let state f (variant, hash, job_id) =
+    Fmt.pf f "%s:%s %a@" variant hash Fmt.(Dump.option string) job_id
+  in
+  Alcotest.testable (Fmt.Dump.list state) ( = )
+
+let database = Alcotest.(list string)
+
+let setup () =
+  let db = Lazy.force Current.Db.v in
+  Index.init ();
+  Current.Db.exec_literal db "DELETE FROM cache";
+  db
+
+let test_active_refs () =
   let owner = "owner" in
   let name = "name" in
   let repo = { Ocaml_ci.Repo_id.owner; name } in
   let hash = "abc" in
-  let db = Lazy.force Current.Db.v in
-  Index.init ();
-  Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
-                                     VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', '2019-11-01 9:01', '2019-11-01 9:02', 0)";
   Index.set_active_refs ~repo @@ Ref_map.singleton "master" hash;
-  Index.record ~repo ~hash ~status:`Pending [ "analysis", Some "job1";
-                             "alpine", None ];
-  Alcotest.(check (list (pair string string))) "Refs" ["master", hash] (Index.get_active_refs repo |> Ref_map.bindings);
-  Alcotest.(check jobs) "Jobs" ["alpine", `Not_started; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Current.Db.exec_literal db "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, finished, build)
-                                     VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', '2019-11-01 9:04', '2019-11-01 9:05', 0)";
-  Index.record ~repo ~hash ~status:`Failed [ "analysis", Some "job1";
-                             "alpine", Some "job2" ];
-  Alcotest.(check jobs) "Jobs" ["alpine", `Failed "!"; "analysis", `Passed] @@ Index.get_jobs ~owner ~name hash;
-  Index.record ~repo ~hash ~status:`Passed [ "analysis", Some "job1" ];
-  Alcotest.(check jobs) "Jobs" ["analysis", `Passed] @@ Index.get_jobs ~owner ~name hash
+  Alcotest.(check (list (pair string string)))
+    "Refs"
+    [ ("master", hash) ]
+    (Index.get_active_refs repo |> Ref_map.bindings)
 
-let tests = [
-    Alcotest_lwt.test_case_sync "simple" `Quick test_simple;
+let test_get_jobs () =
+  let db = setup () in
+  Alcotest.check database "Disk store initially empty" [] @@ [];
+  let owner = "owner" in
+  let name = "name" in
+  let repo = { Ocaml_ci.Repo_id.owner; name } in
+  let hash = "abc" in
+  Current.Db.exec_literal db
+    "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, \
+     finished, build) \n\
+     VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', \
+     '2019-11-01 9:01', '2019-11-01 9:02', 0)";
+  Index.record ~repo ~hash ~status:`Pending ~gref:"master"
+    [ ("analysis", Some "job1"); ("alpine", None) ];
+  Alcotest.(check jobs)
+    "Jobs"
+    [ ("alpine", `Not_started); ("analysis", `Passed) ]
+  @@ Index.get_jobs ~owner ~name hash;
+  Current.Db.exec_literal db
+    "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, \
+     finished, build) \n\
+     VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', \
+     '2019-11-01 9:04', '2019-11-01 9:05', 0)";
+  Index.record ~repo ~hash ~status:`Failed ~gref:"master"
+    [ ("analysis", Some "job1"); ("alpine", Some "job2") ];
+  Alcotest.(check jobs)
+    "Jobs"
+    [ ("alpine", `Failed "!"); ("analysis", `Passed) ]
+  @@ Index.get_jobs ~owner ~name hash;
+  Index.record ~repo ~hash ~status:`Passed ~gref:"master"
+    [ ("analysis", Some "job1") ];
+  Alcotest.(check jobs) "Jobs" [ ("analysis", `Passed) ]
+  @@ Index.get_jobs ~owner ~name hash
+
+let test_get_build_history () =
+  let db = setup () in
+  Alcotest.check database "Disk store initially empty" [] @@ [];
+  let owner = "owner" in
+  let name = "name" in
+  let repo = { Ocaml_ci.Repo_id.owner; name } in
+  let hash = "abc" in
+  Current.Db.exec_literal db
+    "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, \
+     finished, build)\n\
+     VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 9:00', \
+     '2019-11-01 9:01', '2019-11-01 9:02', 0)";
+  Index.record ~repo ~hash ~status:`Pending ~gref:"master"
+    [ ("analysis", Some "job1"); ("alpine", None) ];
+  Current.Db.exec_literal db
+    "INSERT INTO cache (op, key, job_id, value, ok, outcome, ready, running, \
+     finished, build)\n\
+     VALUES ('test', x'01', 'job2', x'01', 0, x'21', '2019-11-01 9:03', \
+     '2019-11-01 9:04', '2019-11-01 9:05', 0)";
+  Index.record ~repo ~hash ~status:`Failed ~gref:"master"
+    [ ("analysis", Some "job1"); ("alpine", Some "job2") ];
+  Index.record ~repo ~hash ~status:`Passed ~gref:"master"
+    [ ("analysis", Some "job1") ];
+  Index.record ~repo ~hash:"def" ~status:`Passed ~gref:"master"
+    [ ("lint", Some "job2") ];
+  Alcotest.(check commits_jobs)
+    "Commits"
+    [ ("analysis", "abc", Some "job1"); ("lint", "def", Some "job2") ]
+  @@ Index.get_build_history ~owner ~name ~gref:"master"
+
+let tests =
+  [
+    Alcotest_lwt.test_case_sync "build_history" `Quick test_get_build_history;
+    Alcotest_lwt.test_case_sync "active_refs" `Quick test_active_refs;
+    Alcotest_lwt.test_case_sync "jobs" `Quick test_get_jobs;
   ]


### PR DESCRIPTION
In preparation for supporting history of builds for a branch, we need to add refs to the persistence layer. Then we can lookup the commits/builds associated to the branch of a repo - i.e. to an `(owner, name, ref)`