### PR TITLE
Fix transient server error

### DIFF
--- a/lib_client/run_time.ml
+++ b/lib_client/run_time.ml
@@ -191,7 +191,11 @@ let total_of_run_times (build : Client.job_info list) =
   |> List.fold_left (fun subtotal rt -> subtotal +. total_time rt) 0.
 
 let first_step_queued_at (jil : Client.job_info list) =
-  if jil = [] then Error "Empty build"
+  (* for_all holds for the empty list as well as preventing transient
+     error when only the analysis step exists with a None timestamp.
+     Error would be caused by trying to format [max_float] as a string. *)
+  let no_queued_at_ts (ji : Client.job_info) = ji.queued_at = None in
+  if List.for_all no_queued_at_ts jil then Error "Empty build"
   else
     let minn accum (ji : Client.job_info) =
       Option.fold ~none:accum ~some:(fun v -> min accum v) ji.queued_at

--- a/test/test_run_time_client.ml
+++ b/test/test_run_time_client.ml
@@ -401,6 +401,15 @@ let test_total_of_run_times =
   Alcotest.(check (float 0.001)) "total_of_run_times" expected result
 
 let test_first_step_queued_at =
+  let not_started : Client.job_info =
+    {
+      variant = "variant";
+      outcome = NotStarted;
+      queued_at = None;
+      started_at = None;
+      finished_at = None;
+    }
+  in
   let step_1 : Client.job_info =
     {
       variant = "variant";
@@ -438,7 +447,13 @@ let test_first_step_queued_at =
   let expected = Ok 1234567. in
   let result = Run_time.first_step_queued_at build in
   Alcotest.(check (result (float 0.001) string))
-    "first_step_queued_at not-empty" expected result
+    "first_step_queued_at not-empty" expected result;
+
+  let build = [ not_started ] in
+  let expected = Error "Empty build" in
+  let result = Run_time.first_step_queued_at build in
+  Alcotest.(check (result (float 0.001) string))
+    "first_step_queued_at no-timestamp" expected result
 
 let test_duration_pp =
   let ten_power_9 : int64 = 1000000000L in

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -172,7 +172,6 @@ let list_refs ~org ~repo ~refs =
     let table = table_head :: List.map (fun (_, ref) -> f ref) bindings in
     (table, n_prs)
   in
-  Dream.log "n_branches: %d - n_prs: %d" n_branches n_prs;
   let title =
     let github_repo_url = github_repo_url ~org repo in
     div


### PR DESCRIPTION
Possible fix for issue #580.

In computing the timestamp for `first_queued_at`, the case where all jobs have a `None` timestamp is not accounted for, which results in the default-case `max_float` being returned, which is too large for Timedesc to cast to a 64-bit integer, tripping an assert.

The transient error then happens at the beginning of the build when only the analysis step exists, and there is a period of time where it has no `queued_at` timestamp.

I'm having issues running ocaml-ci locally so haven't been able to test fully.