### PR TITLE
Support history within the web UI

### DIFF
--- a/api/client.mli
+++ b/api/client.mli
@@ -68,6 +68,14 @@ module Repo : sig
 
   val commit_of_ref : t -> git_ref -> Commit.t
   (** [commit_of_ref t gref] is the commit at the head of Git reference [gref]. *)
+
+  val history_of_ref :
+    t ->
+    git_ref ->
+    ( (Build_status.t * float option) Ref_map.t,
+      [> `Capnp of Capnp_rpc.Error.t ] )
+    Lwt_result.t
+  (** [history_of_ref t gref] is the list of builds for the Git reference [gref] *)
 end
 
 module Org : sig

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -13,6 +13,10 @@ struct RefInfo {
   ref         @0 :Text;
   hash        @1 :Text;
   state       @2 :BuildStatus;
+  started     :union {
+    ts        @3 :Float64;
+    none      @4 :Void;
+  }
   # The state of the ref's head commit
 }
 
@@ -78,6 +82,9 @@ interface Repo {
   # The hash doesn't need to be the full hash, but must be at least 6 characters long.
 
   commitOfRef @5 (ref :Text) -> (commit :Commit);
+  # ref should be of the form "refs/heads/..." or "refs/pull/4/head"
+
+  historyOfRef @6 (ref :Text) -> (refs :List(RefInfo));
   # ref should be of the form "refs/heads/..." or "refs/pull/4/head"
 }
 

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -52,6 +52,15 @@ val get_build_history :
     gref of the repo identfied by (owner, name) The builds are identified by
     triples (variant, hash, Some job_id) *)
 
+val get_build_history_with_time :
+  owner:string ->
+  name:string ->
+  gref:string ->
+  (string * string * float option) list
+(** [get_build_history_with_time ~owner ~name ~gref] is a list of builds for the
+    branch gref of the repo identfied by (owner, name). The builds are
+    identified by triples (variant, hash, Some timestamp) *)
+
 val get_status : owner:string -> name:string -> hash:string -> build_status
 (** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
 

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -108,6 +108,25 @@ let create ~github ~gitlab =
             ~org:(Dream.param request "org")
             ~repo:(Dream.param request "repo")
             github);
+      Dream.get "/github/:org/:repo/history/branch/**" (fun request ->
+          let fpath = Dream.target request |> Dream.from_path in
+          let rec f = function
+            | [] -> Dream.empty `Not_Found
+            | "branch" :: refs ->
+                let gref = String.concat Filename.dir_sep refs in
+                Controller.Github.list_history
+                  ~org:(Dream.param request "org")
+                  ~repo:(Dream.param request "repo")
+                  ~gref:(`Branch gref) github
+            | _ :: paths -> f paths
+          in
+          f fpath);
+      Dream.get "/github/:org/:repo/history/pull/:number" (fun request ->
+          let number = Dream.param request "number" in
+          Controller.Github.list_history
+            ~org:(Dream.param request "org")
+            ~repo:(Dream.param request "repo")
+            ~gref:(`Pull number) github);
       Dream.get "/github/:org/:repo/commit/:hash" (fun request ->
           Controller.Github.list_steps
             ~org:(Dream.param request "org")

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -40,6 +40,13 @@ module type View = sig
     refs:(string * Build_status.t) Client.Ref_map.t ->
     string
 
+  val list_history :
+    org:string ->
+    repo:string ->
+    ref:string ->
+    history:(string * Client.Build_status.t) list ->
+    string
+
   val list_steps :
     org:string ->
     repo:string ->

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -47,6 +47,15 @@ let refs_v ~org ~repo ~refs =
          ~a:[ a_class [ Build_status.class_name status ] ]
          [ a ~a:[ a_href (commit_url ~org ~repo commit) ] [ txt branch ] ])
 
+let history_v ~org ~repo ~history =
+  ul
+    ~a:[ a_class [ "statuses" ] ]
+    (history
+    |> List.map @@ fun (commit, status) ->
+       li
+         ~a:[ a_class [ Build_status.class_name status ] ]
+         [ a ~a:[ a_href (commit_url ~org ~repo commit) ] [ txt commit ] ])
+
 let link_gitlab_refs ~org ~repo = function
   | [] -> txt "(not at the head of any monitored branch or merge request)"
   | refs ->
@@ -104,6 +113,14 @@ let list_refs ~org ~repo ~refs =
   Template.instance
     [
       breadcrumbs [ (prefix, prefix); (org, org) ] repo; refs_v ~org ~repo ~refs;
+    ]
+
+let list_history ~org ~repo ~ref ~history =
+  Template.instance
+    [
+      breadcrumbs [ (prefix, prefix); (org, org) ] repo;
+      link_gitlab_refs ~org ~repo [ ref ];
+      history_v ~org ~repo ~history;
     ]
 
 let cancel_success_message success =


### PR DESCRIPTION
This PR introduces a building history into the web UI as a hidden link. Next PR will make it accessible from the step interface and conform it with the new UI.
- [X] Update the Capn Proto schema to support history
- [X] Create a view for GitHub
- [x] Create a view for GitLab
- [x] Replace `Either.t` with a custom type