### PR TITLE
Support migrations into OCaml-ci

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,7 +22,7 @@
    logs
    current
    current_docker
-   (omigrate (>= 0.3.0))
+   (omigrate (>= 0.3.2))
    ocaml-ci-api
    capnp-rpc-unix
    ppx_deriving_yojson

--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,7 @@
    logs
    current
    current_docker
+   (omigrate (>= 0.3.0))
    ocaml-ci-api
    capnp-rpc-unix
    ppx_deriving_yojson

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -45,7 +45,6 @@ let platforms =
   let v2_1 = Ocaml_ci_service.Conf.platforms `V2_1 in
   Current.list_seq (List.map v v2_1)
 
-let migrations = Index.migrate ()
 let program_name = "ocaml-ci"
 
 (* Link for GitLab statuses. *)
@@ -310,10 +309,11 @@ let gitlab_status_of_state head result =
   | Error (`Msg m) ->
       Gitlab.Api.Status.v ~url `Failure ~description:m ~name:program_name
 
-let v ?ocluster ~app ~solver () =
+let v ?ocluster ~app ~solver ~migration () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
+  let migrations = if migration then Index.migrate () else Current.return () in
   Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -45,6 +45,7 @@ let platforms =
   let v2_1 = Ocaml_ci_service.Conf.platforms `V2_1 in
   Current.list_seq (List.map v v2_1)
 
+let migrations = Index.migrate ()
 let program_name = "ocaml-ci"
 
 (* Link for GitLab statuses. *)
@@ -313,6 +314,7 @@ let v ?ocluster ~app ~solver () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
+  Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->
   Current.return gitlab_installations

--- a/lib/dune
+++ b/lib/dune
@@ -9,6 +9,8 @@
   current_docker
   current.term
   ocaml-ci-api
+  omigrate
+  omigrate.sqlite3
   str
   capnp-rpc-unix
   current.cache

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -14,6 +14,10 @@ type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
 val init : unit -> unit
 (** Ensure the database is initialised (for unit-tests). *)
 
+val migrate : unit -> unit Current.t
+(** [migrate ()] ensures the database is up-to-date when the project is run.
+    If the date changes, it will try to run the migration again. **)
+
 val record :
   repo:Repo_id.t ->
   hash:string ->

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -11,12 +11,12 @@ type job_state =
 
 type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
 
-val init : unit -> unit
+val init : unit -> unit Lwt.t
 (** Ensure the database is initialised (for unit-tests). *)
 
 val migrate : unit -> unit Current.t
-(** [migrate ()] ensures the database is up-to-date when the project is run.
-    If the date changes, it will try to run the migration again. **)
+(** [migrate ()] ensures the database is up-to-date when the project is run. If
+    the date changes, it will try to run the migration again. **)
 
 val record :
   repo:Repo_id.t ->

--- a/migrations/20221019123702_create-build-index.down.sql
+++ b/migrations/20221019123702_create-build-index.down.sql
@@ -1,0 +1,1 @@
+DROP IF EXISTS ci_build_index;

--- a/migrations/20221019123702_create-build-index.up.sql
+++ b/migrations/20221019123702_create-build-index.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS ci_build_index (
+    owner     TEXT NOT NULL,
+    name      TEXT NOT NULL,
+    hash      TEXT NOT NULL,
+    variant   TEXT NOT NULL,
+    job_id    TEXT,
+    gref      TEXT NOT NULL DEFAULT "-",
+    PRIMARY KEY (owner, name, hash, variant)
+);

--- a/ocaml-ci.opam
+++ b/ocaml-ci.opam
@@ -11,6 +11,7 @@ depends: [
   "logs"
   "current"
   "current_docker"
+  "omigrate" {>= "0.3.0"}
   "ocaml-ci-api"
   "capnp-rpc-unix"
   "ppx_deriving_yojson"

--- a/ocaml-ci.opam
+++ b/ocaml-ci.opam
@@ -11,7 +11,7 @@ depends: [
   "logs"
   "current"
   "current_docker"
-  "omigrate" {>= "0.3.0"}
+  "omigrate" {>= "0.3.2"}
   "ocaml-ci-api"
   "capnp-rpc-unix"
   "ppx_deriving_yojson"

--- a/service/main.ml
+++ b/service/main.ml
@@ -107,7 +107,7 @@ let run_capnp capnp_public_address capnp_listen_address =
       Lwt.return (vat, Some rpc_engine_resolver)
 
 let main () config mode app capnp_public_address capnp_listen_address
-    github_auth submission_uri : ('a, [ `Msg of string ]) result =
+    github_auth submission_uri no_migration : ('a, [ `Msg of string ]) result =
   Lwt_main.run
     (let solver = Ocaml_ci.Solver_pool.spawn_local () in
      run_capnp capnp_public_address capnp_listen_address
@@ -115,8 +115,10 @@ let main () config mode app capnp_public_address capnp_listen_address
      let ocluster =
        Option.map (Capnp_rpc_unix.Vat.import_exn vat) submission_uri
      in
+     let migration = not no_migration in
      let engine =
-       Current.Engine.create ~config (Pipeline.v ?ocluster ~app ~solver)
+       Current.Engine.create ~config
+         (Pipeline.v ?ocluster ~app ~solver ~migration)
      in
      rpc_engine_resolver
      |> Option.iter (fun r ->
@@ -176,6 +178,13 @@ let submission_service =
   @@ Arg.info ~doc:"The submission.cap file for the build scheduler service"
        ~docv:"FILE" [ "submission-service" ]
 
+let disable_migrations =
+  Arg.(
+    value
+    @@ flag
+    @@ info ~doc:"Disable the system to execute the migrations."
+         [ "disable-migrations" ])
+
 let cmd =
   let doc = "Build OCaml projects on GitHub" in
   let info = Cmd.info "ocaml-ci-service" ~doc ~envs:Conf.cmdliner_envs in
@@ -190,6 +199,7 @@ let cmd =
         $ capnp_public_address
         $ capnp_listen_address
         $ Current_github.Auth.cmdliner
-        $ submission_service))
+        $ submission_service
+        $ disable_migrations))
 
 let () = exit @@ Cmd.eval cmd

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -41,8 +41,6 @@ let opam_repository_commit =
   let repo = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } in
   Github.Api.Anonymous.head_of repo @@ `Ref "refs/heads/master"
 
-let migrations = Index.migrate ()
-
 let github_status_of_state ~head result results =
   let+ head = head and+ result = result and+ results = results in
   let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
@@ -258,10 +256,11 @@ let local_test ~solver repo () =
      in
      Current_incr.const (result, None)
 
-let v ?ocluster ~app ~solver () =
+let v ?ocluster ~app ~solver ~migration () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
+  let migrations = if migration then Index.migrate () else Current.return () in
   Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -41,6 +41,8 @@ let opam_repository_commit =
   let repo = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } in
   Github.Api.Anonymous.head_of repo @@ `Ref "refs/heads/master"
 
+let migrations = Index.migrate ()
+
 let github_status_of_state ~head result results =
   let+ head = head and+ result = result and+ results = results in
   let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
@@ -260,6 +262,7 @@ let v ?ocluster ~app ~solver () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
+  Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->
   let installations =

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -7,7 +7,9 @@ val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_github.App.t ->
   solver:Ocaml_ci_api.Solver.t ->
+  migration:bool ->
   unit ->
   unit Current.t
 (** The main ocaml-ci pipeline. Tests everything configured for GitHub
-    application [app]. *)
+    application [app]. If [migration] is true, it will automatically executes
+    the migrations. *)

--- a/test/dune
+++ b/test/dune
@@ -16,6 +16,7 @@
  (alias runtest)
  (package ocaml-ci-service)
  (deps
+  (source_tree migrations)
   (package ocaml-ci-solver))
  (action
-  (run ./test.exe)))
+  (run ./test.exe -e)))

--- a/test/migrations
+++ b/test/migrations
@@ -1,0 +1,1 @@
+../migrations

--- a/test/test_run_time_client.ml
+++ b/test/test_run_time_client.ml
@@ -3,12 +3,6 @@ module Run_time = Ocaml_ci_client_lib.Run_time
 module Job = Current.Job
 module Client = Ocaml_ci_api.Client
 
-let setup () =
-  let db = Lazy.force Current.Db.v in
-  Index.init ();
-  Current.Db.exec_literal db "DELETE FROM cache";
-  db
-
 let database = Alcotest.(list string)
 let cmp_floats v1 v2 = abs_float (v1 -. v2) < 0.0000001
 


### PR DESCRIPTION
This PR intends to support migrations into `ocaml-ci` using `omigrate`.
Be aware that it requires more tests to ensure everything works fine.

:warning: If you plan to test it from home, create a copy of the  `var/` so you won't lose everything you have in the DB if it fails.