### PR TITLE
Fix formatting of refs page -- Truncate ref message. Remove started_at.

### DIFF
--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -12,6 +12,9 @@ module Make (M : M_Git_forge) = struct
     | _ -> raise Not_found
 
   let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
+    ignore started_at; (*See FIXME - revert this when started_at is implemented *)
+    (* messages are of arbitrary length - let's truncate them *)
+    let message = Astring.String.with_range ~len:72 message in
     let ref_title =
       match ref with Branch title -> title | PR { title; _ } -> title
     in
@@ -27,7 +30,8 @@ module Make (M : M_Git_forge) = struct
                   ~a:[ a_class [ "flex space-x-1 items-center" ] ]
                   [ logo; div [ txt (Printf.sprintf "#%s" id) ] ];
               ])
-        @ [ div [ txt "-" ]; div [ txt started_at ] ]
+        (* FIXME: We do not have started_at implemented yet.*)
+        (* @ [ div [ txt "-" ]; div [ txt started_at ] ] *)
       in
       a
         ~a:[ a_class [ "table-row" ]; a_href ref_uri ]
@@ -93,7 +97,7 @@ module Make (M : M_Git_forge) = struct
       let started_at = Timestamps_durations.pp_timestamp started_at in
       let ran_for = Timestamps_durations.pp_timestamp ran_for in
       row ~ref:(ref gref name) ~short_hash ~started_at ~ran_for ~status
-        ~ref_uri:(commit_url ~org ~repo short_hash)
+        ~ref_uri:(commit_url ~org ~repo hash)
         ~message
     in
     let default_table, main_ref =

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -12,7 +12,8 @@ module Make (M : M_Git_forge) = struct
     | _ -> raise Not_found
 
   let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
-    ignore started_at; (*See FIXME - revert this when started_at is implemented *)
+    ignore started_at;
+    (*See FIXME - revert this when started_at is implemented *)
     (* messages are of arbitrary length - let's truncate them *)
     let message = Astring.String.with_range ~len:72 message in
     let ref_title =
@@ -21,15 +22,16 @@ module Make (M : M_Git_forge) = struct
     Tyxml.Html.(
       let description =
         [ div [ txt short_hash ] ]
-        @ (match ref with
-          | Branch _ -> []
-          | PR { id; _ } ->
-              [
-                div [ txt "-" ];
-                div
-                  ~a:[ a_class [ "flex space-x-1 items-center" ] ]
-                  [ logo; div [ txt (Printf.sprintf "#%s" id) ] ];
-              ])
+        @
+        match ref with
+        | Branch _ -> []
+        | PR { id; _ } ->
+            [
+              div [ txt "-" ];
+              div
+                ~a:[ a_class [ "flex space-x-1 items-center" ] ]
+                [ logo; div [ txt (Printf.sprintf "#%s" id) ] ];
+            ]
         (* FIXME: We do not have started_at implemented yet.*)
         (* @ [ div [ txt "-" ]; div [ txt started_at ] ] *)
       in


### PR DESCRIPTION
Addressing some of the formatting issues here by truncating messages to 72 characters and removing `started_at` related strings for now. 

![Screen Shot 2022-11-15 at 2 41 45 pm](https://user-images.githubusercontent.com/181086/201821165-bce9ee21-06a7-4071-ae16-edfdbf863551.png)
