### PR TITLE
Dockerfiles arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN opam-2.1 exec -- dune build ./_build/install/default/bin/ocaml-ci-service
 FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
+RUN echo 'deb https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-service"]

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -43,7 +43,7 @@ RUN opam-2.1 exec -- dune build ./_build/install/default/bin/ocaml-ci-gitlab
 FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-RUN echo 'deb [arch=amd64] https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
+RUN echo 'deb https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
 RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-gitlab"]


### PR DESCRIPTION
This PR allows `Dockerfile` and `Dockerfile.gitlab` to be built on arm64 machines (`Dockerfile.web` already works).

While `docker build` works on my machine I currently do not have a working local deployment process. I will leave as draft until I or someone else verifies deployment on arm64.

After a while trying to explicitly target the architecture with `uname -m` and variable expansion in the Dockerfile, I realised that by simply removing the `[arch=...]` requirement it targets arm64 on my machine automatically. Could people on other architectures (principally x86_64) please verify that both building and deployment still work on their machines?