### PR TITLE
Make migrations not shadowed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,5 +50,5 @@ ENV OCAMLRUNPARAM=a=2
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 COPY --from=build /src/_build/install/default/bin/ocaml-ci-service /src/_build/install/default/bin/ocaml-ci-solver /usr/local/bin/
 # Create migration directory
-RUN mkdir -p migrations
-COPY --from=build /src/migrations ./migrations
+RUN mkdir -p /migrations
+COPY --from=build /src/migrations /migrations

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -52,5 +52,5 @@ ENV OCAMLRUNPARAM=a=2
 ENV DOCKER_CLI_EXPERIMENTAL=enabled
 COPY --from=build /src/_build/install/default/bin/ocaml-ci-gitlab /src/_build/install/default/bin/ocaml-ci-solver /usr/local/bin/
 # Create migration directory
-RUN mkdir -p migrations
-COPY --from=build /src/migrations ./migrations
+RUN mkdir -p /migrations
+COPY --from=build /src/migrations /migrations

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -42,6 +42,7 @@ dune exec -- ocaml-ci-service \
   --submission-service <path-to-the-submission-capability-file> \
   --github-webhook-secret-file <path-to-the-app-secret> \
   --capnp-listen-address tcp:127.0.0.1:9001
+  --migration-path "$PWD/migrations"
 ```
 
 This will generate a capability file. See the logs for `Wrote capability reference to "./capnp-secrets/ocaml-ci-admin.cap"`
@@ -57,11 +58,12 @@ You will need the following:
 3. A capability file for submitting jobs to a cluster, in this case the main ocaml-ci cluster as documented in https://github.com/ocurrent/ocluster#admin
 
 ``` shell
-dune exec -- ocaml-ci-gitlab \                             
+dune exec -- ocaml-ci-gitlab \
   --gitlab-token-file <your-gitlab-token> \
   --gitlab-webhook-secret-file <your-gitlab-secret> \
   --submission-service <path-to-the-submission-capability-file> \
   --capnp-listen-address tcp:127.0.0.1:9800
+  --migration-path "$PWD/migrations"
 ```
 
 This will generate a capability file. See the logs for `Wrote capability reference to "./capnp-secrets/ocaml-ci-gitlab-admin.cap"`

--- a/doc/example-stack.yml
+++ b/doc/example-stack.yml
@@ -29,7 +29,7 @@ services:
       - caddy_config:/config
   ci:
     image: ocaml-ci-service
-    command: --github-app-id 215418 --github-private-key-file /run/secrets/example-ci-github-key --github-account-allowlist "github-username" --confirm above-average --confirm-auto-release 120 --capnp-public-address=tcp:ci.example.org:8102 --capnp-listen-address=tcp:0.0.0.0:9000 --submission-service /run/secrets/ocaml-ci-submission.cap --github-webhook-secret-file /run/secrets/example-ci-webhook-secret
+    command: --github-app-id 215418 --github-private-key-file /run/secrets/example-ci-github-key --github-account-allowlist "github-username" --confirm above-average --confirm-auto-release 120 --capnp-public-address=tcp:ci.example.org:8102 --capnp-listen-address=tcp:0.0.0.0:9000 --submission-service /run/secrets/ocaml-ci-submission.cap --github-webhook-secret-file /run/secrets/example-ci-webhook-secret --migration-path "/migrations"
     environment:
       - "CI_PROFILE=production"
       - "DOCKER_BUILDKIT=1"

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -320,11 +320,15 @@ let gitlab_status_of_state head result =
   | Error (`Msg m) ->
       Gitlab.Api.Status.v ~url `Failure ~description:m ~name:program_name
 
-let v ?ocluster ~app ~solver ~migration () =
+let v ?ocluster ~app ~solver ~migrations () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
-  let migrations = if migration then Index.migrate () else Current.return () in
+  let migrations =
+    match migrations with
+    | Some path -> Index.migrate path
+    | None -> Current.return ()
+  in
   Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -14,9 +14,10 @@ type build_status = [ `Not_started | `Pending | `Failed | `Passed ]
 val init : unit -> unit Lwt.t
 (** Ensure the database is initialised (for unit-tests). *)
 
-val migrate : unit -> unit Current.t
-(** [migrate ()] ensures the database is up-to-date when the project is run. If
-    the date changes, it will try to run the migration again. **)
+val migrate : string -> unit Current.t
+(** [migrate path] ensures the database is up-to-date when the project is run.
+    It will check for the migrations stored in [path]. If the date changes, it
+    will try to run the migration again. **)
 
 val record :
   repo:Repo_id.t ->

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -256,11 +256,15 @@ let local_test ~solver repo () =
      in
      Current_incr.const (result, None)
 
-let v ?ocluster ~app ~solver ~migration () =
+let v ?ocluster ~app ~solver ~migrations () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
-  let migrations = if migration then Index.migrate () else Current.return () in
+  let migrations =
+    match migrations with
+    | Some path -> Index.migrate path
+    | None -> Current.return ()
+  in
   Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -7,9 +7,9 @@ val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_github.App.t ->
   solver:Ocaml_ci_api.Solver.t ->
-  migration:bool ->
+  migrations:string option ->
   unit ->
   unit Current.t
 (** The main ocaml-ci pipeline. Tests everything configured for GitHub
-    application [app]. If [migration] is true, it will automatically executes
-    the migrations. *)
+    application [app]. If [migration] is [Some path], it will automatically
+    executes the migrations. *)

--- a/stack.yml
+++ b/stack.yml
@@ -24,7 +24,7 @@ secrets:
 services:
   ci:
     image: ocurrent/ocaml-ci-service:live
-    command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-allowlist "talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,roburio,misterda,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV,ocaml-community,verbosemode,tomjridge,thizanne,n-osborne,TheLortex,patricoferris,routineco,moby,djs55,hyunha,hyper-systems,coco33920,sanette,maiste,yomimono,c-cube,novemberkilo,joaosreis,mtelvers,ygrek,geocaml,panglesd,SimonJF,haesbaert,benmandrew,andrenth,backtracking,jmid,shindere,gildor478,mefyl" --confirm above-average --confirm-auto-release 120 --capnp-public-address=tcp:ci.ocamllabs.io:8102 --capnp-listen-address=tcp:0.0.0.0:9000 --github-oauth /run/secrets/ocaml-ci-oauth --submission-service /run/secrets/ocaml-ci-submission.cap --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret
+    command: --github-app-id 39151 --github-private-key-file /run/secrets/ocaml-ci-github-key --github-account-allowlist "talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,roburio,misterda,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV,ocaml-community,verbosemode,tomjridge,thizanne,n-osborne,TheLortex,patricoferris,routineco,moby,djs55,hyunha,hyper-systems,coco33920,sanette,maiste,yomimono,c-cube,novemberkilo,joaosreis,mtelvers,ygrek,geocaml,panglesd,SimonJF,haesbaert,benmandrew,andrenth,backtracking,jmid,shindere,gildor478,mefyl" --confirm above-average --confirm-auto-release 120 --capnp-public-address=tcp:ci.ocamllabs.io:8102 --capnp-listen-address=tcp:0.0.0.0:9000 --github-oauth /run/secrets/ocaml-ci-oauth --submission-service /run/secrets/ocaml-ci-submission.cap --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret --migration-path "/migrations"
     environment:
       - "CI_PROFILE=production"
       - "DOCKER_BUILDKIT=1"
@@ -47,7 +47,7 @@ services:
     image: ocurrent/ocaml-ci-gitlab-service:live
     # image: ocaml-ci-gitlab-service
     # For local deploys using docker -c ci.ocamllabs.io build -t ocaml-ci-gitlab-service -f Dockerfile.gitlab .
-    command: --gitlab-oauth /run/secrets/ocaml-ci-gitlab-oauth --gitlab-token-file /run/secrets/ocaml-ci-gitlab-token --gitlab-webhook-secret-file /run/secrets/ocaml-ci-gitlab-webhook-secret --submission-service /run/secrets/ocaml-ci-submission.cap --capnp-public-address=tcp:ci.ocamllabs.io:8202 --capnp-listen-address=tcp:0.0.0.0:9000 -v
+    command: --gitlab-oauth /run/secrets/ocaml-ci-gitlab-oauth --gitlab-token-file /run/secrets/ocaml-ci-gitlab-token --gitlab-webhook-secret-file /run/secrets/ocaml-ci-gitlab-webhook-secret --submission-service /run/secrets/ocaml-ci-submission.cap --capnp-public-address=tcp:ci.ocamllabs.io:8202 --capnp-listen-address=tcp:0.0.0.0:9000 --migration-path "/migrations" -v
     environment:
       - "CI_PROFILE=production"
       - "DOCKER_BUILDKIT=1"


### PR DESCRIPTION
After noticing the problem with the fact that the Dockerfiles were not updated with the `migrations` directory, there was another bug: the migrations weren't available in the Docker container.  

@tmcgilchrist elucidates the mystery by finding that the `/var/lib/ocurrent/` directory, where we copied the `migrations`, mounts an external volume that erases everything from the point of view of the system. 

This pr is a proposed correction to this problem, but it changes the behaviour of the command line to make it more transparent about what happens.

- This suppresses the `--disable-migrations` flag and replaces it with the `--migration-path [path]` flag instead. This new flag runs the migrations located at  _path_; if absent, it doesn't do anything with the database.
- Update the Dockefiles to copy the migrations in the `/migrations` directory instead of `/var/lib/ocurrent` for the `ocaml-ci-service-*` images.
- Update the `stack.yml` to use the flag and the new locations.
- Update the documentation to conform it with the new instructions.