### PR TITLE
Point to fork of dream for OCaml 5.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -121,7 +121,7 @@
   (ansi (>= 0.5.0))
   (capnp-rpc-unix (>= 1.2))
   (crunch (and (>= 3.2.0) :build))
-  (dream (= 1.0.0~alpha4))
+  dream
   (fmt (>= 0.8.9))
   (logs (>= 0.7.0))
   (lwt (>= 5.6.1))
@@ -131,7 +131,6 @@
   (prometheus-app (>= 1.2))
   tyxml
   (timedesc (>= 0.9.0)))
-  (conflicts (ocaml (>= 5.0)))
 )
 (package
 (name ocaml-ci-client-lib)

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -10,7 +10,7 @@ depends: [
   "ansi" {>= "0.5.0"}
   "capnp-rpc-unix" {>= "1.2"}
   "crunch" {>= "3.2.0" & build}
-  "dream" {= "1.0.0~alpha4"}
+  "dream"
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.6.1"}
@@ -21,9 +21,6 @@ depends: [
   "tyxml"
   "timedesc" {>= "0.9.0"}
   "odoc" {with-doc}
-]
-conflicts: [
-  "ocaml" {>= "5.0"}
 ]
 build: [
   ["dune" "subst"] {dev}
@@ -40,3 +37,9 @@ build: [
   ]
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
+
+pin-depends: [
+  ["dream.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+  ["dream-httpaf.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+  ["dream-pure.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+]

--- a/ocaml-ci-web.opam.template
+++ b/ocaml-ci-web.opam.template
@@ -1,0 +1,6 @@
+
+pin-depends: [
+  ["dream.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+  ["dream-httpaf.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+  ["dream-pure.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+]


### PR DESCRIPTION
Points to my fork of dream that builds on OCaml 5. Once https://github.com/aantron/dream/pull/241 is merged, we can revert this (modulo the restriction on OCaml 5).