### PR TITLE
Correct readme to remove vendored obuilder pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Get the code with:
 ```sh
 git clone --recursive https://github.com/ocurrent/ocaml-ci.git
 cd ocaml-ci
-opam install --deps-only ./ocaml-version ./ocaml-dockerfile ./ocluster/obuilder ./ocluster ./ocurrent .
+opam install --deps-only ./ocaml-version ./ocaml-dockerfile ./ocluster ./ocurrent .
 ```
 
 Note: you need to clone with `--recursive` because this project uses submodules


### PR DESCRIPTION
Now that ocurrent depends obuilder 0.5 through opam instead of vendoring with a git submodule (https://github.com/ocurrent/ocluster/commit/f1b490efdaf114b55ae7ddf266830003390802c7) this can be removed from the instructions in the README, as otherwise it causes an error.