### PR TITLE
Small cleanup of ref page.

### DIFF
--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -169,9 +169,7 @@ let ref_row ~ref_title ~short_hash ~last_updated ~status ~ref_uri ~message =
                       [ txt message ];
                     div
                       ~a:[ a_class [ "flex text-sm space-x-2" ] ]
-                      [
-                        div [ txt short_hash ];
-                      ];
+                      [ div [ txt short_hash ] ];
                   ];
               ];
           ];

--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -139,6 +139,7 @@ let repo_row ~repo_title ~short_hash ~last_updated ~status ~repo_uri =
       ])
 
 let ref_row ~ref_title ~short_hash ~last_updated ~status ~ref_uri ~message =
+  let () = ignore last_updated in
   Tyxml.Html.(
     a
       ~a:[ a_class [ "table-row" ]; a_href ref_uri ]
@@ -170,8 +171,6 @@ let ref_row ~ref_title ~short_hash ~last_updated ~status ~ref_uri ~message =
                       ~a:[ a_class [ "flex text-sm space-x-2" ] ]
                       [
                         div [ txt short_hash ];
-                        div [ txt "-" ];
-                        div [ txt last_updated ];
                       ];
                   ];
               ];

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -118,7 +118,7 @@ let list_refs ~org ~repo ~refs =
     let last_updated = Timestamps_durations.pp_timestamp last_updated in
     Build.ref_row ~ref_title:(ref_name gref) ~short_hash ~last_updated ~status
       ~ref_uri:(commit_url ~org ~repo short_hash)
-      ~message:short_hash
+      ~message:""
   in
   let default_table, main_ref =
     let main_ref, main_ref_info =


### PR DESCRIPTION
Temporary changes so that the ref page is cleaned up of repetition and empty fields ... and so that master can be deployed.

This should be rebased on master once #570 has been merged