### PR TITLE
Fixed bug preventing GitLab routes from being added

### DIFF
--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -226,9 +226,5 @@ let create ~github ~gitlab =
        Dream.get "/" (fun _ ->
            Dream.html @@ Controller.Index.render github gitlab);
      ]
-    @
-    match github with
-    | Some github -> github_routes github
-    | None -> (
-        []
-        @ match gitlab with Some gitlab -> gitlab_routes gitlab | None -> []))
+    @ (match github with Some github -> github_routes github | None -> [])
+    @ match gitlab with Some gitlab -> gitlab_routes gitlab | None -> [])


### PR DESCRIPTION
I don't have a GitLab account so I haven't been able to test this fully myself, but it should work.

The bug is that GitLab routes are only added if there are no GitHub routes, almost certainly not the intended behaviour.