### PR TITLE
History page to new design.

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -396,10 +396,7 @@ let _record_build_summary t ~owner ~name ~hash ~gref ~status
           FLOAT current_time;
         ]
   in
-  match status with
-  | `Not_started | `Pending -> ()
-  | `Failed -> v 0
-  | `Passed -> v 1
+  v (status_to_int status)
 
 let record ~repo ~hash ~status ~gref jobs =
   let { Repo_id.owner; name } = repo in

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -108,8 +108,8 @@ let make_commit ~engine ~owner ~name hash =
          in
          (match active with
          | [] ->
-             Logs.err (fun m -> m "Commit has no associated message: %s" hash);
-             raise Not_found
+             Logs.info (fun m -> m "Commit has no associated message: %s" hash);
+             Results.message_set results hash
          | message :: _ -> Results.message_set results message);
          Service.return response
 


### PR DESCRIPTION
Small changes:

- [x] Fix 500s that result from a missing commit message (I think these are only available for active refs and we have to persist them). We now fallback to the hash itself.
- [x] New designs for history page. 
- [x] Fix incorrectly persisted build status.

![Screenshot 2022-12-06 at 4 29 55 pm](https://user-images.githubusercontent.com/181086/205824729-04b0aae8-566c-45c5-aaad-5a3e5483f9a2.png)
