### PR TITLE
Fix broken build page.

### DIFF
--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -101,3 +101,13 @@ let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
             div [ txt @@ Fmt.str "Ran for %s" ran_for ]; Common.right_arrow_head;
           ];
       ])
+
+let tabulate_steps step_rows =
+  Tyxml.Html.(
+    div
+      ~a:[ a_class [ "container-fluid mt-8 flex flex-col space-y-6" ] ]
+      [
+        div
+          ~a:[ a_id "table-container"; a_class [ "table-container" ] ]
+          step_rows;
+      ])

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -296,7 +296,7 @@ let list_steps ~org ~repo ~message ~refs ~hash ~jobs ~first_step_queued_at
         (Printf.sprintf "%s" (short_hash hash));
       title_card;
       Common.flash_messages flash_messages;
-      Common.tabulate steps_table;
+      Build.tabulate_steps steps_table;
     ]
 
 let show_step ~org ~repo ~refs ~hash ~jobs ~variant ~job ~status ~csrf_token


### PR DESCRIPTION
The build page polling javascript relies on the table having a specific id and this appears to have got collected in some refactoring. Restoring ... 