### PR TITLE
Drive step-page Rebuild button from API.

### DIFF
--- a/test/test_web_representation.ml
+++ b/test/test_web_representation.ml
@@ -2,15 +2,17 @@ module Step = Representation.Step
 module Client = Ocaml_ci_api.Client
 module Run_time = Ocaml_ci_client_lib.Run_time
 
-let test_to_json (step_info, run_time, expected) =
+let test_to_json (step_info, run_time, can_rebuild, expected) =
   let result =
-    Step.to_json @@ Step.from_status_info_run_time ~step_info ~run_time
+    Step.to_json
+    @@ Step.from_status_info_run_time ~step_info ~run_time ~can_rebuild
   in
   Alcotest.(check string) "to_json" expected result
 
 (* NOTE that for the purposes of testing, the timezone has been set to UTC
    by adding timedesc-tzlocal.utc to the dune file. See the README for timedesc *)
 let test_simple () =
+  let can_rebuild = true in
   let step_info_1 : Client.job_info option =
     Some
       {
@@ -25,7 +27,7 @@ let test_simple () =
     Some (Running { queued_for = 42.2; ran_for = 0. })
   in
   let expected_1 =
-    {|{"version":"1.0","status":"active","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"0s"}|}
+    {|{"version":"1.0","status":"active","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"0s","can_rebuild":true}|}
   in
   let step_info_2 : Client.job_info option =
     Some
@@ -41,7 +43,7 @@ let test_simple () =
     Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
   in
   let expected_2 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"5s"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"5s","can_rebuild":true}|}
   in
   let step_info_3 : Client.job_info option =
     Some
@@ -57,14 +59,14 @@ let test_simple () =
     Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
   in
   let expected_3 =
-    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s"}|}
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true}|}
   in
 
   List.iter test_to_json
     [
-      (step_info_1, run_time_1, expected_1);
-      (step_info_2, run_time_2, expected_2);
-      (step_info_3, run_time_3, expected_3);
+      (step_info_1, run_time_1, can_rebuild, expected_1);
+      (step_info_2, run_time_2, can_rebuild, expected_2);
+      (step_info_3, run_time_3, can_rebuild, expected_3);
     ]
 
 let tests = [ Alcotest_lwt.test_case_sync "simple" `Quick test_simple ]

--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -312,7 +312,10 @@ module Make_API (Api : Api) = struct
     let jobs = Client.Commit.jobs commit_cap in
     Capability.with_ref (Client.Commit.job_of_variant commit_cap variant)
     @@ fun job_cap ->
+    let status = Current_rpc.Job.status job_cap in
+    Current_rpc.Job.log job_cap ~start:0L >>!= fun _ ->
     jobs >>!= fun jobs ->
+    status >>!= fun status ->
     Capability.inc_ref job_cap;
     let build_created_at =
       Run_time.build_created_at ~build:jobs
@@ -340,5 +343,5 @@ module Make_API (Api : Api) = struct
         (Run_time.run_times_from_timestamps ~build_created_at)
         timestamps
     in
-    Api.show_step ~step_info ~run_time
+    Api.show_step ~step_info ~run_time ~can_rebuild:status.can_rebuild
 end

--- a/web-ui/representation/step.ml
+++ b/web-ui/representation/step.ml
@@ -11,10 +11,11 @@ type t = {
   finished_at : string;
   queued_for : string;
   ran_for : string;
+  can_rebuild : bool;
 }
 [@@deriving yojson]
 
-let from_status_info_run_time ~step_info ~run_time =
+let from_status_info_run_time ~step_info ~run_time ~can_rebuild =
   {
     version;
     status =
@@ -33,6 +34,7 @@ let from_status_info_run_time ~step_info ~run_time =
       Timestamps_durations.pp_duration (Option.map Run_time.queued_for run_time);
     ran_for =
       Timestamps_durations.pp_duration (Option.map Run_time.ran_for run_time);
+    can_rebuild;
   }
 
 let to_json t = Yojson.Safe.to_string @@ to_yojson t

--- a/web-ui/view/api/github.ml
+++ b/web-ui/view/api/github.ml
@@ -2,7 +2,7 @@ module Step = Representation.Step
 module Run_time = Ocaml_ci_client_lib.Run_time
 module Client = Ocaml_ci_api.Client
 
-let show_step ~step_info ~run_time =
+let show_step ~step_info ~run_time ~can_rebuild =
   Dream.json
   @@ Step.to_json
-  @@ Step.from_status_info_run_time ~step_info ~run_time
+  @@ Step.from_status_info_run_time ~step_info ~run_time ~can_rebuild

--- a/web-ui/view/api/gitlab.ml
+++ b/web-ui/view/api/gitlab.ml
@@ -2,7 +2,7 @@ module Step = Representation.Step
 module Run_time = Ocaml_ci_client_lib.Run_time
 module Client = Ocaml_ci_api.Client
 
-let show_step ~step_info ~run_time =
+let show_step ~step_info ~run_time ~can_rebuild =
   Dream.json
   @@ Step.to_json
-  @@ Step.from_status_info_run_time ~step_info ~run_time
+  @@ Step.from_status_info_run_time ~step_info ~run_time ~can_rebuild

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -90,6 +90,7 @@ module type Api = sig
   val show_step :
     step_info:Client.job_info option ->
     run_time:Run_time.run_time_info option ->
+    can_rebuild:bool ->
     Dream.response Lwt.t
 end
 

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -192,10 +192,12 @@ let poll =
                   element_step_status.innerHTML = iconSuccess;
                 } else {
                   element_step_status.innerHTML = iconFailed;
+                };
+                if (data["can_rebuild"]) {
                   document
                     .getElementById("rebuild-step")
                     .style.removeProperty("display");
-                }
+                };
                 console.log("Build has finished. Stop polling.");
               }
 


### PR DESCRIPTION
It is incorrect to have client side logic that decides when to render the rebuild button. This PR corrects that to use the `can_rebuild` attribute of the build status, thus aligning the live-update machinery with the way the rebuild button is handled in the server rendered page.