### PR TITLE
Refactor and harden url helpers.

### DIFF
--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -80,6 +80,7 @@ module Make (View : View) = struct
   module Capability = Capnp_rpc_lwt.Capability
 
   let job_url ~org ~repo ~hash variant =
+    assert (String.length hash > 10);
     Fmt.str "/%s/%s/%s/commit/%s/variant/%s" View.prefix org repo hash variant
 
   let list_orgs ci =

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -26,13 +26,6 @@ module type View = sig
     ([> `Success ] * string) list
 
   val rebuild_fail_message_v1 : int -> ([> `Fail ] * string) list
-
-  val return_link :
-    org:string ->
-    repo:string ->
-    hash:string ->
-    [> [> Html_types.txt ] Html_types.a ] Tyxml_html.elt
-
   val list_orgs : orgs:string list -> string
   val list_repos : org:string -> repos:Client.Org.repo_info list -> string
 

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -79,12 +79,6 @@ module Make (M : M_Git_forge) = struct
             [ div [ txt ran_for ]; Common.right_arrow_head ];
         ])
 
-  let commit_url ~org ~repo hash =
-    Printf.sprintf "/%s/%s/%s/commit/%s" M.prefix org repo hash
-
-  let github_repo_url ~org repo =
-    Printf.sprintf "https://github.com/%s/%s" org repo
-
   let ref gref title =
     match Astring.String.cuts ~sep:"/" gref with
     | "refs" :: "heads" :: branch ->
@@ -99,7 +93,7 @@ module Make (M : M_Git_forge) = struct
       let started_at = Timestamps_durations.pp_timestamp started_at in
       let ran_for = Timestamps_durations.pp_timestamp ran_for in
       row ~ref:(ref gref name) ~short_hash ~started_at ~ran_for ~status
-        ~ref_uri:(commit_url ~org ~repo hash)
+        ~ref_uri:(Url.commit_url M.prefix ~org ~repo ~hash)
         ~message
     in
     let default_table, main_ref =
@@ -144,7 +138,7 @@ module Make (M : M_Git_forge) = struct
     in
     Dream.log "n_branches: %d - n_prs: %d" n_branches n_prs;
     let title =
-      let github_repo_url = github_repo_url ~org repo in
+      let repo_url = Url.repo_url M.prefix ~org ~repo in
       div
         ~a:[ a_class [ "justify-between items-center flex" ] ]
         [
@@ -162,9 +156,9 @@ module Make (M : M_Git_forge) = struct
                         ~a:
                           [
                             a_class [ "flex items-center space-x-2" ];
-                            a_href github_repo_url;
+                            a_href repo_url;
                           ]
-                        [ span [ txt github_repo_url ]; Common.external_link ];
+                        [ span [ txt repo_url ]; Common.external_link ];
                     ];
                 ];
             ];

--- a/web-ui/view/url.ml
+++ b/web-ui/view/url.ml
@@ -1,0 +1,10 @@
+let org_url prefix ~org = Printf.sprintf "/%s/%s" prefix org
+let repo_url prefix ~org ~repo = Printf.sprintf "/%s/%s/%s" prefix org repo
+
+let commit_url prefix ~org ~repo ~hash =
+  assert (String.length hash > 10);
+  Printf.sprintf "/%s/%s/%s/commit/%s" prefix org repo hash
+
+let job_url prefix ~org ~repo ~hash variant =
+  assert (String.length hash > 10);
+  Printf.sprintf "/%s/%s/%s/commit/%s/variant/%s" prefix org repo hash variant


### PR DESCRIPTION
We've had an issue where we've drifted into using short hashes in urls. So far we've been using long hashes and in an effort to maintain consistency, this PR collects all url helpers in one place, and asserts that hashes are not short.

This PR builds on #603 