### PR TITLE
Define `CI` and `OCAMLCI` envvars to `true` in builds

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -120,6 +120,8 @@ let install_project_deps ~opam_version ~opam_files ~selection =
   @ pin_opam_files ~network groups
   @ [
       env "DEPS" non_root_pkgs;
+      env "CI" "true";
+      env "OCAMLCI" "true";
       opam_depext;
       run ~network ~cache "opam install $DEPS";
     ]


### PR DESCRIPTION
> Possibly a test library could detect it's running under CI and increase its verbosity (e.g. showing all failing logs rather than just the first) if that's useful.

_Originally posted by @talex5 in https://github.com/ocurrent/ocaml-ci/pull/332#pullrequestreview-634603681_

CI providers usually define the `CI` environment variable to `true`, as well as an env var with their name (I've picked `OCAMLCI`) to `true` (verified for GHA, Travis, Appveyor).

Of course being in the global state this could influence building of opam packages dependencies and depexts, so it's not exactly clear where to define these variables. At the start of the script for consistency? Just before doing anything with opam? Just before building the current package and running it's tests?

For now I've defined them just before building opam packages.