### PR TITLE
Allow unauthenticated access to the metrics endpoint.

### DIFF
--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -90,16 +90,12 @@ let run_capnp capnp_public_address capnp_listen_address =
 
 module Gitlab = struct
   (* Access control policy. *)
-  let has_role user role =
-    match user with
-    | None ->
-        role = `Viewer (* Unauthenticated users can only look at things. *)
-    | Some user -> (
-        match (Current_web.User.id user, role) with
-        | "gitlab:tmcgilchrist", _ -> true (* This user has all roles *)
-        | _, (`Viewer | `Builder) ->
-            true (* Any GitLab user can cancel and rebuild *)
-        | _ -> false)
+  let has_role user = function
+    | `Viewer | `Monitor -> true
+    | `Builder | `Admin -> (
+        match Option.map Current_web.User.id user with
+        | Some "gitlab:tmcgilchrist" -> true
+        | Some _ | None -> false)
 
   let webhook_route ~webhook_secret =
     Routes.(

--- a/service/github.ml
+++ b/service/github.ml
@@ -1,13 +1,13 @@
 (* Access control policy. *)
 let has_role user = function
   | `Viewer | `Monitor -> true
-  | _ -> (
+  | `Builder | `Admin -> (
       match Option.map Current_web.User.id user with
       | Some
           ( "github:talex5" | "github:avsm" | "github:kit-ty-kate"
           | "github:samoht" | "github:tmcgilchrist" | "github:dra27" ) ->
           true
-      | _ -> false)
+      | Some _ | None -> false)
 
 let webhook_route ~engine ~get_job_ids ~webhook_secret =
   Routes.(


### PR DESCRIPTION
The main change here is to align the auth check between GitHub and GitLab, in particular the `/metrics` endpoint used by prometheus was unnecessarily requiring authentication. 

Second I explicitly matched on variants in match statements, both to make it clearer what the roles are and for completeness.