### PR TITLE
Timestamps on the step page

### DIFF
--- a/api/client.ml
+++ b/api/client.ml
@@ -31,7 +31,13 @@ module Build_status = struct
     | Undefined x -> Fmt.pf f "unknown:%d" x
 end
 
-type job_info = { variant : variant; outcome : State.t }
+type job_info = {
+  variant : variant;
+  outcome : State.t;
+  queued_at : float option;
+  started_at : float option;
+  finished_at : float option;
+}
 
 module CI = struct
   type t = Raw.Client.CI.t Capability.t
@@ -115,12 +121,27 @@ module Commit = struct
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map @@ fun jobs ->
-       Results.jobs_get_list jobs
-       |> List.map (fun job ->
-              let variant = Raw.Reader.JobInfo.variant_get job in
-              let state = Raw.Reader.JobInfo.state_get job in
-              let outcome = Raw.Reader.JobInfo.State.get state in
-              { variant; outcome })
+    Results.jobs_get_list jobs |> List.map (fun job ->
+        let variant = Raw.Reader.JobInfo.variant_get job in
+        let state = Raw.Reader.JobInfo.state_get job in
+        let outcome = Raw.Reader.JobInfo.State.get state in
+        let queued_at = Raw.Reader.JobInfo.queued_at_get job in
+        let queued_at = match Raw.Reader.JobInfo.QueuedAt.get queued_at with
+        | Raw.Reader.JobInfo.QueuedAt.None | Undefined _ -> None
+        | Raw.Reader.JobInfo.QueuedAt.Ts v -> Some v
+        in
+        let started_at = Raw.Reader.JobInfo.started_at_get job in
+        let started_at = match Raw.Reader.JobInfo.StartedAt.get started_at with
+        | Raw.Reader.JobInfo.StartedAt.None | Undefined _ -> None
+        | Raw.Reader.JobInfo.StartedAt.Ts v -> Some v
+        in
+        let finished_at = Raw.Reader.JobInfo.finished_at_get job in
+        let finished_at = match Raw.Reader.JobInfo.FinishedAt.get finished_at with
+        | Raw.Reader.JobInfo.FinishedAt.None | Undefined _ -> None
+        | Raw.Reader.JobInfo.FinishedAt.Ts v -> Some v
+        in
+        { variant; outcome; queued_at; started_at; finished_at }
+      )
 
   let refs t =
     let open Raw.Client.Commit.Refs in

--- a/api/client.ml
+++ b/api/client.ml
@@ -121,27 +121,30 @@ module Commit = struct
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map @@ fun jobs ->
-    Results.jobs_get_list jobs |> List.map (fun job ->
-        let variant = Raw.Reader.JobInfo.variant_get job in
-        let state = Raw.Reader.JobInfo.state_get job in
-        let outcome = Raw.Reader.JobInfo.State.get state in
-        let queued_at = Raw.Reader.JobInfo.queued_at_get job in
-        let queued_at = match Raw.Reader.JobInfo.QueuedAt.get queued_at with
-        | Raw.Reader.JobInfo.QueuedAt.None | Undefined _ -> None
-        | Raw.Reader.JobInfo.QueuedAt.Ts v -> Some v
-        in
-        let started_at = Raw.Reader.JobInfo.started_at_get job in
-        let started_at = match Raw.Reader.JobInfo.StartedAt.get started_at with
-        | Raw.Reader.JobInfo.StartedAt.None | Undefined _ -> None
-        | Raw.Reader.JobInfo.StartedAt.Ts v -> Some v
-        in
-        let finished_at = Raw.Reader.JobInfo.finished_at_get job in
-        let finished_at = match Raw.Reader.JobInfo.FinishedAt.get finished_at with
-        | Raw.Reader.JobInfo.FinishedAt.None | Undefined _ -> None
-        | Raw.Reader.JobInfo.FinishedAt.Ts v -> Some v
-        in
-        { variant; outcome; queued_at; started_at; finished_at }
-      )
+       Results.jobs_get_list jobs
+       |> List.map (fun job ->
+              let variant = Raw.Reader.JobInfo.variant_get job in
+              let state = Raw.Reader.JobInfo.state_get job in
+              let outcome = Raw.Reader.JobInfo.State.get state in
+              let queued_at = Raw.Reader.JobInfo.queued_at_get job in
+              let queued_at =
+                match Raw.Reader.JobInfo.QueuedAt.get queued_at with
+                | Raw.Reader.JobInfo.QueuedAt.None | Undefined _ -> None
+                | Raw.Reader.JobInfo.QueuedAt.Ts v -> Some v
+              in
+              let started_at = Raw.Reader.JobInfo.started_at_get job in
+              let started_at =
+                match Raw.Reader.JobInfo.StartedAt.get started_at with
+                | Raw.Reader.JobInfo.StartedAt.None | Undefined _ -> None
+                | Raw.Reader.JobInfo.StartedAt.Ts v -> Some v
+              in
+              let finished_at = Raw.Reader.JobInfo.finished_at_get job in
+              let finished_at =
+                match Raw.Reader.JobInfo.FinishedAt.get finished_at with
+                | Raw.Reader.JobInfo.FinishedAt.None | Undefined _ -> None
+                | Raw.Reader.JobInfo.FinishedAt.Ts v -> Some v
+              in
+              { variant; outcome; queued_at; started_at; finished_at })
 
   let refs t =
     let open Raw.Client.Commit.Refs in

--- a/api/client.mli
+++ b/api/client.mli
@@ -20,7 +20,13 @@ module State : sig
   val pp : t Fmt.t
 end
 
-type job_info = { variant : variant; outcome : State.t }
+type job_info = {
+  variant : variant;
+  outcome : State.t;
+  queued_at : float option;
+  started_at : float option;
+  finished_at : float option;
+}
 
 module Commit : sig
   type t = Raw.Client.Commit.t Capability.t

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -34,7 +34,26 @@ struct JobInfo {
     # that the server crashed while building, and when it came back up we
     # no longer wanted to test that commit anyway.
   }
+
+  queuedAt  :union {
+    ts         @6 :Float64;
+    # timestamp as seconds since epoch
+    none       @7 :Void;
+  }
+
+  startedAt :union {
+    ts         @8 :Float64;
+    # timestamp as seconds since epoch
+    none       @9 :Void;
+  }
+
+  finishedAt :union {
+    ts         @10 :Float64;
+    # timestamp as seconds since epoch
+    none       @11 :Void;
+  }
 }
+
 
 interface Commit {
   jobs  @0 () -> (jobs :List(JobInfo));

--- a/client/main.ml
+++ b/client/main.ml
@@ -86,8 +86,10 @@ let list_refs repo =
            Fmt.pr "%s %s (%a)@." hash gref Client.Build_status.pp status)
          refs
 
-let pp_job f { Client.variant; outcome } =
-  Fmt.pf f "%s (%a)" variant Client.State.pp outcome
+let pp_job f { Client.variant; outcome; queued_at; started_at; finished_at } =
+  Fmt.pf f "%s (%a) (Queued_at: %g) (Started_at: %g) (Finished_at: %g)"
+    variant Client.State.pp outcome (Option.value queued_at ~default:(-1.))
+    (Option.value started_at ~default:(-1.)) (Option.value finished_at ~default:(-1.))
 
 let list_variants commit =
   Client.Commit.jobs commit

--- a/client/main.ml
+++ b/client/main.ml
@@ -87,9 +87,11 @@ let list_refs repo =
          refs
 
 let pp_job f { Client.variant; outcome; queued_at; started_at; finished_at } =
-  Fmt.pf f "%s (%a) (Queued_at: %g) (Started_at: %g) (Finished_at: %g)"
-    variant Client.State.pp outcome (Option.value queued_at ~default:(-1.))
-    (Option.value started_at ~default:(-1.)) (Option.value finished_at ~default:(-1.))
+  Fmt.pf f "%s (%a) (Queued_at: %g) (Started_at: %g) (Finished_at: %g)" variant
+    Client.State.pp outcome
+    (Option.value queued_at ~default:(-1.))
+    (Option.value started_at ~default:(-1.))
+    (Option.value finished_at ~default:(-1.))
 
 let list_variants commit =
   Client.Commit.jobs commit

--- a/dune-project
+++ b/dune-project
@@ -100,4 +100,5 @@
   (lwt (>= 5.6.1))
   ocaml-ci-api
   (prometheus-app (>= 1.2))
-  tyxml))
+  tyxml
+  (timedesc (>= 0.9.0))))

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -215,20 +215,20 @@ let get_jobs ~owner ~name hash =
   let t = Lazy.force db in
   Db.query t.get_jobs Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
   |> List.map @@ function
-  | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
-    let outcome = if Current.Job.lookup_running job_id = None then `Aborted else `Active in
-    let ts = Run_time.timestamps_of_job job_id in
-    variant, outcome, ts
-  | Sqlite3.Data.[ TEXT variant; TEXT job_id; INT ok; BLOB outcome ] ->
-    let outcome =
-      if ok = 1L then `Passed else `Failed outcome
-    in
-    let ts = Run_time.timestamps_of_job job_id in
-    variant, outcome, ts
-  | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] ->
-    variant, `Not_started, None
-  | row ->
-    Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
+     | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
+         let outcome =
+           if Current.Job.lookup_running job_id = None then `Aborted
+           else `Active
+         in
+         let ts = Run_time.timestamps_of_job job_id in
+         (variant, outcome, ts)
+     | Sqlite3.Data.[ TEXT variant; TEXT job_id; INT ok; BLOB outcome ] ->
+         let outcome = if ok = 1L then `Passed else `Failed outcome in
+         let ts = Run_time.timestamps_of_job job_id in
+         (variant, outcome, ts)
+     | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] ->
+         (variant, `Not_started, None)
+     | row -> Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
 
 let get_job ~owner ~name ~hash ~variant =
   let t = Lazy.force db in

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -24,11 +24,11 @@ val record :
 (** [record ~repo ~hash ~gref jobs] updates the entry for [repo, hash] to point
     at [jobs]. *)
 
-val get_jobs : owner:string -> name:string -> string -> (string * job_state * Run_time.timestamps option) list
-(** [get_jobs ~owner ~name commit] is the last known set of OCurrent jobs for hash [commit] in repository [owner/name]. *)
-
 val get_jobs :
-  owner:string -> name:string -> string -> (string * job_state) list
+  owner:string ->
+  name:string ->
+  string ->
+  (string * job_state * Run_time.timestamps option) list
 (** [get_jobs ~owner ~name commit] is the last known set of OCurrent jobs for
     hash [commit] in repository [owner/name]. *)
 

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -24,6 +24,9 @@ val record :
 (** [record ~repo ~hash ~gref jobs] updates the entry for [repo, hash] to point
     at [jobs]. *)
 
+val get_jobs : owner:string -> name:string -> string -> (string * job_state * Run_time.timestamps option) list
+(** [get_jobs ~owner ~name commit] is the last known set of OCurrent jobs for hash [commit] in repository [owner/name]. *)
+
 val get_jobs :
   owner:string -> name:string -> string -> (string * job_state) list
 (** [get_jobs ~owner ~name commit] is the last known set of OCurrent jobs for

--- a/lib/run_time.ml
+++ b/lib/run_time.ml
@@ -66,9 +66,9 @@ let timestamps_eq st1 st2 =
         cmp_floats ready1 ready2 && cmp_floats finished1 finished2
     | Finished {ready=ready1; started=Some started1; finished=finished1}, Finished {ready=ready2; started=Some started2; finished=finished2} ->
         cmp_floats ready1 ready2 && cmp_floats started1 started2 && cmp_floats finished1 finished2
-    | Queued _, (Running _ | Finished _ ) -> false
-    | Running _, (Queued _ | Finished _) -> false
-    | Finished {started=None; _}, (Queued _ | Running _ | Finished {started=Some _; _}) -> false
+    | Queued _, (Running _ | Finished _ )
+    | Running _, (Queued _ | Finished _) 
+    | Finished {started=None; _}, (Queued _ | Running _ | Finished {started=Some _; _})
     | Finished {started=Some _; _}, (Queued _ | Running _ | Finished {started=None; _}) -> false
 
 let info_to_string = function

--- a/lib/run_time.ml
+++ b/lib/run_time.ml
@@ -58,7 +58,7 @@ type run_time_info =
   | Finished of { queued_for : float; ran_for : float option }
 [@@deriving show]
 
-let timestamps_eq st1 st2 =
+let eq_timestamps st1 st2 =
     match (st1, st2) with
     | Queued v1, Queued v2 -> cmp_floats v1 v2
     | Running v1, Running v2 -> cmp_floats v1.ready v2.ready && cmp_floats v1.started v2.started

--- a/lib/run_time.mli
+++ b/lib/run_time.mli
@@ -39,7 +39,7 @@ type run_time_info =
           - Finished - has a queued_for and an optional ran_for duration. The
             ran_for duration will be None when it did not run. *)
 
-val timestamps_eq : timestamps -> timestamps -> bool
+val eq_timestamps : timestamps -> timestamps -> bool
 (** equality of timestamps - useful for tests *)
 
 val pp_timestamps : Format.formatter -> timestamps -> unit

--- a/lib/run_time.mli
+++ b/lib/run_time.mli
@@ -39,6 +39,9 @@ type run_time_info =
           - Finished - has a queued_for and an optional ran_for duration. The
             ran_for duration will be None when it did not run. *)
 
+val timestamps_eq : timestamps -> timestamps -> bool
+(** equality of timestamps - useful for tests *)
+
 val pp_timestamps : Format.formatter -> timestamps -> unit
 (** ppx_derived show formatter for timestamps *)
 
@@ -60,5 +63,5 @@ val merge : timestamps -> timestamps -> timestamps
 (** Merges two timestamps describe the timings of the 'build' that is
     represented by the two steps that correspond to the given timestamps. *)
 
-val of_build : owner:string -> name:string -> hash:string -> timestamps option
-(** Derives the timestamps of a build identified by (owner, name, hash) *)
+val of_build : string list -> timestamps option
+(** Derives the timestamps of a build specified by `[ job_id ]` *)

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -17,6 +17,7 @@ depends: [
   "ocaml-ci-api"
   "prometheus-app" {>= "1.2"}
   "tyxml"
+  "timedesc" {>= "0.9.0"}
   "odoc" {with-doc}
 ]
 build: [

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -3,93 +3,91 @@ module Raw = Ocaml_ci_api.Raw
 module String_map = Map.Make (String)
 module Index = Ocaml_ci.Index
 module Run_time = Ocaml_ci.Run_time
-
 open Capnp_rpc_lwt
 
 let make_commit ~engine ~owner ~name hash =
   let module Commit = Raw.Service.Commit in
-  Commit.local @@ object
-    inherit Commit.service
+  Commit.local
+  @@ object
+       inherit Commit.service
 
-    method jobs_impl _params release_param_caps =
-      let open Commit.Jobs in
-      release_param_caps ();
-      let jobs = Index.get_jobs ~owner ~name hash in
-      let response, results = Service.Response.create Results.init_pointer in
-      let arr = Results.jobs_init results (List.length jobs) in
-      jobs |> List.iteri (fun i (variant, outcome, ts) ->
-          let slot = Capnp.Array.get arr i in
-          Raw.Builder.JobInfo.variant_set slot variant;
-          let queued_at, started_at, finished_at = match ts with
-          | None -> None, None, None
-          | Some Run_time.Queued v -> Some v, None, None
-          | Some Running v -> Some v.ready, Some v.started, None
-          | Some Finished v -> Some v.ready, v.started, Some v.finished
-          in
-          let queued_at_t = Raw.Builder.JobInfo.queued_at_init slot in
-          let module S = Raw.Builder.JobInfo.QueuedAt in
-          begin
-            match queued_at with
-            | None -> S.none_set queued_at_t
-            | Some v -> S.ts_set queued_at_t v
-          end;
-          let started_at_t = Raw.Builder.JobInfo.started_at_init slot in
-          let module S = Raw.Builder.JobInfo.StartedAt in
-          begin
-            match started_at with
-            | None -> S.none_set started_at_t
-            | Some v -> S.ts_set started_at_t v
-          end;
-          let finished_at_t = Raw.Builder.JobInfo.finished_at_init slot in
-          let module S = Raw.Builder.JobInfo.FinishedAt in
-          begin
-            match finished_at with
-            | None -> S.none_set finished_at_t
-            | Some v -> S.ts_set finished_at_t v
-          end;
-          let state = Raw.Builder.JobInfo.state_init slot in
-          let module S = Raw.Builder.JobInfo.State in
-          match outcome with
-          | `Not_started -> S.not_started_set state
-          | `Passed -> S.passed_set state
-          | `Aborted -> S.aborted_set state
-          | `Active -> S.active_set state
-          | `Failed msg -> S.failed_set state msg
-        );
-      Service.return response
+       method jobs_impl _params release_param_caps =
+         let open Commit.Jobs in
+         release_param_caps ();
+         let jobs = Index.get_jobs ~owner ~name hash in
+         let response, results = Service.Response.create Results.init_pointer in
+         let arr = Results.jobs_init results (List.length jobs) in
+         jobs
+         |> List.iteri (fun i (variant, outcome, ts) ->
+                let slot = Capnp.Array.get arr i in
+                Raw.Builder.JobInfo.variant_set slot variant;
+                let queued_at, started_at, finished_at =
+                  match ts with
+                  | None -> (None, None, None)
+                  | Some (Run_time.Queued v) -> (Some v, None, None)
+                  | Some (Running v) -> (Some v.ready, Some v.started, None)
+                  | Some (Finished v) ->
+                      (Some v.ready, v.started, Some v.finished)
+                in
+                let queued_at_t = Raw.Builder.JobInfo.queued_at_init slot in
+                let module S = Raw.Builder.JobInfo.QueuedAt in
+                (match queued_at with
+                | None -> S.none_set queued_at_t
+                | Some v -> S.ts_set queued_at_t v);
+                let started_at_t = Raw.Builder.JobInfo.started_at_init slot in
+                let module S = Raw.Builder.JobInfo.StartedAt in
+                (match started_at with
+                | None -> S.none_set started_at_t
+                | Some v -> S.ts_set started_at_t v);
+                let finished_at_t = Raw.Builder.JobInfo.finished_at_init slot in
+                let module S = Raw.Builder.JobInfo.FinishedAt in
+                (match finished_at with
+                | None -> S.none_set finished_at_t
+                | Some v -> S.ts_set finished_at_t v);
+                let state = Raw.Builder.JobInfo.state_init slot in
+                let module S = Raw.Builder.JobInfo.State in
+                match outcome with
+                | `Not_started -> S.not_started_set state
+                | `Passed -> S.passed_set state
+                | `Aborted -> S.aborted_set state
+                | `Active -> S.active_set state
+                | `Failed msg -> S.failed_set state msg);
+         Service.return response
 
-    method job_of_variant_impl params release_param_caps =
-      let open Commit.JobOfVariant in
-      let variant = Params.variant_get params in
-      release_param_caps ();
-      match Index.get_job ~owner ~name ~hash ~variant with
-      | Error `No_such_variant -> Service.fail "No such variant %S" variant
-      | Ok None -> Service.fail "No job for variant %S yet" variant
-      | Ok (Some id) ->
-        let job = Rpc.job ~engine id in
-        let response, results = Service.Response.create Results.init_pointer in
-        Results.job_set results (Some job);
-        Capability.dec_ref job;
-        Service.return response
+       method job_of_variant_impl params release_param_caps =
+         let open Commit.JobOfVariant in
+         let variant = Params.variant_get params in
+         release_param_caps ();
+         match Index.get_job ~owner ~name ~hash ~variant with
+         | Error `No_such_variant -> Service.fail "No such variant %S" variant
+         | Ok None -> Service.fail "No job for variant %S yet" variant
+         | Ok (Some id) ->
+             let job = Rpc.job ~engine id in
+             let response, results =
+               Service.Response.create Results.init_pointer
+             in
+             Results.job_set results (Some job);
+             Capability.dec_ref job;
+             Service.return response
 
-    method refs_impl _params release_param_caps =
-      let open Commit.Refs in
-      release_param_caps ();
-      let refs =
-        Index.get_active_refs { Ocaml_ci.Repo_id.owner; name }
-        |> Index.Ref_map.bindings
-        |> List.filter_map (fun (name, h) -> if h = hash then Some name else None)
-      in
-      let response, results = Service.Response.create Results.init_pointer in
-      Results.refs_set_list results refs |> ignore;
-      Service.return response
+       method refs_impl _params release_param_caps =
+         let open Commit.Refs in
+         release_param_caps ();
+         let refs =
+           Index.get_active_refs { Ocaml_ci.Repo_id.owner; name }
+           |> Index.Ref_map.bindings
+           |> List.filter_map (fun (name, h) ->
+                  if h = hash then Some name else None)
+         in
+         let response, results = Service.Response.create Results.init_pointer in
+         Results.refs_set_list results refs |> ignore;
+         Service.return response
 
-    method status_impl _params release_param_caps =
-      let open Commit.Status in
-      release_param_caps ();
-      let response, results = Service.Response.create Results.init_pointer in
-      Index.get_status ~owner ~name ~hash
-      |> (function
+       method status_impl _params release_param_caps =
+         let open Commit.Status in
+         release_param_caps ();
+         let response, results = Service.Response.create Results.init_pointer in
+         (Index.get_status ~owner ~name ~hash |> function
           | `Not_started -> Results.status_set results NotStarted
           | `Pending -> Results.status_set results Pending
           | `Failed -> Results.status_set results Failed

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -2,19 +2,18 @@ module Index = Ocaml_ci.Index
 module Ref_map = Index.Ref_map
 module Run_time = Ocaml_ci.Run_time
 
-
 let jobs =
   let state f (variant, state, (ts : Run_time.timestamps option)) =
     let ts' =
-    match ts with
-    | None -> ""
-    | Some ts -> Fmt.str "%a" Run_time.pp_timestamps ts
+      match ts with
+      | None -> ""
+      | Some ts -> Fmt.str "%a" Run_time.pp_timestamps ts
     in
     Fmt.pf f "%s:%a:%s" variant Index.pp_job_state state ts'
   in
   let equal (v1, s1, ts1) (v2, s2, ts2) =
-    match ts1, ts2 with
-    | None, None -> v1=v2 && s1=s2
+    match (ts1, ts2) with
+    | None, None -> v1 = v2 && s1 = s2
     | None, Some _ | Some _, None -> false
     | Some ts1, Some ts2 -> v1 = v2 && s1 = s2 && Run_time.eq_timestamps ts1 ts2
   in
@@ -57,11 +56,19 @@ let test_get_jobs () =
      finished, build) \n\
      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 09:00', \
      '2019-11-01 09:01', '2019-11-01 09:02', 0)";
-  Index.record ~repo ~hash ~status:`Pending ~gref:"master" [ ("analysis", Some "job1"); ("alpine", None) ];
-  let job_1_ts : Run_time.timestamps = Run_time.Finished { ready=1572598800.;
-                                                           started=Some 1572598860.;
-                                                           finished=1572598920. } in
-  let expected = [ ("alpine", `Not_started, None); ("analysis", `Passed, Some job_1_ts) ] in
+  Index.record ~repo ~hash ~status:`Pending ~gref:"master"
+    [ ("analysis", Some "job1"); ("alpine", None) ];
+  let job_1_ts : Run_time.timestamps =
+    Run_time.Finished
+      {
+        ready = 1572598800.;
+        started = Some 1572598860.;
+        finished = 1572598920.;
+      }
+  in
+  let expected =
+    [ ("alpine", `Not_started, None); ("analysis", `Passed, Some job_1_ts) ]
+  in
   let result = Index.get_jobs ~owner ~name hash in
   Alcotest.(check jobs) "Jobs" expected result;
 
@@ -72,10 +79,20 @@ let test_get_jobs () =
      '2019-11-01 09:04', '2019-11-01 09:05', 0)";
   Index.record ~repo ~hash ~status:`Failed ~gref:"master"
     [ ("analysis", Some "job1"); ("alpine", Some "job2") ];
-  let job_2_ts : Run_time.timestamps = Run_time.Finished { ready=1572598980.;
-                                                           started=Some 1572599040.;
-                                                           finished=1572599100. } in
-  let expected = [ ("alpine", `Failed "!", Some job_2_ts); ("analysis", `Passed, Some job_1_ts) ] in
+  let job_2_ts : Run_time.timestamps =
+    Run_time.Finished
+      {
+        ready = 1572598980.;
+        started = Some 1572599040.;
+        finished = 1572599100.;
+      }
+  in
+  let expected =
+    [
+      ("alpine", `Failed "!", Some job_2_ts);
+      ("analysis", `Passed, Some job_1_ts);
+    ]
+  in
   let result = Index.get_jobs ~owner ~name hash in
   Alcotest.(check jobs) "Jobs" expected result;
 

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -16,7 +16,7 @@ let jobs =
     match ts1, ts2 with
     | None, None -> v1=v2 && s1=s2
     | None, Some _ | Some _, None -> false
-    | Some ts1, Some ts2 -> v1 = v2 && s1 = s2 && Run_time.timestamps_eq ts1 ts2
+    | Some ts1, Some ts2 -> v1 = v2 && s1 = s2 && Run_time.eq_timestamps ts1 ts2
   in
   Alcotest.testable (Fmt.Dump.list state) (List.equal equal)
 

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -1,11 +1,24 @@
 module Index = Ocaml_ci.Index
 module Ref_map = Index.Ref_map
+module Run_time = Ocaml_ci.Run_time
+
 
 let jobs =
-  let state f (variant, state) =
-    Fmt.pf f "%s:%a" variant Index.pp_job_state state
+  let state f (variant, state, (ts : Run_time.timestamps option)) =
+    let ts' =
+    match ts with
+    | None -> ""
+    | Some ts -> Fmt.str "%a" Run_time.pp_timestamps ts
+    in
+    Fmt.pf f "%s:%a:%s" variant Index.pp_job_state state ts'
   in
-  Alcotest.testable (Fmt.Dump.list state) ( = )
+  let equal (v1, s1, ts1) (v2, s2, ts2) =
+    match ts1, ts2 with
+    | None, None -> v1=v2 && s1=s2
+    | None, Some _ | Some _, None -> false
+    | Some ts1, Some ts2 -> v1 = v2 && s1 = s2 && Run_time.timestamps_eq ts1 ts2
+  in
+  Alcotest.testable (Fmt.Dump.list state) (List.equal equal)
 
 let commits_jobs =
   let state f (variant, hash, job_id) =
@@ -44,9 +57,11 @@ let test_get_jobs () =
      finished, build) \n\
      VALUES ('test', x'00', 'job1', x'01', 1, x'02', '2019-11-01 09:00', \
      '2019-11-01 09:01', '2019-11-01 09:02', 0)";
-  Index.record ~repo ~hash ~status:`Pending ~gref:"master"
-    [ ("analysis", Some "job1"); ("alpine", None) ];
-  let expected = [ ("alpine", `Not_started); ("analysis", `Passed) ] in
+  Index.record ~repo ~hash ~status:`Pending ~gref:"master" [ ("analysis", Some "job1"); ("alpine", None) ];
+  let job_1_ts : Run_time.timestamps = Run_time.Finished { ready=1572598800.;
+                                                           started=Some 1572598860.;
+                                                           finished=1572598920. } in
+  let expected = [ ("alpine", `Not_started, None); ("analysis", `Passed, Some job_1_ts) ] in
   let result = Index.get_jobs ~owner ~name hash in
   Alcotest.(check jobs) "Jobs" expected result;
 
@@ -57,13 +72,16 @@ let test_get_jobs () =
      '2019-11-01 09:04', '2019-11-01 09:05', 0)";
   Index.record ~repo ~hash ~status:`Failed ~gref:"master"
     [ ("analysis", Some "job1"); ("alpine", Some "job2") ];
-  let expected = [ ("alpine", `Failed "!"); ("analysis", `Passed) ] in
+  let job_2_ts : Run_time.timestamps = Run_time.Finished { ready=1572598980.;
+                                                           started=Some 1572599040.;
+                                                           finished=1572599100. } in
+  let expected = [ ("alpine", `Failed "!", Some job_2_ts); ("analysis", `Passed, Some job_1_ts) ] in
   let result = Index.get_jobs ~owner ~name hash in
   Alcotest.(check jobs) "Jobs" expected result;
 
   Index.record ~repo ~hash ~status:`Passed ~gref:"master"
     [ ("analysis", Some "job1") ];
-  let expected = [ ("analysis", `Passed) ] in
+  let expected = [ ("analysis", `Passed, Some job_1_ts) ] in
   let result = Index.get_jobs ~owner ~name hash in
   Alcotest.(check jobs) "Jobs" expected result
 

--- a/test/test_run_time.ml
+++ b/test/test_run_time.ml
@@ -12,7 +12,9 @@ let database = Alcotest.(list string)
 let cmp_floats v1 v2 = abs_float (v1 -. v2) < 0.0000001
 
 let timestamps =
-  let state f (st: Run_time.timestamps) = Fmt.pf f "%a" Run_time.pp_timestamps st in
+  let state f (st : Run_time.timestamps) =
+    Fmt.pf f "%a" Run_time.pp_timestamps st
+  in
   Alcotest.testable (Fmt.Dump.list state) (List.equal Run_time.eq_timestamps)
 
 let run_time_info =
@@ -238,11 +240,16 @@ let test_timestamps_of_build () =
 
     Note: 2019-11-01 09:00:00 is 1572598800 milliseconds from epoch
   *)
-  let expected : Run_time.timestamps = Run_time.Finished { ready=1572598800.;
-                                                           started=Some 1572598860.;
-                                                           finished=1572599100. } in
+  let expected : Run_time.timestamps =
+    Run_time.Finished
+      {
+        ready = 1572598800.;
+        started = Some 1572598860.;
+        finished = 1572599100.;
+      }
+  in
   let result = Option.get @@ Run_time.of_build [ "job1"; "job2" ] in
-  Alcotest.(check timestamps) "timestamps_of_build" [expected] [result]
+  Alcotest.(check timestamps) "timestamps_of_build" [ expected ] [ result ]
 
 let test_timestamps_of_queued_build () =
   let db = setup () in
@@ -275,7 +282,7 @@ let test_timestamps_of_queued_build () =
   *)
   let expected : Run_time.timestamps = Run_time.Queued 1572598800. in
   let result = Option.get @@ Run_time.of_build [ "job1"; "job2" ] in
-  Alcotest.(check timestamps) "timestamps_of_build" [expected] [result]
+  Alcotest.(check timestamps) "timestamps_of_build" [ expected ] [ result ]
 
 let test_timestamps_of_three_steps_build () =
   let db = setup () in
@@ -315,12 +322,16 @@ let test_timestamps_of_three_steps_build () =
 
     Note: 2019-11-01 09:00:00 is 1572598800 milliseconds from epoch
   *)
-
-  let expected : Run_time.timestamps = Run_time.Finished {ready=1572598800.;
-                                                          started=Some 1572598860.;
-                                                          finished=1572599340.} in
+  let expected : Run_time.timestamps =
+    Run_time.Finished
+      {
+        ready = 1572598800.;
+        started = Some 1572598860.;
+        finished = 1572599340.;
+      }
+  in
   let result = Option.get @@ Run_time.of_build [ "job1"; "job2"; "job3" ] in
-  Alcotest.(check timestamps) "timestamps_of_build" [expected] [result]
+  Alcotest.(check timestamps) "timestamps_of_build" [ expected ] [ result ]
 
 let tests =
   [

--- a/test/test_run_time.ml
+++ b/test/test_run_time.ml
@@ -13,7 +13,7 @@ let cmp_floats v1 v2 = abs_float (v1 -. v2) < 0.0000001
 
 let timestamps =
   let state f (st: Run_time.timestamps) = Fmt.pf f "%a" Run_time.pp_timestamps st in
-  Alcotest.testable (Fmt.Dump.list state) (List.equal Run_time.timestamps_eq)
+  Alcotest.testable (Fmt.Dump.list state) (List.equal Run_time.eq_timestamps)
 
 let run_time_info =
   let state f (rt : Run_time.run_time_info) =

--- a/web-ui/view/dune
+++ b/web-ui/view/dune
@@ -1,4 +1,4 @@
 (library
  (public_name ocaml-ci-web.view)
  (name view)
- (libraries ansi unix fmt dream tyxml ocaml_ci_api))
+ (libraries ansi unix fmt dream tyxml ocaml_ci_api timedesc))

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -175,6 +175,30 @@ let list_refs ~org ~repo ~refs =
       refs_v ~org ~repo ~refs;
     ]
 
+let show_timestamps step_info =
+  let to_iso8601 (tt : float) =
+    let ts = Timedesc.of_timestamp_float_s tt in
+    Timedesc.to_iso8601 @@ Option.get ts
+  in
+  match step_info with
+  | None -> div [ span [ txt @@ Fmt.str "-" ] ]
+  | Some step_info ->
+      let queued_at =
+        Option.fold ~none:"-" ~some:to_iso8601 step_info.Client.queued_at
+      in
+      let started_at =
+        Option.fold ~none:"-" ~some:to_iso8601 step_info.Client.started_at
+      in
+      let finished_at =
+        Option.fold ~none:"-" ~some:to_iso8601 step_info.Client.finished_at
+      in
+      ul
+        [
+          li [ txt @@ Fmt.str "Queued at: %s" queued_at ];
+          li [ txt @@ Fmt.str "Started at: %s" started_at ];
+          li [ txt @@ Fmt.str "Finished at: %s" finished_at ];
+        ]
+
 let cancel_success_message success =
   let format_job_info ji =
     li [ span [ txt @@ Fmt.str "Cancelling job: %s" ji.Client.variant ] ]
@@ -327,6 +351,9 @@ let show_step ~org ~repo ~refs ~hash ~jobs ~variant ~job ~status ~csrf_token
         ]
       else []
     in
+    let step_info =
+      List.find_opt (fun (j : Client.job_info) -> j.variant = variant) jobs
+    in
     let body =
       Template.instance ~flash_messages
         [
@@ -340,6 +367,7 @@ let show_step ~org ~repo ~refs ~hash ~jobs ~variant ~job ~status ~csrf_token
             variant;
           link_github_refs ~org ~repo refs;
           link_jobs ~org ~repo ~hash ~selected:variant jobs;
+          show_timestamps step_info;
           div buttons;
           pre [ txt "@@@" ];
         ]

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -145,7 +145,7 @@ let link_github_refs ~org ~repo = function
         @ [ txt ")" ])
 
 let link_jobs ~org ~repo ~hash ?selected jobs =
-  let render_job trees { Client.variant; outcome } =
+  let render_job trees { Client.variant; outcome; _ } =
     let uri = job_url ~org ~repo ~hash variant in
     match
       List.rev


### PR DESCRIPTION
This builds on https://github.com/ocurrent/ocaml-ci/pull/516 to use `Timedesc` to write out ISO8601 timestamps in the local timezone.

<img width="614" alt="Screen Shot 2022-08-25 at 4 32 57 pm" src="https://user-images.githubusercontent.com/181086/186612225-01373ab9-d82d-4522-9393-f3cc4353f497.png">
