### PR TITLE
Grant admin privileges to some users

### DIFF
--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -110,7 +110,7 @@ module Gitlab = struct
     | `Viewer | `Monitor -> true
     | `Builder | `Admin -> (
         match Option.map Current_web.User.id user with
-        | Some "gitlab:tmcgilchrist" -> true
+        | Some ("gitlab:tmcgilchrist" | "gitlab:maiste") -> true
         | Some _ | None -> false)
 
   let webhook_route ~webhook_secret =

--- a/service/github.ml
+++ b/service/github.ml
@@ -5,7 +5,8 @@ let has_role user = function
       match Option.map Current_web.User.id user with
       | Some
           ( "github:talex5" | "github:avsm" | "github:kit-ty-kate"
-          | "github:samoht" | "github:tmcgilchrist" | "github:dra27" ) ->
+          | "github:samoht" | "github:tmcgilchrist" | "github:dra27"
+          | "github:maiste" ) ->
           true
       | Some _ | None -> false)
 


### PR DESCRIPTION
Privileges are required to handle some actions in `ocaml-ci`.