### PR TITLE
Colors in opam and Dune logs

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -106,6 +106,7 @@ let install_project_deps ~opam_version ~opam_files ~selection =
   (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
    [ shell [ "/usr/bin/linux32"; "/bin/sh"; "-c" ] ]
   else [])
+  @ [ env "CLICOLOR_FORCE" "1" ]
   @ distro_extras
   @ [
       run "sudo ln -f %s /usr/bin/opam" opam_cmd;

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -107,6 +107,7 @@ let install_project_deps ~opam_version ~opam_files ~selection =
    [ shell [ "/usr/bin/linux32"; "/bin/sh"; "-c" ] ]
   else [])
   @ [ env "CLICOLOR_FORCE" "1" ]
+  @ [ env "OPAMCOLOR" "always" ]
   @ distro_extras
   @ [
       run "sudo ln -f %s /usr/bin/opam" opam_cmd;


### PR DESCRIPTION
All tools supporting it (Dune, some build systems and system utilities) will now emit ANSI colors in CI runs.