### PR TITLE
Make the local reproduction command not require to set a new directory up manually

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -100,6 +100,7 @@ module Op = struct
     Current.Job.write job
       (Fmt.str "@.\
                  To reproduce locally:@.@.\
+                 cd $(mktemp -d)@.\
                  %a@.\
                  cat > Dockerfile <<'END-OF-DOCKERFILE'@.\
                  \o033[34m%s\o033[0m\


### PR DESCRIPTION
Makes the command copy/pastable as-is. Otherwise if a `opam-repository` directory is already present in the current directory it might erase some of its content