### PR TITLE
Better build run-times.

### DIFF
--- a/lib_client/run_time.mli
+++ b/lib_client/run_time.mli
@@ -78,6 +78,17 @@ val build_created_at :
 val total_time : run_time_info -> float
 (** The total time taken -- the sum of the queued and running times *)
 
+val max_of_step_run_times :
+  build_created_at:float -> Ocaml_ci_api.Client.job_info list -> float
+(** Takes a list of steps and returns the maximum of the run-times of the steps.
+    This is done by calculating the run-times of the steps in the list, sorting
+    the resulting list of run-times, and returning the head of the list
+    (defaulting to 0) *)
+
 val total_of_run_times : Ocaml_ci_api.Client.job_info list -> float
 (** Takes a list of job_info which is meant to be the steps in a build. Returns
     total of run times of the steps in the build.*)
+
+val build_run_time : Ocaml_ci_api.Client.job_info list -> float
+(** Takes a list of job_info which is meant to be the steps in a build. Returns
+    the (run-time of the analysis step) + max(run-times of the steps in the build) *)

--- a/lib_client/run_time.mli
+++ b/lib_client/run_time.mli
@@ -91,4 +91,5 @@ val total_of_run_times : Ocaml_ci_api.Client.job_info list -> float
 
 val build_run_time : Ocaml_ci_api.Client.job_info list -> float
 (** Takes a list of job_info which is meant to be the steps in a build. Returns
-    the (run-time of the analysis step) + max(run-times of the steps in the build) *)
+    the (run-time of the analysis step) + max(run-times of the steps in the
+    build) *)

--- a/test/test_build_representation.ml
+++ b/test/test_build_representation.ml
@@ -16,7 +16,7 @@ let test_to_json (jobs, build_status, build_created_at, expected) =
 let test_simple () =
   let step_info_1 : Client.job_info =
     {
-      variant = "variant";
+      variant = "analysis";
       outcome = Passed;
       queued_at = Some 1666210392.;
       started_at = Some 1666210434.;
@@ -24,7 +24,7 @@ let test_simple () =
     }
   in
   let expected_1 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"variant":"analysis"}|}
   in
   let step_info_2 : Client.job_info =
     {
@@ -55,7 +55,7 @@ let test_simple () =
   let build_created_at = 1666210300. in
   let expected =
     Fmt.str "%s[%s,%s,%s],\"step_route_prefix\":\"/github/foo/bar\"}"
-      {|{"version":"1.0","status":"failed: for reasons","first_created_at":"Oct 19 20:13 +00:00","ran_for":"6m04s","can_cancel":false,"can_rebuild":true,"steps":|}
+      {|{"version":"1.0","status":"failed: for reasons","first_created_at":"Oct 19 20:13 +00:00","ran_for":"4m16s","total_ran_for":"6m04s","can_cancel":false,"can_rebuild":true,"steps":|}
       expected_1 expected_2 expected_3
   in
   List.iter test_to_json [ (jobs, build_status, build_created_at, expected) ]

--- a/test/test_run_time_client.ml
+++ b/test/test_run_time_client.ml
@@ -394,6 +394,81 @@ let test_total_of_run_times =
   let result = Run_time.total_of_run_times build in
   Alcotest.(check (float 0.001)) "total_of_run_times" expected result
 
+let test_max_run_times =
+  let analysis_step : Client.job_info =
+    {
+      variant = "(analysis)";
+      outcome = Passed;
+      queued_at = Some 1234567.;
+      started_at = Some 1234570.;
+      finished_at = Some 1234575.;
+    }
+    (* thus run-time of analysis step is 3 + 5 = 8 *)
+  in
+  let lint_step : Client.job_info =
+    {
+      variant = "(lint-fmt)";
+      outcome = Passed;
+      queued_at = Some 1234576.;
+      started_at = Some 1234579.;
+      finished_at = Some 1234585.;
+    }
+    (* run-time of lint_step is 3 + 6 = 9 *)
+  in
+  let build_step : Client.job_info =
+    {
+      variant = "foo-11-4.14";
+      outcome = Passed;
+      queued_at = Some 1234576.;
+      started_at = Some 1234579.;
+      finished_at = Some 1234590.;
+    }
+    (* run-time of build_step is 3 + 11 = 14 -- this is the longest running step *)
+  in
+  let steps = [ analysis_step; lint_step; build_step ] in
+  let expected = 14. in
+  let result =
+    Run_time.max_of_step_run_times ~build_created_at:1234567. steps
+  in
+  Alcotest.(check (float 0.001)) "max_run_times" expected result
+
+let test_build_run_time =
+  let analysis_step : Client.job_info =
+    {
+      variant = "(analysis)";
+      outcome = Passed;
+      queued_at = Some 1234567.;
+      started_at = Some 1234570.;
+      finished_at = Some 1234575.;
+    }
+    (* thus run-time of analysis step is 3 + 5 = 8 *)
+  in
+  let lint_step : Client.job_info =
+    {
+      variant = "(lint-fmt)";
+      outcome = Passed;
+      queued_at = Some 1234576.;
+      started_at = Some 1234579.;
+      finished_at = Some 1234585.;
+    }
+    (* run-time of lint_step is 3 + 6 = 9 *)
+  in
+  let build_step : Client.job_info =
+    {
+      variant = "foo-11-4.14";
+      outcome = Passed;
+      queued_at = Some 1234576.;
+      started_at = Some 1234579.;
+      finished_at = Some 1234590.;
+    }
+    (* run-time of build_step is 3 + 11 = 14 -- this is the longest running step *)
+  in
+  let build = [ analysis_step; lint_step; build_step ] in
+  let expected = 8. +. 14. in
+  (* run-time of analysis + run-time of build-step (since it is the longest running step)*)
+  let result = Run_time.build_run_time build in
+  Alcotest.(check (float 0.001)) "build_run_time" expected result
+
 let test_first_step_queued_at =
   let not_started : Client.job_info =
     {

--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -123,6 +123,7 @@ module Make (View : View) = struct
       | Ok v -> Some v
     in
     let total_run_time = Run_time.total_of_run_times jobs in
+    (* let build_run_time = Run_time.wall_clock_run_time jobs in *)
     Dream.respond
     @@ View.list_steps ~org ~repo ~message ~refs ~hash ~jobs ~csrf_token
          ~first_step_queued_at ~total_run_time ~flash_messages ~build_status ()

--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -123,10 +123,11 @@ module Make (View : View) = struct
       | Ok v -> Some v
     in
     let total_run_time = Run_time.total_of_run_times jobs in
-    (* let build_run_time = Run_time.wall_clock_run_time jobs in *)
+    let build_run_time = Run_time.build_run_time jobs in
     Dream.respond
     @@ View.list_steps ~org ~repo ~message ~refs ~hash ~jobs ~csrf_token
-         ~first_step_queued_at ~total_run_time ~flash_messages ~build_status ()
+         ~first_step_queued_at ~total_run_time ~build_run_time ~flash_messages
+         ~build_status ()
 
   let list_history ~org ~repo ~gref ci =
     Backend.ci ci >>= fun ci ->

--- a/web-ui/representation/build.ml
+++ b/web-ui/representation/build.ml
@@ -9,6 +9,7 @@ type t = {
   status : string;
   first_created_at : string;
   ran_for : string;
+  total_ran_for : string;
   can_cancel : bool;
   can_rebuild : bool;
   steps : Step.t list;
@@ -27,6 +28,7 @@ let from_jobs_status ~jobs ~build_status ~build_created_at ~step_route_prefix =
     | Ok v -> Some v
   in
   let total_run_time = Run_time.total_of_run_times jobs in
+  let build_run_time = Run_time.build_run_time jobs in
   let can_cancel =
     let check job_info =
       match job_info.Client.outcome with
@@ -54,7 +56,8 @@ let from_jobs_status ~jobs ~build_status ~build_created_at ~step_route_prefix =
     version;
     status = Fmt.str "%a" Client.State.pp build_status;
     first_created_at = Timestamps_durations.pp_timestamp first_step_queued_at;
-    ran_for = Timestamps_durations.pp_duration @@ Some total_run_time;
+    total_ran_for = Timestamps_durations.pp_duration @@ Some total_run_time;
+    ran_for = Timestamps_durations.pp_duration @@ Some build_run_time;
     can_cancel;
     can_rebuild;
     steps;

--- a/web-ui/static/js/build-page-poll.js
+++ b/web-ui/static/js/build-page-poll.js
@@ -49,6 +49,8 @@ function poll(api_path, timeout, interval) {
         build_created_at.textContent = data["first_created_at"];
         const build_ran_for = document.getElementById("build-ran-for");
         build_ran_for.textContent = data["ran_for"];
+        const build_total_run_time = document.getElementById("build-total-run-time")
+        build_total_run_time.textContent = "Total build run time " + data["total_ran_for"]
         const build_status = document.getElementById("build-status");
         build_status.innerHTML = icon_from(data["status"]);
 

--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -1,5 +1,5 @@
 let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
-    ~ran_for ~buttons =
+    ~ran_for ~total_run_time ~buttons =
   let ref_links =
     let initial =
       Tyxml.Html.
@@ -7,6 +7,10 @@ let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
           div [ hash_link ];
           div [ txt "-" ];
           div ~a:[ a_id "build-created-at" ] [ txt first_created_at ];
+          div [ txt "-" ];
+          div
+            ~a:[ a_id "build-total-run-time" ]
+            [ txt @@ Fmt.str "Total build run time %s" total_run_time ];
         ]
     in
     List.fold_left

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -52,6 +52,7 @@ module type View = sig
     jobs:Client.job_info list ->
     first_step_queued_at:float option ->
     total_run_time:float ->
+    build_run_time:float ->
     ?flash_messages:(string * string) list ->
     ?build_status:Client.State.t ->
     csrf_token:string ->

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -207,7 +207,7 @@ let rebuild_fail_message_v1 = function
       ]
 
 let list_steps ~org ~repo ~message ~refs ~hash ~jobs ~first_step_queued_at
-    ~total_run_time ?(flash_messages = [])
+    ~total_run_time ~build_run_time ?(flash_messages = [])
     ?(build_status : Client.State.t = Passed) ~csrf_token () =
   let can_cancel =
     let check job_info =
@@ -235,7 +235,8 @@ let list_steps ~org ~repo ~message ~refs ~hash ~jobs ~first_step_queued_at
       ~hash_link:(link_github_commit ~org ~repo ~hash)
       ~ref_links:(link_github_refs' ~org ~repo refs)
       ~first_created_at:(Timestamps_durations.pp_timestamp first_step_queued_at)
-      ~ran_for:(Timestamps_durations.pp_duration (Some total_run_time))
+      ~ran_for:(Timestamps_durations.pp_duration (Some build_run_time))
+      ~total_run_time:(Timestamps_durations.pp_duration (Some total_run_time))
       ~buttons
   in
   let steps_table_div =

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -252,7 +252,7 @@ let rebuild_fail_message_v1 : int -> ([> `Fail ] * uri) list_wrap = function
 (* TODO: Same as GitHub. Clean up so that success and fail messages appear
    in flash messages and we do a redirect instead of providing a return link. *)
 let list_steps ~org ~repo ~message ~refs ~hash ~jobs ~first_step_queued_at
-    ~total_run_time ?(flash_messages = [])
+    ~total_run_time ~build_run_time ?(flash_messages = [])
     ?(build_status : Client.State.t = Passed) ~csrf_token () =
   let can_cancel =
     let check job_info =
@@ -280,7 +280,8 @@ let list_steps ~org ~repo ~message ~refs ~hash ~jobs ~first_step_queued_at
       ~hash_link:(link_gitlab_commit ~org ~repo ~hash:(short_hash hash))
       ~ref_links:(link_gitlab_refs' ~org ~repo refs)
       ~first_created_at:(Timestamps_durations.pp_timestamp first_step_queued_at)
-      ~ran_for:(Timestamps_durations.pp_duration (Some total_run_time))
+      ~ran_for:(Timestamps_durations.pp_duration (Some build_run_time))
+      ~total_run_time:(Timestamps_durations.pp_duration (Some total_run_time))
       ~buttons
   in
   let steps_table_div =


### PR DESCRIPTION
The run-time for a build is described as the total of the run-times of all the steps of the build. While this is useful, it does not tell a very good story of how long a build takes to run and this is mainly because after the analysis step, the rest of the steps run in parallel.

This PR introduces a `build-run-time` which is:

```
(run-time of the analysis step) + max ((run-time of step) | step in build)
``` 

This `build_run_time` is displayed prominently (in the same spot that the run-time for the build has been displayed). The total-run-time continues to be displayed, but now less prominently.

![Screen Shot 2022-11-17 at 9 40 39 pm](https://user-images.githubusercontent.com/181086/202425319-2e3ef226-1e61-4c80-ac51-93648f17d152.png)
