### PR TITLE
Normalise calculation of step run-times.

### DIFF
--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -246,10 +246,15 @@ let list_steps ~org ~repo ~message ~refs ~hash ~jobs ~first_step_queued_at
         (* TODO: We need to start with no stage separation - introduce Analysis/Checks and Build steps later *)
       [ txt "Build" ]
   in
+  let build_created_at =
+    Run_time.build_created_at ~build:jobs
+    |> Result.to_option
+    |> Option.join
+    |> Option.value ~default:0.
+  in
   let steps_table =
     List.fold_left
       (fun l j ->
-        let build_created_at = Option.value ~default:0. first_step_queued_at in
         let ts = Result.to_option @@ Run_time.timestamps_from_job_info j in
         let rt =
           Option.map (Run_time.run_times_from_timestamps ~build_created_at) ts


### PR DESCRIPTION
This corrects a difference in the way run-times are calculated for steps between the HTML controller (for the build page) and the API controller (for the build page) https://github.com/ocurrent/ocaml-ci/blob/d67d787df7060dae4ba29246af9e9c2699bbe554/web-ui/controller/api/git_forge.ml#L42-L46