### PR TITLE
Link to the git forge within Ref Branches list

### DIFF
--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -1,5 +1,6 @@
 module type M_Git_forge = sig
   val prefix : string
+  val request_url : org:string -> repo:string -> string -> string
 end
 
 module type View = sig

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -7,14 +7,6 @@ open Git_forge
 
 let prefix = "github"
 
-module Ref = Ref.Make (struct
-  let prefix = prefix
-end)
-
-module Repo = Repo.Make (struct
-  let prefix = prefix
-end)
-
 let github_branch_url ~org ~repo ref =
   Printf.sprintf "https://github.com/%s/%s/tree/%s" org repo ref
 
@@ -23,6 +15,16 @@ let github_commit_url ~org ~repo ~hash =
 
 let github_pr_url ~org ~repo id =
   Printf.sprintf "https://github.com/%s/%s/pull/%s" org repo id
+
+module Ref = Ref.Make (struct
+  let prefix = prefix
+  let request_url = github_pr_url
+end)
+
+module Repo = Repo.Make (struct
+  let prefix = prefix
+  let request_url = github_pr_url
+end)
 
 let format_org org =
   li [ a ~a:[ a_href (Url.org_url prefix ~org) ] [ txt org ] ]

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -8,10 +8,6 @@ open Git_forge
 
 let prefix = "gitlab"
 
-module Ref = Ref.Make (struct
-  let prefix = prefix
-end)
-
 let gitlab_branch_url ~org ~repo ref =
   Fmt.str "https://gitlab.com/%s/%s/-/tree/%s" org repo ref
 
@@ -20,6 +16,11 @@ let gitlab_mr_url ~org ~repo id =
 
 let gitlab_commit_url ~org ~repo ~hash =
   Printf.sprintf "https://gitlab.com/%s/%s/-/commit/%s" org repo hash
+
+module Ref = Ref.Make (struct
+  let prefix = prefix
+  let request_url = gitlab_mr_url
+end)
 
 let format_org org =
   li [ a ~a:[ a_href (Url.org_url prefix ~org) ] [ txt org ] ]

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -11,7 +11,8 @@ module Make (M : M_Git_forge) = struct
     | "gitlab" -> Common.gitlab_logo
     | _ -> raise Not_found
 
-  let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
+  let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~request_url
+      ~message =
     ignore started_at;
     (*See FIXME - revert this when started_at is implemented *)
     (* messages are of arbitrary length - let's truncate them *)
@@ -28,7 +29,11 @@ module Make (M : M_Git_forge) = struct
               div [ txt "-" ];
               div
                 ~a:[ a_class [ "flex space-x-1 items-center" ] ]
-                [ logo; div [ txt (Printf.sprintf "#%s" id) ] ];
+                [
+                  a
+                    ~a:[ a_href (request_url id) ]
+                    [ logo; txt (Printf.sprintf "#%s" id) ];
+                ];
             ])
       @
       match started_at with
@@ -103,7 +108,7 @@ module Make (M : M_Git_forge) = struct
       let short_hash = short_hash hash in
       row ~ref:(ref gref name) ~short_hash ~started_at ~ran_for ~status
         ~ref_uri:(Url.commit_url M.prefix ~org ~repo ~hash)
-        ~message
+        ~request_url:(M.request_url ~org ~repo) ~message
     in
     let default_table, main_ref =
       let main_ref, main_ref_info =


### PR DESCRIPTION
I think it's nice to have a link to the Git forge here considering we're showing the forge log and the PR/MR id as well.