### PR TITLE
Cleanup small things in build & step pages

### DIFF
--- a/lib_client/run_time.ml
+++ b/lib_client/run_time.ml
@@ -31,20 +31,8 @@ let duration_pp ppf t =
           Fmt.pf ppf "%dm%02ds" min sec
   else
     (* below one minute *)
-    let fields t =
-      let sec = to_sec_64 t in
-      let left = Int64.sub t (of_sec_64 sec) in
-      let ms = to_ms_64 left in
-      let left = Int64.sub left (of_ms_64 ms) in
-      let us = to_us_64 left in
-      let ns = Int64.(sub left (of_us_64 us)) in
-      (sec, ms, us, ns)
-    in
-    let s, ms, us, ns = fields t in
-    if s > 0L then Fmt.pf ppf "%Lds" s
-    else if ms > 0L then Fmt.pf ppf "%Ldms" ms
-    else (* if us > 0 then *)
-      Fmt.pf ppf "%Ld.%03Ldus" us ns
+    let sec = to_sec t in
+    Fmt.pf ppf "%ds" sec
 
 let cmp_floats v1 v2 = abs_float (v1 -. v2) < 0.0000001
 

--- a/test/test_run_time_client.ml
+++ b/test/test_run_time_client.ml
@@ -440,6 +440,35 @@ let test_first_step_queued_at =
   Alcotest.(check (result (float 0.001) string))
     "first_step_queued_at not-empty" expected result
 
+let test_duration_pp =
+  let ten_power_9 : int64 = 1000000000L in
+
+  let expected = "0s" in
+  let result = Fmt.str "%a" Run_time.duration_pp 0L in
+  Alcotest.(check string) "Os are printed without microseconds" expected result;
+
+  let expected = "12s" in
+  let result = Fmt.str "%a" Run_time.duration_pp (Int64.mul 12L ten_power_9) in
+  Alcotest.(check string) "Os are printed without microseconds" expected result;
+
+  let expected = "1m02s" in
+  let result = Fmt.str "%a" Run_time.duration_pp (Int64.mul 62L ten_power_9) in
+  Alcotest.(check string) "Minutes and seconds" expected result;
+
+  let expected = "1h01m" in
+  let result =
+    Fmt.str "%a" Run_time.duration_pp (Int64.mul 3662L ten_power_9)
+  in
+  Alcotest.(check string)
+    "Seconds are not printed for durations in excess of an hour" expected result;
+
+  let expected = "1d00h" in
+  let result =
+    Fmt.str "%a" Run_time.duration_pp (Int64.mul 86462L ten_power_9)
+  in
+  Alcotest.(check string)
+    "Minutes are not printed for durations in excess of a day" expected result
+
 let tests =
   [
     Alcotest_lwt.test_case_sync "info_from_timestamps_queued" `Quick
@@ -494,4 +523,6 @@ let tests =
         test_total_of_run_times);
     Alcotest_lwt.test_case_sync "first step queued at" `Quick (fun () ->
         test_first_step_queued_at);
+    Alcotest_lwt.test_case_sync "duration_pp" `Quick (fun () ->
+        test_duration_pp);
   ]

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -388,21 +388,28 @@ let show_step ~org ~repo ~refs ~hash ~jobs ~variant ~job ~status ~csrf_token
   in
   let ansi = Ansi.create () in
   let line_number = ref 0 in
+  let last_line_blank = ref false in
   let decorate data : string =
-    let aux l log_line =
-      line_number := !line_number + 1;
-      Fmt.str "%s\n%s" l
-        (Fmt.to_to_string (pp_elt ())
-           (div
-              ~a:[ a_class [ "code-line" ]; a_id (Fmt.str "L%d" !line_number) ]
-              [
-                div
-                  ~a:[ a_class [ "code-line__number" ] ]
-                  [ txt (Fmt.str "%d" !line_number) ];
-                div
-                  ~a:[ a_class [ "code-line__code" ] ]
-                  [ Unsafe.data log_line ];
-              ]))
+    let aux (l : string) log_line =
+      if !last_line_blank && log_line = "" then
+        (* Squash consecutive new lines *)
+        l
+      else (
+        last_line_blank := log_line = "";
+        line_number := !line_number + 1;
+        Fmt.str "%s\n%s" l
+          (Fmt.str "%a" (pp_elt ())
+             (div
+                ~a:
+                  [ a_class [ "code-line" ]; a_id (Fmt.str "L%d" !line_number) ]
+                [
+                  div
+                    ~a:[ a_class [ "code-line__number" ] ]
+                    [ txt (Fmt.str "%d" !line_number) ];
+                  div
+                    ~a:[ a_class [ "code-line__code" ] ]
+                    [ pre [ Unsafe.data log_line ] ];
+                ])))
     in
     List.fold_left aux "" data
   in

--- a/web-ui/view/template_v1.ml
+++ b/web-ui/view/template_v1.ml
@@ -17,6 +17,7 @@ let head =
       script ~a:[ a_defer (); a_src "/js/alpine.js" ] (txt "");
       link ~rel:[ `Stylesheet ] ~href:"/fonts/inter.css" ();
       link ~rel:[ `Stylesheet ] ~href:"/css/tailwind.css" ();
+      link ~rel:[ `Stylesheet ] ~href:"/css/ansi.css" ();
     ]
 
 let header =


### PR DESCRIPTION
- [x] "0s" instead of "0s000ms" 
- [x] Attempt to fix spurious blank lines appearing in the logs (when waiting on the stream)
- [x] Restore colour in logs via `ansi.css` 