### PR TITLE
Ref and repo data aggregation

### DIFF
--- a/api/client.ml
+++ b/api/client.ml
@@ -222,26 +222,27 @@ module Commit = struct
     |> Lwt_result.map @@ fun jobs ->
        Results.jobs_get_list jobs
        |> List.map (fun job ->
-              let variant = Raw.Reader.JobInfo.variant_get job in
-              let state = Raw.Reader.JobInfo.state_get job in
-              let outcome = Raw.Reader.JobInfo.State.get state in
-              let queued_at = Raw.Reader.JobInfo.queued_at_get job in
+              let open Raw.Reader.JobInfo in
+              let variant = variant_get job in
+              let state = state_get job in
+              let outcome = State.get state in
+              let queued_at = queued_at_get job in
               let queued_at =
-                match Raw.Reader.JobInfo.QueuedAt.get queued_at with
-                | Raw.Reader.JobInfo.QueuedAt.None | Undefined _ -> None
-                | Raw.Reader.JobInfo.QueuedAt.Ts v -> Some v
+                match QueuedAt.get queued_at with
+                | QueuedAt.None | Undefined _ -> None
+                | QueuedAt.Ts v -> Some v
               in
-              let started_at = Raw.Reader.JobInfo.started_at_get job in
+              let started_at = started_at_get job in
               let started_at =
-                match Raw.Reader.JobInfo.StartedAt.get started_at with
-                | Raw.Reader.JobInfo.StartedAt.None | Undefined _ -> None
-                | Raw.Reader.JobInfo.StartedAt.Ts v -> Some v
+                match StartedAt.get started_at with
+                | StartedAt.None | Undefined _ -> None
+                | StartedAt.Ts v -> Some v
               in
-              let finished_at = Raw.Reader.JobInfo.finished_at_get job in
+              let finished_at = finished_at_get job in
               let finished_at =
-                match Raw.Reader.JobInfo.FinishedAt.get finished_at with
-                | Raw.Reader.JobInfo.FinishedAt.None | Undefined _ -> None
-                | Raw.Reader.JobInfo.FinishedAt.Ts v -> Some v
+                match FinishedAt.get finished_at with
+                | FinishedAt.None | Undefined _ -> None
+                | FinishedAt.Ts v -> Some v
               in
               { variant; outcome; queued_at; started_at; finished_at })
 

--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -22,7 +22,7 @@ module Metrics = struct
     with
     | None -> acc
     | Some { Index.hash; _ } -> (
-        match Index.get_status ~owner ~name ~hash with
+        match Index.Commit_cache.(find ~owner ~name ~hash |> get_status) with
         | `Failed -> { acc with failed = acc.failed + 1 }
         | `Passed -> { acc with ok = acc.ok + 1 }
         | `Not_started | `Pending -> { acc with active = acc.active + 1 })

--- a/lib/dune
+++ b/lib/dune
@@ -19,5 +19,4 @@
   opam-0install
   current_ocluster
   ocluster-api
-  obuilder-spec
-  dream))
+  obuilder-spec))

--- a/lib/dune
+++ b/lib/dune
@@ -19,4 +19,5 @@
   opam-0install
   current_ocluster
   ocluster-api
-  obuilder-spec))
+  obuilder-spec
+  dream))

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -190,134 +190,6 @@ let get_build_history_with_time ~owner ~name ~gref =
   |> List.filter (fun (gref', _, time) ->
          if Option.is_none time then false else gref = gref')
 
-(* module Status_cache = struct
-  let cache = Hashtbl.create 1_000
-  let cache_max_size = 1_000_000
-
-  type elt = [ `Not_started | `Pending | `Failed | `Passed ]
-
-  let add ~owner ~name ~hash (status : elt) =
-    if Hashtbl.length cache > cache_max_size then Hashtbl.clear cache;
-    Hashtbl.add cache (owner, name, hash) status
-
-  let find ~owner ~name ~hash : elt =
-    Hashtbl.find_opt cache (owner, name, hash) |> function
-    | Some s -> s
-    | None -> `Not_started
-end
-
-let get_status = Status_cache.find *)
-
-let record ~repo ~hash ~status ~gref jobs =
-  let { Repo_id.owner; name } = repo in
-  let t = Lazy.force db in
-  let jobs = Job_map.of_list jobs in
-  let previous =
-    get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list
-  in
-  let merge variant prev job =
-    let set job_id =
-      Log.info (fun f ->
-          f "@[<h>Index.record %s/%s %s %s -> %a@]" owner name
-            (Astring.String.with_range ~len:6 hash)
-            variant
-            Fmt.(option ~none:(any "-") string)
-            job_id);
-      match job_id with
-      | None ->
-          Db.exec t.record_job
-            Sqlite3.Data.
-              [
-                TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT gref; NULL;
-              ]
-      | Some id ->
-          Db.exec t.record_job
-            Sqlite3.Data.
-              [
-                TEXT owner;
-                TEXT name;
-                TEXT hash;
-                TEXT variant;
-                TEXT gref;
-                TEXT id;
-              ]
-    in
-    let update j1 j2 =
-      match (j1, j2) with
-      | Some j1, Some j2 when j1 = j2 -> ()
-      | None, None -> ()
-      | _, j2 -> set j2
-    in
-    let remove () =
-      Log.info (fun f ->
-          f "@[<h>Index.record %s/%s %s %s REMOVED@]" owner name
-            (Astring.String.with_range ~len:6 hash)
-            variant);
-      Db.exec t.remove
-        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
-    in
-    (match (prev, job) with
-    | Some j1, Some j2 -> update j1 j2
-    | None, Some j2 -> set j2
-    | Some _, None -> remove ()
-    | None, None -> assert false);
-    None
-  in
-  let (_ : [ `Empty ] Job_map.t) = Job_map.merge merge previous jobs in
-  (* () *)
-
-
-  let () = Status_cache.add ~owner ~name ~hash status in
-  let first_queued = Run_time.build_created_at in
-  let ts = List.map (fun (_, job_id) -> Run_time.timestamps_of_job job_id) jobs in
-
-let get_full_hash ~owner ~name short_hash =
-  let t = Lazy.force db in
-  if is_valid_hash short_hash then
-    match
-      Db.query t.full_hash
-        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ]
-    with
-    | [] -> Error `Unknown
-    | [ Sqlite3.Data.[ TEXT hash ] ] -> Ok hash
-    | [ _ ] -> failwith "full_hash: invalid result!"
-    | _ :: _ :: _ -> Error `Ambiguous
-  else Error `Invalid
-
-let get_jobs ~owner ~name hash =
-  let t = Lazy.force db in
-  Db.query t.get_jobs Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
-  |> List.map @@ function
-     | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
-         let outcome =
-           if Current.Job.lookup_running job_id = None then `Aborted
-           else `Active
-         in
-         let ts = Run_time.timestamps_of_job job_id in
-         (variant, outcome, ts)
-     | Sqlite3.Data.[ TEXT variant; TEXT job_id; INT ok; BLOB outcome ] ->
-         let outcome = if ok = 1L then `Passed else `Failed outcome in
-         let ts = Run_time.timestamps_of_job job_id in
-         (variant, outcome, ts)
-     | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] ->
-         (variant, `Not_started, None)
-     | row -> Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
-
-let get_job ~owner ~name ~hash ~variant =
-  let t = Lazy.force db in
-  match
-    Db.query_some t.get_job
-      Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
-  with
-  | None -> Error `No_such_variant
-  | Some Sqlite3.Data.[ TEXT id ] -> Ok (Some id)
-  | Some Sqlite3.Data.[ NULL ] -> Ok None
-  | _ -> failwith "get_job: invalid result!"
-
-let get_job_ids ~owner ~name ~hash =
-  let t = Lazy.force db in
-  get_job_ids_with_variant t ~owner ~name ~hash |> List.filter_map snd
-
 module Owner_set = Set.Make (String)
 
 let active_owners = ref Owner_set.empty
@@ -389,7 +261,8 @@ module Aggregate = struct
     let s_repo =
       match Repo_map.find_opt repo !state with
       | None -> { default_ref = ref; ref_states = Ref_map.singleton ref s_ref }
-      | Some { default_ref; ref_states } -> { default_ref; ref_states = Ref_map.add ref s_ref ref_states }
+      | Some { default_ref; ref_states } ->
+          { default_ref; ref_states = Ref_map.add ref s_ref ref_states }
     in
     state := Repo_map.add repo s_repo !state
 
@@ -431,9 +304,124 @@ module Commit_cache = struct
 
   let add ~owner ~name ~hash status started_at ran_for =
     let v = { s = status; started_at; ran_for } in
-    state := Commit_map.add (owner, name, hash) v !state
+    state := Commit_map.add (owner, name, hash) v !state;
+    Aggregate.set_ref_state ~repo:{ Repo_id.owner; name }
+  (* !!! *)
 
   let find ~owner ~name ~hash =
     let default = { s = `Not_started; started_at = None; ran_for = None } in
     Commit_map.find_opt (owner, name, hash) !state |> Option.value ~default
 end
+
+let record ~repo ~hash ~status ~gref jobs =
+  let { Repo_id.owner; name } = repo in
+  let t = Lazy.force db in
+  let jobs_m = Job_map.of_list jobs in
+  let previous =
+    get_job_ids_with_variant t ~owner ~name ~hash |> Job_map.of_list
+  in
+  let merge variant prev job =
+    let set job_id =
+      Log.info (fun f ->
+          f "@[<h>Index.record %s/%s %s %s -> %a@]" owner name
+            (Astring.String.with_range ~len:6 hash)
+            variant
+            Fmt.(option ~none:(any "-") string)
+            job_id);
+      match job_id with
+      | None ->
+          Db.exec t.record_job
+            Sqlite3.Data.
+              [
+                TEXT owner; TEXT name; TEXT hash; TEXT variant; TEXT gref; NULL;
+              ]
+      | Some id ->
+          Db.exec t.record_job
+            Sqlite3.Data.
+              [
+                TEXT owner;
+                TEXT name;
+                TEXT hash;
+                TEXT variant;
+                TEXT gref;
+                TEXT id;
+              ]
+    in
+    let update j1 j2 =
+      match (j1, j2) with
+      | Some j1, Some j2 when j1 = j2 -> ()
+      | None, None -> ()
+      | _, j2 -> set j2
+    in
+    let remove () =
+      Log.info (fun f ->
+          f "@[<h>Index.record %s/%s %s %s REMOVED@]" owner name
+            (Astring.String.with_range ~len:6 hash)
+            variant);
+      Db.exec t.remove
+        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
+    in
+    (match (prev, job) with
+    | Some j1, Some j2 -> update j1 j2
+    | None, Some j2 -> set j2
+    | Some _, None -> remove ()
+    | None, None -> assert false);
+    None
+  in
+  let (_ : [ `Empty ] Job_map.t) = Job_map.merge merge previous jobs_m in
+  let ts =
+    List.map
+      (fun (_, job_id) ->
+        Option.map (fun id -> Run_time.timestamps_of_job id) job_id
+        |> Option.join)
+      jobs
+  in
+  let first_queued = Run_time.first_queued_at (List.filter_map Fun.id ts) in
+  Commit_cache.add ~owner ~name ~hash status first_queued None
+
+let get_full_hash ~owner ~name short_hash =
+  let t = Lazy.force db in
+  if is_valid_hash short_hash then
+    match
+      Db.query t.full_hash
+        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ]
+    with
+    | [] -> Error `Unknown
+    | [ Sqlite3.Data.[ TEXT hash ] ] -> Ok hash
+    | [ _ ] -> failwith "full_hash: invalid result!"
+    | _ :: _ :: _ -> Error `Ambiguous
+  else Error `Invalid
+
+let get_jobs ~owner ~name hash =
+  let t = Lazy.force db in
+  Db.query t.get_jobs Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash ]
+  |> List.map @@ function
+     | Sqlite3.Data.[ TEXT variant; TEXT job_id; NULL; NULL ] ->
+         let outcome =
+           if Current.Job.lookup_running job_id = None then `Aborted
+           else `Active
+         in
+         let ts = Run_time.timestamps_of_job job_id in
+         (variant, outcome, ts)
+     | Sqlite3.Data.[ TEXT variant; TEXT job_id; INT ok; BLOB outcome ] ->
+         let outcome = if ok = 1L then `Passed else `Failed outcome in
+         let ts = Run_time.timestamps_of_job job_id in
+         (variant, outcome, ts)
+     | Sqlite3.Data.[ TEXT variant; NULL; NULL; NULL ] ->
+         (variant, `Not_started, None)
+     | row -> Fmt.failwith "get_jobs: invalid result: %a" Db.dump_row row
+
+let get_job ~owner ~name ~hash ~variant =
+  let t = Lazy.force db in
+  match
+    Db.query_some t.get_job
+      Sqlite3.Data.[ TEXT owner; TEXT name; TEXT hash; TEXT variant ]
+  with
+  | None -> Error `No_such_variant
+  | Some Sqlite3.Data.[ TEXT id ] -> Ok (Some id)
+  | Some Sqlite3.Data.[ NULL ] -> Ok None
+  | _ -> failwith "get_job: invalid result!"
+
+let get_job_ids ~owner ~name ~hash =
+  let t = Lazy.force db in
+  get_job_ids_with_variant t ~owner ~name ~hash |> List.filter_map snd

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -380,7 +380,6 @@ let record ~repo ~hash ~status ~gref jobs =
           Option.map (fun id -> Run_time.timestamps_of_job id) job_id
           |> Option.join
         in
-        Dream.log "%s" variant;
         (variant, id))
       jobs
   in

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -190,6 +190,15 @@ let get_build_history_with_time ~owner ~name ~gref =
   |> List.filter (fun (gref', _, time) ->
          if Option.is_none time then false else gref = gref')
 
+let get_build_history_hashes ~owner ~name ~gref =
+  let t = Lazy.force db in
+  Db.query t.get_commits_job_ids_for_ref
+    Sqlite3.Data.[ TEXT owner; TEXT name; TEXT gref ]
+  |> List.map @@ function
+     | Sqlite3.Data.[ TEXT _; TEXT hash; NULL ] -> hash
+     | Sqlite3.Data.[ TEXT _; TEXT hash; TEXT _ ] -> hash
+     | row -> Fmt.failwith "get_build_history: invalid row %a" Db.dump_row row
+
 module Owner_set = Set.Make (String)
 
 let active_owners = ref Owner_set.empty

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -190,15 +190,6 @@ let get_build_history_with_time ~owner ~name ~gref =
   |> List.filter (fun (gref', _, time) ->
          if Option.is_none time then false else gref = gref')
 
-let get_build_history_hashes ~owner ~name ~gref =
-  let t = Lazy.force db in
-  Db.query t.get_commits_job_ids_for_ref
-    Sqlite3.Data.[ TEXT owner; TEXT name; TEXT gref ]
-  |> List.map @@ function
-     | Sqlite3.Data.[ TEXT _; TEXT hash; NULL ] -> hash
-     | Sqlite3.Data.[ TEXT _; TEXT hash; TEXT _ ] -> hash
-     | row -> Fmt.failwith "get_build_history: invalid row %a" Db.dump_row row
-
 module Owner_set = Set.Make (String)
 
 let active_owners = ref Owner_set.empty

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -65,7 +65,7 @@ val get_build_history_with_time :
     branch gref of the repo identfied by (owner, name). The builds are
     identified by triples (variant, hash, Some timestamp) *)
 
-val get_status : owner:string -> name:string -> hash:string -> build_status
+(* val get_status : owner:string -> name:string -> hash:string -> build_status *)
 (** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
 
 val get_full_hash :

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -149,6 +149,12 @@ val get_build_history_with_time :
     branch gref of the repo identfied by (owner, name). The builds are
     identified by triples (variant, hash, Some timestamp) *)
 
+val get_build_history_hashes :
+  owner:string -> name:string -> gref:string -> string list
+(** [get_build_history ~owner ~name ~gref] is a list of builds for the branch
+    gref of the repo identfied by (owner, name) The builds are identified by
+    their hashes *)
+
 (* val get_status : owner:string -> name:string -> hash:string -> build_status *)
 (** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
 

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -18,6 +18,89 @@ val migrate : unit -> unit Current.t
 (** [migrate ()] ensures the database is up-to-date when the project is run. If
     the date changes, it will try to run the migration again. **)
 
+module Owner_set : Set.S with type elt = string
+module Repo_set : Set.S with type elt = string
+
+val set_active_owners : Owner_set.t -> unit
+(** [set_active_owners owners] records that [owners] is the set of accounts on
+    which the CI is installed. This is displayed in the CI web interface. *)
+
+val get_active_owners : unit -> Owner_set.t
+(** [get_active_owners ()] is the last value passed to [set_active_owners], or
+    [\[\]] if not known yet. *)
+
+val set_active_repos : owner:string -> Repo_set.t -> unit
+(** [set_active_repos ~owner repos] records that [repos] is the set of active
+    repositories under [owner]. *)
+
+val get_active_repos : owner:string -> Repo_set.t
+(** [get_active_repos ~owner] is the last value passed to [set_active_repos] for
+    [owner], or [empty] if not known yet. *)
+
+module Ref_map : Map.S with type key = string
+
+type ref_info = { hash : string; message : string; name : string }
+[@@deriving show]
+
+val set_active_refs : repo:Repo_id.t -> ref_info Ref_map.t -> string -> unit
+(** [set_active_refs ~repo refs] records that [refs] is the current set of Git
+    references that the CI is watching. There is one entry for each branch and
+    PR. Each entry maps the Git reference name to the head commit's hash. *)
+
+val get_active_refs : Repo_id.t -> ref_info Ref_map.t
+(** [get_active_refs repo] is the entries last set for [repo] with
+    [set_active_refs], or [empty] if this repository isn't known. Elements in
+    ref tuple are ([hash], [message], [title]) *)
+
+val get_default_gref : Repo_id.t -> string
+(** [get_default_gref repo] is the default gref of the repo last set with
+    [set_active_refs] *)
+
+type status = [ `Not_started | `Pending | `Failed | `Passed ]
+
+(** Aggregation of state for refs and repos. Refs take their state from their
+    head commit, and repos take their state from their main/master branch *)
+module Aggregate : sig
+  type ref_state
+  type repo_state
+
+  val get_ref_status : ref_state -> status
+  val get_ref_started_at : ref_state -> float option
+  val get_ref_ran_for : ref_state -> float option
+  val get_repo_status : repo_state -> status
+  val get_repo_started_at : repo_state -> float option
+
+  val set_ref_state :
+    repo:Repo_id.t ->
+    ref:string ->
+    status ->
+    float option ->
+    float option ->
+    unit
+
+  val get_ref_state : repo:Repo_id.t -> ref:string -> ref_state
+  val get_repo_state : repo:Repo_id.t -> repo_state
+end
+
+module Commit_cache : sig
+  type commit_state
+
+  val get_status : commit_state -> status
+  val get_started_at : commit_state -> float option
+  val get_ran_for : commit_state -> float option
+
+  val add :
+    owner:string ->
+    name:string ->
+    hash:string ->
+    status ->
+    float option ->
+    float option ->
+    unit
+
+  val find : owner:string -> name:string -> hash:string -> commit_state
+end
+
 val record :
   repo:Repo_id.t ->
   hash:string ->
@@ -75,86 +158,3 @@ val get_full_hash :
   (string, [> `Ambiguous | `Unknown | `Invalid ]) result
 (** [get_full_hash ~owner ~name short_hash] returns the full hash for
     [short_hash]. *)
-
-module Owner_set : Set.S with type elt = string
-module Repo_set : Set.S with type elt = string
-
-val set_active_owners : Owner_set.t -> unit
-(** [set_active_owners owners] records that [owners] is the set of accounts on
-    which the CI is installed. This is displayed in the CI web interface. *)
-
-val get_active_owners : unit -> Owner_set.t
-(** [get_active_owners ()] is the last value passed to [set_active_owners], or
-    [\[\]] if not known yet. *)
-
-val set_active_repos : owner:string -> Repo_set.t -> unit
-(** [set_active_repos ~owner repos] records that [repos] is the set of active
-    repositories under [owner]. *)
-
-val get_active_repos : owner:string -> Repo_set.t
-(** [get_active_repos ~owner] is the last value passed to [set_active_repos] for
-    [owner], or [empty] if not known yet. *)
-
-module Ref_map : Map.S with type key = string
-
-type ref_info = { hash : string; message : string; name : string }
-[@@deriving show]
-
-val set_active_refs : repo:Repo_id.t -> ref_info Ref_map.t -> string -> unit
-(** [set_active_refs ~repo refs] records that [refs] is the current set of Git
-    references that the CI is watching. There is one entry for each branch and
-    PR. Each entry maps the Git reference name to the head commit's hash. *)
-
-val get_active_refs : Repo_id.t -> ref_info Ref_map.t
-(** [get_active_refs repo] is the entries last set for [repo] with
-    [set_active_refs], or [empty] if this repository isn't known. Elements in
-    ref tuple are ([hash], [message], [title]) *)
-
-val get_default_gref : Repo_id.t -> string
-(** [get_default_gref repo] is the default gref of the repo last set with
-    [set_active_refs] *)
-    
-type status = [ `Not_started | `Pending | `Failed | `Passed ]
-
-(** Aggregation of state for refs and repos. Refs take their state from their
-    head commit, and repos take their state from their main/master branch *)
-module Aggregate : sig
-  type ref_state
-  type repo_state
-
-  val get_ref_status : ref_state -> status
-  val get_ref_started_at : ref_state -> float option
-  val get_ref_ran_for : ref_state -> float option
-  val get_repo_status : repo_state -> status
-  val get_repo_started_at : repo_state -> float option
-
-  val set_ref_state :
-    repo:Repo_id.t ->
-    ref:string ->
-    status ->
-    float option ->
-    float option ->
-    unit
-
-  val get_ref_state : repo:Repo_id.t -> ref:string -> ref_state
-  val get_repo_state : repo:Repo_id.t -> repo_state
-end
-
-module Commit_cache : sig
-  type commit_state
-
-  val get_status : commit_state -> status
-  val get_started_at : commit_state -> float option
-  val get_ran_for : commit_state -> float option
-
-  val add :
-    owner:string ->
-    name:string ->
-    hash:string ->
-    status ->
-    float option ->
-    float option ->
-    unit
-
-  val find : owner:string -> name:string -> hash:string -> commit_state
-end

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -97,13 +97,7 @@ val get_active_repos : owner:string -> Repo_set.t
 
 module Ref_map : Map.S with type key = string
 
-type ref_info = {
-  hash : string;
-  message : string;
-  name : string;
-      (* started_at : float option;
-         ran_for : float option; *)
-}
+type ref_info = { hash : string; message : string; name : string }
 [@@deriving show]
 
 val set_active_refs : repo:Repo_id.t -> ref_info Ref_map.t -> string -> unit
@@ -128,14 +122,19 @@ module Aggregate : sig
   type repo_state
 
   val get_ref_status : ref_state -> status
-  val get_ref_started_at : ref_state -> float
-  val get_ref_ran_for : ref_state -> float
+  val get_ref_started_at : ref_state -> float option
+  val get_ref_ran_for : ref_state -> float option
   val get_repo_status : repo_state -> status
-  val get_repo_started_at : repo_state -> float
+  val get_repo_started_at : repo_state -> float option
 
   val set_ref_state :
-    repo:Repo_id.t -> ref:string -> status -> float -> float -> unit
+    repo:Repo_id.t ->
+    ref:string ->
+    status ->
+    float option ->
+    float option ->
+    unit
 
   val get_ref_state : repo:Repo_id.t -> ref:string -> ref_state
-  val aggregate_repo : repo:Repo_id.t -> unit
+  val get_repo_state : repo:Repo_id.t -> repo_state
 end

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -72,7 +72,7 @@ module Aggregate : sig
 
   val set_ref_state :
     repo:Repo_id.t ->
-    ref:string ->
+    gref:string ->
     status ->
     float option ->
     float option ->
@@ -93,6 +93,7 @@ module Commit_cache : sig
     owner:string ->
     name:string ->
     hash:string ->
+    gref:string ->
     status ->
     float option ->
     float option ->

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -149,12 +149,6 @@ val get_build_history_with_time :
     branch gref of the repo identfied by (owner, name). The builds are
     identified by triples (variant, hash, Some timestamp) *)
 
-val get_build_history_hashes :
-  owner:string -> name:string -> gref:string -> string list
-(** [get_build_history ~owner ~name ~gref] is a list of builds for the branch
-    gref of the repo identfied by (owner, name) The builds are identified by
-    their hashes *)
-
 (* val get_status : owner:string -> name:string -> hash:string -> build_status *)
 (** [get_status ~owner ~name ~hash] is the latest status for this combination. *)
 

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -113,11 +113,12 @@ val get_active_refs : Repo_id.t -> ref_info Ref_map.t
 val get_default_gref : Repo_id.t -> string
 (** [get_default_gref repo] is the default gref of the repo last set with
     [set_active_refs] *)
+    
+type status = [ `Not_started | `Pending | `Failed | `Passed ]
 
 (** Aggregation of state for refs and repos. Refs take their state from their
     head commit, and repos take their state from their main/master branch *)
 module Aggregate : sig
-  type status = [ `Not_started | `Pending | `Failed | `Passed ]
   type ref_state
   type repo_state
 
@@ -137,4 +138,23 @@ module Aggregate : sig
 
   val get_ref_state : repo:Repo_id.t -> ref:string -> ref_state
   val get_repo_state : repo:Repo_id.t -> repo_state
+end
+
+module Commit_cache : sig
+  type commit_state
+
+  val get_status : commit_state -> status
+  val get_started_at : commit_state -> float option
+  val get_ran_for : commit_state -> float option
+
+  val add :
+    owner:string ->
+    name:string ->
+    hash:string ->
+    status ->
+    float option ->
+    float option ->
+    unit
+
+  val find : owner:string -> name:string -> hash:string -> commit_state
 end

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -119,3 +119,23 @@ val get_active_refs : Repo_id.t -> ref_info Ref_map.t
 val get_default_gref : Repo_id.t -> string
 (** [get_default_gref repo] is the default gref of the repo last set with
     [set_active_refs] *)
+
+(** Aggregation of state for refs and repos. Refs take their state from their
+    head commit, and repos take their state from their main/master branch *)
+module Aggregate : sig
+  type status = [ `Not_started | `Pending | `Failed | `Passed ]
+  type ref_state
+  type repo_state
+
+  val get_ref_status : ref_state -> status
+  val get_ref_started_at : ref_state -> float
+  val get_ref_ran_for : ref_state -> float
+  val get_repo_status : repo_state -> status
+  val get_repo_started_at : repo_state -> float
+
+  val set_ref_state :
+    repo:Repo_id.t -> ref:string -> status -> float -> float -> unit
+
+  val get_ref_state : repo:Repo_id.t -> ref:string -> ref_state
+  val aggregate_repo : repo:Repo_id.t -> unit
+end

--- a/lib/run_time.ml
+++ b/lib/run_time.ml
@@ -102,3 +102,18 @@ let timestamps_of_job job_id : timestamps option =
                 y.Current_cache.Db.job_id))
         x;
       None
+
+let first_queued_at ts =
+  let time =
+    List.fold_left
+      (fun acc x ->
+        let queued_at =
+          match x with
+          | Queued v -> v
+          | Running { queued_at; _ } -> queued_at
+          | Finished { queued_at; _ } -> queued_at
+        in
+        Float.min acc queued_at)
+      Float.infinity ts
+  in
+  if Float.is_finite time then Some time else None

--- a/lib/run_time.ml
+++ b/lib/run_time.ml
@@ -16,6 +16,14 @@ type timestamps =
     }
 [@@deriving show]
 
+type run_time_info =
+  | Cached
+    (* This indicates that the job never ran because cached results were used *)
+  | Queued_for of float (* elapsed time in seconds *)
+  | Running of { queued_for : float; ran_for : float }
+  | Finished of { queued_for : float; ran_for : float option }
+[@@deriving show]
+
 let eq_timestamps (st1 : timestamps) (st2 : timestamps) =
   match (st1, st2) with
   | Queued v1, Queued v2 -> cmp_floats v1 v2
@@ -103,17 +111,93 @@ let timestamps_of_job job_id : timestamps option =
         x;
       None
 
-let first_queued_at ts =
-  let time =
-    List.fold_left
-      (fun acc x ->
-        let queued_at =
-          match x with
-          | Queued v -> v
-          | Running { queued_at; _ } -> queued_at
-          | Finished { queued_at; _ } -> queued_at
-        in
-        Float.min acc queued_at)
-      Float.infinity ts
+let queued_at = function
+  | Queued v -> v
+  | Running v -> v.queued_at
+  | Finished v -> v.queued_at
+
+let partition_build_steps build =
+  let analysis_steps, rest = List.partition (fun (variant, _) -> String.equal variant "analysis") build in
+  let analysis_steps = List.map snd analysis_steps in
+  let rest = List.map snd rest in
+  match analysis_steps with
+  | [] -> Error "No analysis step found"
+  | [ h ] -> Ok (h, rest)
+  | _ :: _ -> Error "Multiple analysis steps found"
+
+let run_times_from_timestamps ~build_created_at
+    ?(current_time = Unix.gettimeofday ()) (ts : timestamps) : run_time_info =
+  match ts with
+  | Queued v -> Queued_for (current_time -. v)
+  | Running { queued_at; started_at } ->
+      Running
+        {
+          queued_for = started_at -. queued_at;
+          ran_for = current_time -. started_at;
+        }
+  | Finished { queued_at; started_at; finished_at } -> (
+      if finished_at < build_created_at then Cached
+      else
+        match started_at with
+        | None ->
+            Finished { queued_for = finished_at -. queued_at; ran_for = None }
+        | Some v ->
+            Finished
+              { queued_for = v -. queued_at; ran_for = Some (finished_at -. v) }
+      )
+
+let total_time = function
+  | Cached -> 0.
+  | Queued_for v -> v
+  | Running v -> v.queued_for +. v.ran_for
+  | Finished v -> v.queued_for +. Option.value ~default:0. v.ran_for
+
+let max_of_step_run_times ~build_created_at ts =
+  let sorted_steps =
+    ts
+    |> List.map (fun ts ->
+           total_time @@ run_times_from_timestamps ~build_created_at ts)
+    |> List.sort Float.compare
+    |> List.rev
   in
-  if Float.is_finite time then Some time else None
+  Option.value ~default:0. (List.nth_opt sorted_steps 0)
+
+let build_run_time build =
+  let partitioned = Result.to_option @@ partition_build_steps build in
+   match partitioned with
+   | None -> 0.
+   | Some (analysis_step, rest) -> (
+       let build_created_at = queued_at @@ snd analysis_step in
+       let analysis_step_timestamps = snd analysis_step
+       in
+       match analysis_step_timestamps with
+       | None -> 0.
+       | Some analysis_step_timestamps ->
+           let run_time_analysis_step =
+             total_time
+             @@ run_times_from_timestamps ~build_created_at
+                   analysis_step_timestamps
+           in
+           run_time_analysis_step +. max_of_step_run_times ~build_created_at rest
+       )
+
+
+(* let build_run_time build =
+   let partitioned = Result.to_option @@ partition_build_steps build in
+   match partitioned with
+   | None -> 0.
+   | Some (analysis_step, rest) -> (
+       let build_created_at = Option.value ~default:0. analysis_step.queued_at in
+       let analysis_step_timestamps =
+         Result.to_option @@ timestamps_from_job_info analysis_step
+       in
+       match analysis_step_timestamps with
+       | None -> 0.
+       | Some analysis_step_timestamps ->
+           let run_time_analysis_step =
+             total_time
+             @@ run_times_from_timestamps ~build_created_at
+                   analysis_step_timestamps
+           in
+           run_time_analysis_step +. max_of_step_run_times ~build_created_at rest
+       ) *)

--- a/lib/run_time.mli
+++ b/lib/run_time.mli
@@ -32,3 +32,5 @@ val pp_timestamps : Format.formatter -> timestamps -> unit
 val timestamps_of_job : Current.job_id -> timestamps option
 (** Hydrates a timestamps instance for a step/job by looking up timestamps in
     the ocurrent layer. *)
+
+val first_queued_at : timestamps list -> float option

--- a/lib/run_time.mli
+++ b/lib/run_time.mli
@@ -40,5 +40,5 @@ val timestamps_of_job : Current.job_id -> timestamps option
 (** Hydrates a timestamps instance for a step/job by looking up timestamps in
     the ocurrent layer. *)
 
-val first_queued_at : timestamps list -> float option
-val build_run_time : timestamps list -> float
+val build_ran_for : (string * timestamps option) list -> float
+val first_step_queued_at : timestamps option list -> (float, string) result

--- a/lib/run_time.mli
+++ b/lib/run_time.mli
@@ -23,6 +23,13 @@ type timestamps =
             and when it finished. Note that it may never run -- it may be
             cancelled or it may timeout. *)
 
+type run_time_info =
+  | Cached
+  | Queued_for of float
+  | Running of { queued_for : float; ran_for : float }
+  | Finished of { queued_for : float; ran_for : float option }
+[@@deriving show]
+
 val eq_timestamps : timestamps -> timestamps -> bool
 (** equality of timestamps - useful for tests *)
 
@@ -34,3 +41,4 @@ val timestamps_of_job : Current.job_id -> timestamps option
     the ocurrent layer. *)
 
 val first_queued_at : timestamps list -> float option
+val build_run_time : timestamps list -> float

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -158,10 +158,9 @@ let make_repo ~engine ~owner ~name =
        method refs_impl _params release_param_caps =
          let open Repo.Refs in
          release_param_caps ();
-         let refs =
-           Index.get_active_refs { Ocaml_ci.Repo_id.owner; name }
-           |> Index.Ref_map.bindings
-         in
+
+         let repo_id = { Ocaml_ci.Repo_id.owner; name } in
+         let refs = Index.get_active_refs repo_id |> Index.Ref_map.bindings in
          let response, results = Service.Response.create Results.init_pointer in
          let arr = Results.refs_init results (List.length refs) in
          refs

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -170,16 +170,15 @@ let make_repo ~engine ~owner ~name =
                 let slot = Capnp.Array.get arr i in
                 ref_set slot gref;
                 hash_set slot hash;
+                let ref_s =
+                  Index.Aggregate.get_ref_state ~repo:repo_id ~ref:gref
+                in
                 let status =
-                  to_build_status
-                    Index.Commit_cache.(get_status @@ find ~owner ~name ~hash)
+                  to_build_status (Index.Aggregate.get_ref_status ref_s)
                 in
                 status_set slot status;
                 message_set slot message;
                 name_set slot ref_name;
-                let ref_s =
-                  Index.Aggregate.get_ref_state ~repo:repo_id ~ref:gref
-                in
                 let started_at_t = started_at_init slot in
                 (match Index.Aggregate.get_ref_started_at ref_s with
                 | None -> StartedAt.none_set started_at_t
@@ -206,16 +205,15 @@ let make_repo ~engine ~owner ~name =
              let open Raw.Builder.RefInfo in
              ref_set slot default_gref;
              hash_set slot hash;
+             let ref_s =
+               Index.Aggregate.get_ref_state ~repo:repo_id ~ref:default_gref
+             in
              let status =
-               to_build_status
-                 Index.Commit_cache.(get_status @@ find ~owner ~name ~hash)
+               to_build_status (Index.Aggregate.get_ref_status ref_s)
              in
              status_set slot status;
              message_set slot message;
              name_set slot ref_name;
-             let ref_s =
-               Index.Aggregate.get_ref_state ~repo:repo_id ~ref:default_gref
-             in
              let started_at_t = started_at_init slot in
              (match Index.Aggregate.get_ref_started_at ref_s with
              | None -> StartedAt.none_set started_at_t
@@ -268,26 +266,26 @@ let make_repo ~engine ~owner ~name =
          let open Repo.HistoryOfRef in
          let gref = Params.ref_get params in
          release_param_caps ();
-         let history = Index.get_build_history_with_time ~owner ~name ~gref in
+         let history = Index.get_build_history_hashes ~owner ~name ~gref in
          let response, results = Service.Response.create Results.init_pointer in
          let arr = Results.refs_init results (List.length history) in
          history
-         |> List.iteri (fun i (_, hash, started) ->
+         |> List.iteri (fun i hash ->
                 let open Raw.Builder.RefInfo in
                 let slot = Capnp.Array.get arr i in
                 ref_set slot gref;
                 hash_set slot hash;
+                let commit_s = Index.Commit_cache.find ~owner ~name ~hash in
                 let status =
-                  to_build_status
-                    Index.Commit_cache.(get_status @@ find ~owner ~name ~hash)
+                  to_build_status (Index.Commit_cache.get_status commit_s)
                 in
                 status_set slot status;
                 let started_at_t = started_at_init slot in
-                (match started with
+                (match Index.Commit_cache.get_started_at commit_s with
                 | None -> StartedAt.none_set started_at_t
                 | Some time -> StartedAt.ts_set started_at_t time);
                 let ran_for_t = ran_for_init slot in
-                match started with
+                match Index.Commit_cache.get_ran_for commit_s with
                 | None -> RanFor.none_set ran_for_t
                 | Some time -> RanFor.ts_set ran_for_t time);
          Service.return response

--- a/service/main.ml
+++ b/service/main.ml
@@ -22,7 +22,7 @@ module Metrics = struct
     with
     | None -> acc
     | Some { Index.hash; _ } -> (
-        match Index.get_status ~owner ~name ~hash with
+        match Index.Commit_cache.(find ~owner ~name ~hash |> get_status) with
         | `Failed -> { acc with failed = acc.failed + 1 }
         | `Passed -> { acc with ok = acc.ok + 1 }
         | `Not_started | `Pending -> { acc with active = acc.active + 1 })

--- a/web-ui/static/js/repo-page-search.js
+++ b/web-ui/static/js/repo-page-search.js
@@ -1,23 +1,21 @@
 
-<<<<<<< HEAD
 function title_comparator(a, b) {
-  var title_a = a.getElementsByClassName("repo-title")[0].textContent.toLowerCase()
-  var title_b = b.getElementsByClassName("repo-title")[0].textContent.toLowerCase()
-=======
-
-function title_comparator(a, b) {
-  console.log("A", title_a)
-  console.log("B", title_b)
-  var title_a = a.getElementsByClassName("repo-title")[0].textContent
-  var title_b = b.getElementsByClassName("repo-title")[0].textContent
->>>>>>> 9c78ef6 (Progress with JS for repo sorting)
+  var title_a =
+    a
+    .getElementsByClassName("repo-title")[0]
+    .textContent
+    .toLowerCase()
+  var title_b =
+    b
+    .getElementsByClassName("repo-title")[0]
+    .textContent
+    .toLowerCase()
   if (title_a < title_b) return -1
   if (title_a > title_b) return 1
   return 0
 }
 
 function time_comparator(a, b) {
-<<<<<<< HEAD
   var ts_a = parseFloat(a.getAttribute("data-timestamp"))
   var ts_b = parseFloat(b.getAttribute("data-timestamp"))
   if (ts_a < ts_b) return -1
@@ -25,13 +23,6 @@ function time_comparator(a, b) {
   // Fallback to title comparison for consistency when switching
   // between the two; we don't want rows swapping unnecessarily
   return title_comparator(a, b)
-=======
-  var ts_a = a.getAttribute("data-timestamp")
-  var ts_b = b.getAttribute("data-timestamp")
-  if (ts_a < ts_b) return -1
-  if (ts_a > ts_b) return 1
-  return 0
->>>>>>> 9c78ef6 (Progress with JS for repo sorting)
 }
 
 function sort(select) {
@@ -39,27 +30,22 @@ function sort(select) {
   if (select === "alpha") {
     children = children.sort(title_comparator)
   } else if (select === "recent") {
-<<<<<<< HEAD
     children = children.sort(time_comparator)
   }
-=======
-    children = children.sort(title_comparator)
-  }
-  // for (i = 0; i < itemsArr.length; ++i) {
-  //   list.appendChild(itemsArr[i]);
-  // }
->>>>>>> 9c78ef6 (Progress with JS for repo sorting)
   for (i = 0; i < children.length; ++i) {
     body.appendChild(children[i]);
   }
 }
 
-<<<<<<< HEAD
 function search(target) {
   var children = Array.from(body.children)
 
   function has_substr(child, ss) {
-    var title = child.getElementsByClassName("repo-title")[0].textContent.toLowerCase()
+    var title =
+      child
+      .getElementsByClassName("repo-title")[0]
+      .textContent
+      .toLowerCase()
     return title.indexOf(ss.toLowerCase()) !== -1
   }
   var n_visible = 0
@@ -84,18 +70,4 @@ window.onload = function() {
   head = table_root.firstChild
   // table -> tbody
   body = table_root.lastChild
-=======
-var body = null
-// var children = null
-var head = null
-
-window.onload = function() {
-  var initial = document.getElementById("table")
-  // table -> thead
-  head = initial.firstChild
-  // table -> tbody
-  body = initial.lastChild
-  // children = Array.from(initial.lastChild.children)
-  // sort()
->>>>>>> 9c78ef6 (Progress with JS for repo sorting)
 }

--- a/web-ui/static/js/repo-page-search.js
+++ b/web-ui/static/js/repo-page-search.js
@@ -1,13 +1,23 @@
 
+<<<<<<< HEAD
 function title_comparator(a, b) {
   var title_a = a.getElementsByClassName("repo-title")[0].textContent.toLowerCase()
   var title_b = b.getElementsByClassName("repo-title")[0].textContent.toLowerCase()
+=======
+
+function title_comparator(a, b) {
+  console.log("A", title_a)
+  console.log("B", title_b)
+  var title_a = a.getElementsByClassName("repo-title")[0].textContent
+  var title_b = b.getElementsByClassName("repo-title")[0].textContent
+>>>>>>> 9c78ef6 (Progress with JS for repo sorting)
   if (title_a < title_b) return -1
   if (title_a > title_b) return 1
   return 0
 }
 
 function time_comparator(a, b) {
+<<<<<<< HEAD
   var ts_a = parseFloat(a.getAttribute("data-timestamp"))
   var ts_b = parseFloat(b.getAttribute("data-timestamp"))
   if (ts_a < ts_b) return -1
@@ -15,6 +25,13 @@ function time_comparator(a, b) {
   // Fallback to title comparison for consistency when switching
   // between the two; we don't want rows swapping unnecessarily
   return title_comparator(a, b)
+=======
+  var ts_a = a.getAttribute("data-timestamp")
+  var ts_b = b.getAttribute("data-timestamp")
+  if (ts_a < ts_b) return -1
+  if (ts_a > ts_b) return 1
+  return 0
+>>>>>>> 9c78ef6 (Progress with JS for repo sorting)
 }
 
 function sort(select) {
@@ -22,13 +39,22 @@ function sort(select) {
   if (select === "alpha") {
     children = children.sort(title_comparator)
   } else if (select === "recent") {
+<<<<<<< HEAD
     children = children.sort(time_comparator)
   }
+=======
+    children = children.sort(title_comparator)
+  }
+  // for (i = 0; i < itemsArr.length; ++i) {
+  //   list.appendChild(itemsArr[i]);
+  // }
+>>>>>>> 9c78ef6 (Progress with JS for repo sorting)
   for (i = 0; i < children.length; ++i) {
     body.appendChild(children[i]);
   }
 }
 
+<<<<<<< HEAD
 function search(target) {
   var children = Array.from(body.children)
 
@@ -58,4 +84,18 @@ window.onload = function() {
   head = table_root.firstChild
   // table -> tbody
   body = table_root.lastChild
+=======
+var body = null
+// var children = null
+var head = null
+
+window.onload = function() {
+  var initial = document.getElementById("table")
+  // table -> thead
+  head = initial.firstChild
+  // table -> tbody
+  body = initial.lastChild
+  // children = Array.from(initial.lastChild.children)
+  // sort()
+>>>>>>> 9c78ef6 (Progress with JS for repo sorting)
 }

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -26,8 +26,6 @@ module Make (M : M_Git_forge) = struct
       append truncated "…"
 
   let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
-    ignore started_at;
-    (*See FIXME - revert this when started_at is implemented *)
     (* messages are of arbitrary length - let's truncate them *)
     let message = truncate ~len:72 message in
     let ref_title =

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -67,10 +67,7 @@ module Make (M : M_Git_forge) = struct
       match ran_for with
       | None -> [ Common.right_arrow_head ]
       | Some _ ->
-          [
-            div [ txt (duration status ran_for) ];
-            Common.right_arrow_head;
-          ]
+          [ div [ txt (duration status ran_for) ]; Common.right_arrow_head ]
     in
     a
       ~a:[ a_class [ "table-row" ]; a_href ref_uri ]

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -25,6 +25,17 @@ module Make (M : M_Git_forge) = struct
       let truncated = with_range ~len s in
       append truncated "…"
 
+  let duration (status : Build_status.t) t =
+    let text =
+      match status with
+      | NotStarted -> "In queue for"
+      | Failed -> "Failed in"
+      | Passed -> "Passed in"
+      | Pending -> "Running for"
+      | Undefined _ -> "In queue for"
+    in
+    Printf.sprintf "%s %s" text (Timestamps_durations.pp_duration t)
+
   let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
     (* messages are of arbitrary length - let's truncate them *)
     let message = truncate ~len:72 message in
@@ -57,7 +68,7 @@ module Make (M : M_Git_forge) = struct
       | None -> [ Common.right_arrow_head ]
       | Some _ ->
           [
-            div [ txt (Timestamps_durations.pp_timestamp ran_for) ];
+            div [ txt (duration status ran_for) ];
             Common.right_arrow_head;
           ]
     in


### PR DESCRIPTION
Initial work on data aggregation. Currently working on aggregating ref-level data (derived from the head commit of the ref) and repo-level data (derived from its default branch).

To support history, a second data structure is required - already partially implemented by the `Status_cache` - which needs to provide commit-level granularity. The aggregation of ref and repo data will probably rely on this cache for the head commits.