### PR TITLE
Flash messages for cancel/rebuild - better UX.

### DIFF
--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -250,7 +250,7 @@ module Make (View : View) = struct
     @@ fun commit_cap ->
     Client.Commit.jobs commit_cap >>!= fun jobs ->
     cancel_many commit_cap jobs >>= fun (success, failed) ->
-    let success_msg = View.cancel_success_message_v1 success in
+    let success_msg = View.success_message_v1 `Cancel (List.rev success) in
     let fail_msg = View.cancel_fail_message_v1 failed in
     let flash_messages =
       List.map (fun (`Success, m) -> ("Success", m)) success_msg
@@ -294,7 +294,7 @@ module Make (View : View) = struct
     (* Client.Commit.refs commit_cap >>!= fun refs -> *)
     Client.Commit.jobs commit_cap >>!= fun jobs ->
     rebuild_many commit_cap jobs >>= fun (success, failed) ->
-    let success_msg = View.rebuild_success_message_v1 success in
+    let success_msg = View.success_message_v1 `Rebuild (List.rev success) in
     let fail_msg = View.rebuild_fail_message_v1 failed in
     let flash_messages =
       List.map (fun (`Success, m) -> ("Success", m)) success_msg

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -18,14 +18,12 @@ module type View = sig
     Client.job_info list -> [> `Div | `Ul ] Tyxml_html.elt
 
   val rebuild_fail_message : int -> [> Html_types.div ] Tyxml_html.elt
-
-  val cancel_success_message_v1 :
-    Client.job_info list -> ([> `Success ] * string) list
-
   val cancel_fail_message_v1 : int -> ([> `Fail ] * string) list
 
-  val rebuild_success_message_v1 :
-    Client.job_info list -> ([> `Success ] * string) list
+  val success_message_v1 :
+    [< `Cancel | `Rebuild ] ->
+    Client.job_info list ->
+    ([> `Success ] * string) list
 
   val rebuild_fail_message_v1 : int -> ([> `Fail ] * string) list
 

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -132,13 +132,26 @@ let cancel_success_message success =
   | [] -> div [ span [ txt "No jobs were cancelled." ] ]
   | success -> ul (List.map format_job_info success)
 
-let cancel_success_message_v1 success =
-  let format_job_info ji =
-    (`Success, Printf.sprintf "Cancelling job: %s" ji.Client.variant)
+let success_message_v1 action jis =
+  let empty_message, prefix =
+    match action with
+    | `Cancel -> ("No jobs were cancelled.", "Cancelling")
+    | `Rebuild -> ("No jobs were rebuilt.", "Rebuilding")
   in
-  match success with
-  | [] -> [ (`Success, "No jobs were cancelled.") ]
-  | success -> List.map format_job_info success
+  match jis with
+  | [] -> [ (`Success, empty_message) ]
+  | jis ->
+      let trimmed = List.filteri (fun i _ -> i < 5) jis in
+      let message =
+        Astring.String.concat ~sep:", "
+          (List.map (fun ji -> ji.Client.variant) trimmed)
+      in
+      if List.length jis > 5 then
+        [
+          ( `Success,
+            Astring.String.concat [ prefix; " many: "; message; " ..." ] );
+        ]
+      else [ (`Success, Astring.String.concat [ prefix; ": "; message ]) ]
 
 let cancel_fail_message = function
   | n when n <= 0 -> div []
@@ -178,14 +191,6 @@ let rebuild_success_message success =
   match success with
   | [] -> div [ span [ txt "No jobs were rebuilt." ] ]
   | success -> ul (List.map format_job_info success)
-
-let rebuild_success_message_v1 success =
-  let format_job_info ji =
-    (`Success, Printf.sprintf "Rebuilding job: %s" ji.Client.variant)
-  in
-  match success with
-  | [] -> [ (`Success, "No jobs were rebuilt.") ]
-  | success -> List.map format_job_info success
 
 let rebuild_fail_message = function
   | n when n <= 0 -> div []


### PR DESCRIPTION
We are issuing a flash message for every job that is cancelled or rebuilt. This can result in a lot of flash messages.

This PR collects the labels of all the jobs being rebuilt/cancelled and adds the first five to a single flash message. Depending on the number of jobs being rebuild/cancelled, the flash message is:

```
Rebuilding: (lint-doc), (lint-fmt), foo, bar

or

Rebuilding many: (lint-doc), (lint-fmt), foo, bar, baz, ...
``` 

Closes #579 