### PR TITLE
Default-ref bugfix

### DIFF
--- a/api/client.ml
+++ b/api/client.ml
@@ -84,16 +84,15 @@ module Org = struct
     |> Lwt_result.map (fun result ->
            Results.repos_get_list result
            |> List.map @@ fun repo ->
-              let name = Raw.Reader.RepoInfo.name_get repo in
-              let main_status = Raw.Reader.RepoInfo.main_state_get repo in
-              let main_hash = Raw.Reader.RepoInfo.main_hash_get repo in
+              let open Raw.Reader.RepoInfo in
+              let name = name_get repo in
+              let main_status = main_state_get repo in
+              let main_hash = main_hash_get repo in
               let main_last_updated =
-                let time = Raw.Reader.RepoInfo.main_last_updated_get repo in
-                match Raw.Reader.RepoInfo.MainLastUpdated.get time with
-                | Raw.Reader.RepoInfo.MainLastUpdated.None
-                | Raw.Reader.RepoInfo.MainLastUpdated.Undefined _ ->
-                    None
-                | Raw.Reader.RepoInfo.MainLastUpdated.Ts v -> Some v
+                let time = main_last_updated_get repo in
+                match MainLastUpdated.get time with
+                | MainLastUpdated.None | MainLastUpdated.Undefined _ -> None
+                | MainLastUpdated.Ts v -> Some v
               in
               { name; main_status; main_hash; main_last_updated })
 end
@@ -119,26 +118,23 @@ module Repo = struct
        Results.refs_get_list jobs
        |> List.fold_left
             (fun acc slot ->
-              let gref = Raw.Reader.RefInfo.ref_get slot in
-              let hash = Raw.Reader.RefInfo.hash_get slot in
-              let status = Raw.Reader.RefInfo.status_get slot in
+              let open Raw.Reader.RefInfo in
+              let gref = ref_get slot in
+              let hash = hash_get slot in
+              let status = status_get slot in
               let started_at =
-                let time = Raw.Reader.RefInfo.started_at_get slot in
-                match Raw.Reader.RefInfo.StartedAt.get time with
-                | Raw.Reader.RefInfo.StartedAt.None
-                | Raw.Reader.RefInfo.StartedAt.Undefined _ ->
-                    None
-                | Raw.Reader.RefInfo.StartedAt.Ts v -> Some v
+                let time = started_at_get slot in
+                match StartedAt.get time with
+                | StartedAt.None | StartedAt.Undefined _ -> None
+                | StartedAt.Ts v -> Some v
               in
-              let message = Raw.Reader.RefInfo.message_get slot in
-              let name = Raw.Reader.RefInfo.name_get slot in
+              let message = message_get slot in
+              let name = name_get slot in
               let ran_for =
-                let time = Raw.Reader.RefInfo.ran_for_get slot in
-                match Raw.Reader.RefInfo.RanFor.get time with
-                | Raw.Reader.RefInfo.RanFor.None
-                | Raw.Reader.RefInfo.RanFor.Undefined _ ->
-                    None
-                | Raw.Reader.RefInfo.RanFor.Ts v -> Some v
+                let time = ran_for_get slot in
+                match RanFor.get time with
+                | RanFor.None | RanFor.Undefined _ -> None
+                | RanFor.Ts v -> Some v
               in
               let r =
                 { gref; hash; status; started_at; message; name; ran_for }
@@ -151,27 +147,24 @@ module Repo = struct
     let request = Capability.Request.create_no_args () in
     Capability.call_for_value t method_id request
     |> Lwt_result.map @@ fun jobs ->
+       let open Raw.Reader.RefInfo in
        let res = Results.default_get jobs in
-       let gref = Raw.Reader.RefInfo.ref_get res in
-       let hash = Raw.Reader.RefInfo.hash_get res in
-       let status = Raw.Reader.RefInfo.status_get res in
+       let gref = ref_get res in
+       let hash = hash_get res in
+       let status = status_get res in
        let started_at =
-         let time = Raw.Reader.RefInfo.started_at_get res in
-         match Raw.Reader.RefInfo.StartedAt.get time with
-         | Raw.Reader.RefInfo.StartedAt.None
-         | Raw.Reader.RefInfo.StartedAt.Undefined _ ->
-             None
-         | Raw.Reader.RefInfo.StartedAt.Ts v -> Some v
+         let time = started_at_get res in
+         match StartedAt.get time with
+         | StartedAt.None | StartedAt.Undefined _ -> None
+         | StartedAt.Ts v -> Some v
        in
-       let message = Raw.Reader.RefInfo.message_get res in
-       let name = Raw.Reader.RefInfo.name_get res in
+       let message = message_get res in
+       let name = name_get res in
        let ran_for =
-         let time = Raw.Reader.RefInfo.ran_for_get res in
-         match Raw.Reader.RefInfo.RanFor.get time with
-         | Raw.Reader.RefInfo.RanFor.None
-         | Raw.Reader.RefInfo.RanFor.Undefined _ ->
-             None
-         | Raw.Reader.RefInfo.RanFor.Ts v -> Some v
+         let time = ran_for_get res in
+         match RanFor.get time with
+         | RanFor.None | RanFor.Undefined _ -> None
+         | RanFor.Ts v -> Some v
        in
        { gref; hash; status; started_at; message; name; ran_for }
 
@@ -197,13 +190,14 @@ module Repo = struct
        |> List.fold_left
             (fun acc slot ->
               let open Build_status in
-              let hash = Raw.Reader.RefInfo.hash_get slot in
-              let state = Raw.Reader.RefInfo.status_get slot in
-              let started = Raw.Reader.RefInfo.started_at_get slot in
+              let open Raw.Reader.RefInfo in
+              let hash = hash_get slot in
+              let state = status_get slot in
+              let started = started_at_get slot in
               let time =
-                match Raw.Reader.RefInfo.StartedAt.get started with
-                | Raw.Reader.RefInfo.StartedAt.None | Undefined _ -> None
-                | Raw.Reader.RefInfo.StartedAt.Ts v -> Some v
+                match StartedAt.get started with
+                | StartedAt.None | Undefined _ -> None
+                | StartedAt.Ts v -> Some v
               in
               match (state, Ref_map.find_opt hash acc) with
               | state, None -> Ref_map.add hash (state, time) acc

--- a/api/client.mli
+++ b/api/client.mli
@@ -74,6 +74,11 @@ module Repo : sig
   (** [refs t] returns the known Git references (branches and pull requests)
       that ocaml-ci is monitoring, along with the current head of each one. *)
 
+  val default_ref :
+    t -> (ref_info, [> `Capnp of Capnp_rpc.Error.t ]) Lwt_result.t
+  (** [default_ref t] returns the default branch of the repo that ocaml-ci is
+      monitoring. *)
+
   val commit_of_hash : t -> git_hash -> Commit.t
   (** [commit_of_hash t hash] is the commit [hash] in this repository. *)
 

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -96,6 +96,8 @@ interface Repo {
 
   historyOfRef @6 (ref :Text) -> (refs :List(RefInfo));
   # ref should be of the form "refs/heads/..." or "refs/pull/4/head"
+
+  defaultRef @7 () -> (default :RefInfo);
 }
 
 struct RepoInfo {

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -161,8 +161,8 @@ let set_active_repos ~(installation : Installation.t Current.t)
 let set_active_refs ~(repo : Gitlab.Repo_id.t Current.t) xs =
   let+ repo = repo and+ xs = xs in
   let repo' = { Repo_id.owner = repo.owner; name = repo.name } in
-  Index.set_active_refs ~repo:repo'
-    (xs
+  let refs =
+    xs
     |> List.fold_left
          (fun acc x ->
            let commit = Gitlab.Api.Commit.id x in
@@ -170,7 +170,9 @@ let set_active_refs ~(repo : Gitlab.Repo_id.t Current.t) xs =
            let hash = Git.Commit_id.hash commit in
            (* FIXME [benmandrew]: Implement fields for Gitlab *)
            Index.Ref_map.add gref { Index.hash; message = ""; name = "" } acc)
-         Index.Ref_map.empty);
+         Index.Ref_map.empty
+  in
+  Index.set_active_refs ~repo:repo' refs "master";
   xs
 
 let get_job_id x =

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -158,8 +158,11 @@ let set_active_repos ~(installation : Installation.t Current.t)
     (float_of_int (List.length repos));
   repos
 
-let set_active_refs ~(repo : Gitlab.Repo_id.t Current.t) xs =
-  let+ repo = repo and+ xs = xs in
+let gref_from_commit (x : Gitlab.Api.Commit.t) : string =
+  Git.Commit_id.gref @@ Gitlab.Api.Commit.id x
+
+let set_active_refs ~(repo : Gitlab.Repo_id.t Current.t) ~default xs =
+  let+ repo = repo and+ xs = xs and+ default = default in
   let repo' = { Repo_id.owner = repo.owner; name = repo.name } in
   let refs =
     xs
@@ -172,7 +175,8 @@ let set_active_refs ~(repo : Gitlab.Repo_id.t Current.t) xs =
            Index.Ref_map.add gref { Index.hash; message = ""; name = "" } acc)
          Index.Ref_map.empty
   in
-  Index.set_active_refs ~repo:repo' refs "master";
+  let default_gref = gref_from_commit default in
+  Index.set_active_refs ~repo:repo' refs default_gref;
   xs
 
 let get_job_id x =
@@ -333,10 +337,11 @@ let v ?ocluster ~app ~solver ~migration () =
      |> Current.list_iter ~collapse_key:"repo" (module Gitlab.Repo_id)
         @@ fun repo ->
         let* repo_id = repo in
+        let default = Gitlab.Api.head_commit app repo_id in
         let refs =
           Gitlab.Api.ci_refs app ~staleness:Ocaml_ci_service.Conf.max_staleness
             repo_id
-          |> set_active_refs ~repo
+          |> set_active_refs ~repo ~default
         in
         refs
         |> Current.list_iter (module Gitlab.Api.Commit) @@ fun head ->

--- a/lib/index.ml
+++ b/lib/index.ml
@@ -337,10 +337,19 @@ module Ref_map = Map.Make (String)
 type ref_info = { hash : string; message : string; name : string }
 [@@deriving show]
 
-let active_refs : ref_info Ref_map.t Repo_map.t ref = ref Repo_map.empty
+type repo_info = { default_gref : string; refs : ref_info Ref_map.t }
 
-let set_active_refs ~repo refs =
-  active_refs := Repo_map.add repo refs !active_refs
+let active_refs : repo_info Repo_map.t ref = ref Repo_map.empty
+
+let set_active_refs ~repo refs default_gref =
+  active_refs := Repo_map.add repo { refs; default_gref } !active_refs
 
 let get_active_refs repo =
-  Repo_map.find_opt repo !active_refs |> Option.value ~default:Ref_map.empty
+  Repo_map.find_opt repo !active_refs |> function
+  | Some { refs; _ } -> refs
+  | None -> Ref_map.empty
+
+let get_default_gref repo =
+  Repo_map.find_opt repo !active_refs |> function
+  | Some { default_gref; _ } -> default_gref
+  | None -> raise Not_found

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -106,7 +106,7 @@ type ref_info = {
 }
 [@@deriving show]
 
-val set_active_refs : repo:Repo_id.t -> ref_info Ref_map.t -> unit
+val set_active_refs : repo:Repo_id.t -> ref_info Ref_map.t -> string -> unit
 (** [set_active_refs ~repo refs] records that [refs] is the current set of Git
     references that the CI is watching. There is one entry for each branch and
     PR. Each entry maps the Git reference name to the head commit's hash. *)
@@ -115,3 +115,7 @@ val get_active_refs : Repo_id.t -> ref_info Ref_map.t
 (** [get_active_refs repo] is the entries last set for [repo] with
     [set_active_refs], or [empty] if this repository isn't known. Elements in
     ref tuple are ([hash], [message], [title]) *)
+
+val get_default_gref : Repo_id.t -> string
+(** [get_default_gref repo] is the default gref of the repo last set with
+    [set_active_refs] *)

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -18,8 +18,9 @@ let make_commit ~engine ~owner ~name hash =
          let response, results = Service.Response.create Results.init_pointer in
          let arr = Results.jobs_init results (List.length jobs) in
          let f i (variant, outcome, ts) =
+           let open Raw.Builder.JobInfo in
            let slot = Capnp.Array.get arr i in
-           Raw.Builder.JobInfo.variant_set slot variant;
+           variant_set slot variant;
            let queued_at, started_at, finished_at =
              match ts with
              | None -> (None, None, None)
@@ -28,23 +29,23 @@ let make_commit ~engine ~owner ~name hash =
              | Some (Finished v) ->
                  (Some v.queued_at, v.started_at, Some v.finished_at)
            in
-           let queued_at_t = Raw.Builder.JobInfo.queued_at_init slot in
-           let module S = Raw.Builder.JobInfo.QueuedAt in
+           let queued_at_t = queued_at_init slot in
+           let module S = QueuedAt in
            (match queued_at with
            | None -> S.none_set queued_at_t
            | Some v -> S.ts_set queued_at_t v);
-           let started_at_t = Raw.Builder.JobInfo.started_at_init slot in
-           let module S = Raw.Builder.JobInfo.StartedAt in
+           let started_at_t = started_at_init slot in
+           let module S = StartedAt in
            (match started_at with
            | None -> S.none_set started_at_t
            | Some v -> S.ts_set started_at_t v);
-           let finished_at_t = Raw.Builder.JobInfo.finished_at_init slot in
-           let module S = Raw.Builder.JobInfo.FinishedAt in
+           let finished_at_t = finished_at_init slot in
+           let module S = FinishedAt in
            (match finished_at with
            | None -> S.none_set finished_at_t
            | Some v -> S.ts_set finished_at_t v);
-           let state = Raw.Builder.JobInfo.state_init slot in
-           let module S = Raw.Builder.JobInfo.State in
+           let state = state_init slot in
+           let module S = State in
            match outcome with
            | `Not_started -> S.not_started_set state
            | `Passed -> S.passed_set state
@@ -166,21 +167,22 @@ let make_repo ~engine ~owner ~name =
          refs
          |> List.iteri
               (fun i (gref, { Index.hash; message; name = ref_name }) ->
+                let open Raw.Builder.RefInfo in
                 let slot = Capnp.Array.get arr i in
-                Raw.Builder.RefInfo.ref_set slot gref;
-                Raw.Builder.RefInfo.hash_set slot hash;
+                ref_set slot gref;
+                hash_set slot hash;
                 let status =
                   to_build_status (Index.get_status ~owner ~name ~hash)
                 in
-                Raw.Builder.RefInfo.status_set slot status;
-                Raw.Builder.RefInfo.message_set slot message;
-                Raw.Builder.RefInfo.name_set slot ref_name;
+                status_set slot status;
+                message_set slot message;
+                name_set slot ref_name;
                 (* FIXME [benmandrew]: We need the actual timestamps;
                    this needs to be stored in the DB *)
-                let started_at_t = Raw.Builder.RefInfo.started_at_init slot in
-                Raw.Builder.RefInfo.StartedAt.none_set started_at_t;
-                let ran_for_t = Raw.Builder.RefInfo.ran_for_init slot in
-                Raw.Builder.RefInfo.RanFor.none_set ran_for_t);
+                let started_at_t = started_at_init slot in
+                StartedAt.none_set started_at_t;
+                let ran_for_t = ran_for_init slot in
+                RanFor.none_set ran_for_t);
          Service.return response
 
        method default_ref_impl _params release_param_caps =
@@ -195,20 +197,21 @@ let make_repo ~engine ~owner ~name =
          let slot = Results.default_init results in
          (match default_ref with
          | { Index.hash; message; name = ref_name } ->
-             Raw.Builder.RefInfo.ref_set slot default_gref;
-             Raw.Builder.RefInfo.hash_set slot hash;
+             let open Raw.Builder.RefInfo in
+             ref_set slot default_gref;
+             hash_set slot hash;
              let status =
                to_build_status (Index.get_status ~owner ~name ~hash)
              in
-             Raw.Builder.RefInfo.status_set slot status;
-             Raw.Builder.RefInfo.message_set slot message;
-             Raw.Builder.RefInfo.name_set slot ref_name;
+             status_set slot status;
+             message_set slot message;
+             name_set slot ref_name;
              (* FIXME [benmandrew]: We need the actual timestamps;
                  this needs to be stored in the DB *)
-             let started_at_t = Raw.Builder.RefInfo.started_at_init slot in
-             Raw.Builder.RefInfo.StartedAt.none_set started_at_t;
-             let ran_for_t = Raw.Builder.RefInfo.ran_for_init slot in
-             Raw.Builder.RefInfo.RanFor.none_set ran_for_t);
+             let started_at_t = started_at_init slot in
+             StartedAt.none_set started_at_t;
+             let ran_for_t = ran_for_init slot in
+             RanFor.none_set ran_for_t);
          Service.return response
 
        method obsolete_refs_of_commit_impl _ release_param_caps =
@@ -258,22 +261,22 @@ let make_repo ~engine ~owner ~name =
          let arr = Results.refs_init results (List.length history) in
          history
          |> List.iteri (fun i (_, hash, started) ->
+                let open Raw.Builder.RefInfo in
                 let slot = Capnp.Array.get arr i in
-                Raw.Builder.RefInfo.ref_set slot gref;
-                Raw.Builder.RefInfo.hash_set slot hash;
+                ref_set slot gref;
+                hash_set slot hash;
                 let status =
                   to_build_status (Index.get_status ~owner ~name ~hash)
                 in
-                Raw.Builder.RefInfo.status_set slot status;
-                let started_at_t = Raw.Builder.RefInfo.started_at_init slot in
+                status_set slot status;
+                let started_at_t = started_at_init slot in
                 (match started with
-                | None -> Raw.Builder.RefInfo.StartedAt.none_set started_at_t
-                | Some time ->
-                    Raw.Builder.RefInfo.StartedAt.ts_set started_at_t time);
-                let ran_for_t = Raw.Builder.RefInfo.ran_for_init slot in
+                | None -> StartedAt.none_set started_at_t
+                | Some time -> StartedAt.ts_set started_at_t time);
+                let ran_for_t = ran_for_init slot in
                 match started with
-                | None -> Raw.Builder.RefInfo.RanFor.none_set ran_for_t
-                | Some time -> Raw.Builder.RefInfo.RanFor.ts_set ran_for_t time);
+                | None -> RanFor.none_set ran_for_t
+                | Some time -> RanFor.ts_set ran_for_t time);
          Service.return response
 
        method obsolete_job_of_commit_impl _ release_param_caps =
@@ -325,8 +328,9 @@ let make_org ~engine owner =
          let arr = Results.repos_init results (List.length repos) in
          repos
          |> List.iteri (fun i name ->
+                let open Raw.Builder.RepoInfo in
                 let slot = Capnp.Array.get arr i in
-                Raw.Builder.RepoInfo.name_set slot name;
+                name_set slot name;
                 let refs =
                   Index.get_active_refs { Ocaml_ci.Repo_id.owner; name }
                 in
@@ -339,13 +343,11 @@ let make_org ~engine owner =
                       ( hash,
                         to_build_status (Index.get_status ~owner ~name ~hash) )
                 in
-                Raw.Builder.RepoInfo.main_hash_set slot hash;
-                Raw.Builder.RepoInfo.main_state_set slot status;
+                main_hash_set slot hash;
+                main_state_set slot status;
                 (* FIXME [benmandrew]: Always returning no time, change to actually get it from somewhere *)
-                let last_updated_t =
-                  Raw.Builder.RepoInfo.main_last_updated_init slot
-                in
-                Raw.Builder.RepoInfo.MainLastUpdated.none_set last_updated_t);
+                let last_updated_t = main_last_updated_init slot in
+                MainLastUpdated.none_set last_updated_t);
          Service.return response
      end
 

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -44,8 +44,7 @@ let test_active_refs () =
   let hash = "abc" in
   let message = "message" in
   let name = "name" in
-  let ref = { Index.hash; message; name } in
-  let refs = Ref_map.singleton "master" ref in
+  let refs = Ref_map.singleton "master" { Index.hash; message; name } in
   Index.set_active_refs ~repo refs "master";
 
   let expected = [ ("master", { Index.hash; message; name }) ] in

--- a/test/test_index.ml
+++ b/test/test_index.ml
@@ -44,8 +44,9 @@ let test_active_refs () =
   let hash = "abc" in
   let message = "message" in
   let name = "name" in
-  Index.set_active_refs ~repo
-  @@ Ref_map.singleton "master" { Index.hash; message; name };
+  let ref = { Index.hash; message; name } in
+  let refs = Ref_map.singleton "master" ref in
+  Index.set_active_refs ~repo refs "master";
 
   let expected = [ ("master", { Index.hash; message; name }) ] in
   let result = Index.get_active_refs repo |> Ref_map.bindings in

--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -98,7 +98,9 @@ module Make (View : View) = struct
     Capability.with_ref (Client.CI.org ci org) @@ fun org_cap ->
     Capability.with_ref (Client.Org.repo org_cap repo) @@ fun repo_cap ->
     Client.Repo.refs repo_cap >>!= fun refs ->
-    Dream.respond @@ View.list_refs ~org ~repo ~refs
+    Client.Repo.default_ref repo_cap >>!= function
+    | { Client.Repo.name = default_ref; _ } ->
+        Dream.respond @@ View.list_refs ~org ~repo ~default_ref ~refs
 
   let list_steps ~org ~repo ~hash request ci =
     Backend.ci ci >>= fun ci ->

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -32,6 +32,7 @@ module type View = sig
   val list_refs :
     org:string ->
     repo:string ->
+    default_ref:string ->
     refs:Client.Repo.ref_info Client.Ref_map.t ->
     string
 

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -122,7 +122,8 @@ let link_gitlab_refs' ~org ~repo refs =
 let list_orgs ~orgs = Template.instance @@ orgs_v ~orgs
 let list_repos ~org ~repos = Template.instance @@ repos_v ~org ~repos
 
-let list_refs ~org ~repo ~refs =
+let list_refs ~org ~repo ~default_ref ~refs =
+  ignore default_ref;
   Template.instance
     [
       breadcrumbs [ (prefix, prefix); (org, org) ] repo; refs_v ~org ~repo ~refs;

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -97,7 +97,7 @@ module Make (M : M_Git_forge) = struct
     | [ "refs"; "pull"; id; "head" ] -> PR { title; id }
     | _ -> Branch (Printf.sprintf "Bad ref format %S" gref)
 
-  let list ~org ~repo ~refs =
+  let list ~org ~repo ~default_ref ~refs =
     let f { Client.Repo.gref; hash; status; started_at; message; name; ran_for }
         =
       let short_hash = short_hash hash in
@@ -108,9 +108,8 @@ module Make (M : M_Git_forge) = struct
     let default_table, main_ref =
       let main_ref, main_ref_info =
         Client.Ref_map.bindings refs
-        |> List.find (fun (_, { Client.Repo.gref; _ }) ->
-               String.equal gref "refs/heads/main"
-               || String.equal gref "refs/heads/master")
+        |> List.find (fun (_, { Client.Repo.name; _ }) ->
+               String.equal name default_ref)
       in
       let table_head = Common.table_head_div "Default Branch" in
       let table = table_head :: [ f main_ref_info ] in

--- a/web-ui/view/ref.mli
+++ b/web-ui/view/ref.mli
@@ -4,6 +4,7 @@ module Make : functor (_ : M_Git_forge) -> sig
   val list :
     org:string ->
     repo:string ->
+    default_ref:string ->
     refs:Git_forge.Client.Repo.ref_info Git_forge.Client.Ref_map.t ->
     string
 end


### PR DESCRIPTION
Fixes the 500 error on the refs page when the repo's default branch is not called `main` or `master`.