### PR TITLE
Fix migrations system.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,3 +49,6 @@ ENV OCAMLRUNPARAM=a=2
 # Enable experimental for docker manifest support
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 COPY --from=build /src/_build/install/default/bin/ocaml-ci-service /src/_build/install/default/bin/ocaml-ci-solver /usr/local/bin/
+# Create migration directory
+RUN mkdir -p migrations
+COPY --from=build /src/migrations ./migrations

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -51,3 +51,6 @@ ENV OCAMLRUNPARAM=a=2
 # Enable experimental for docker manifest support
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 COPY --from=build /src/_build/install/default/bin/ocaml-ci-gitlab /src/_build/install/default/bin/ocaml-ci-solver /usr/local/bin/
+# Create migration directory
+RUN mkdir -p migrations
+COPY --from=build /src/migrations ./migrations

--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -133,7 +133,7 @@ let main () config mode app capnp_public_address capnp_listen_address
      let ocluster =
        Option.map (Capnp_rpc_unix.Vat.import_exn vat) submission_uri
      in
-     let migration = no_migration in
+     let migration = not no_migration in
      let engine =
        Current.Engine.create ~config
          (Ocaml_ci_gitlab.Pipeline.v ?ocluster ~app ~solver ~migration)


### PR DESCRIPTION
This PR intends to fix an issue in GitLab. The migrations for GitLab were never deployed, as the flag `no_migration` was not negated here. It didn't cause any issue and shouldn't when deployed, as the table in the migration directory already exists.

Also, it fixes the issue where the migrations couldn't find the `migrations` repository as it was not mounted in the docker file.