### PR TITLE
Responsive text truncation for commit messages

### DIFF
--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -20,21 +20,21 @@ let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
   in
   Tyxml.Html.(
     div
-      ~a:[ a_class [ "justify-between items-center flex" ] ]
+      ~a:[ a_class [ "justify-between items-center flex space-x-3 truncate" ] ]
       [
         div
-          ~a:[ a_class [ "flex items-center space-x-4" ] ]
+          ~a:[ a_class [ "flex items-center space-x-4 truncate" ] ]
           [
             div ~a:[ a_id "build-status" ] [ Common.status_icon status ];
             div
-              ~a:[ a_class [ "flex flex-col space-y-1" ] ]
+              ~a:[ a_class [ "flex flex-col space-y-1 truncate" ] ]
               [
                 div
-                  ~a:[ a_class [ "flex items-center" ] ]
+                  ~a:[ a_class [ "flex items-center truncate" ] ]
                   [
                     h1
-                      ~a:[ a_class [ "text-xl" ] ]
-                      [ txt (Common.truncate ~len:80 card_title) ];
+                      ~a:[ a_class [ "text-xl truncate" ] ]
+                      [ txt card_title ];
                     (* a
                        ~a:
                          [

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -17,8 +17,6 @@ module Make (M : Git_forge_intf.Forge) = struct
     | _ -> raise Not_found
 
   let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
-    (* messages are of arbitrary length - let's truncate them *)
-    let message = Common.truncate ~len:72 message in
     let ref_title =
       match ref with Branch title -> title | PR { title; _ } -> title
     in
@@ -53,14 +51,14 @@ module Make (M : Git_forge_intf.Forge) = struct
           ]
     in
     a
-      ~a:[ a_class [ "table-row" ]; a_href ref_uri ]
+      ~a:[ a_class [ "table-row space-x-3" ]; a_href ref_uri ]
       [
         div
-          ~a:[ a_class [ "flex items-center space-x-3" ] ]
+          ~a:[ a_class [ "flex items-center space-x-3 truncate" ] ]
           [
             Common.status_icon_build status;
             div
-              ~a:[ a_class [ "flex items-center space-x-3" ] ]
+              ~a:[ a_class [ "flex items-center space-x-3 truncate" ] ]
               [
                 div
                   ~a:
@@ -73,10 +71,10 @@ module Make (M : Git_forge_intf.Forge) = struct
                     ]
                   [ txt ref_title ];
                 div
-                  ~a:[ a_class [ "flex flex-col" ] ]
+                  ~a:[ a_class [ "flex flex-col truncate" ] ]
                   [
                     div
-                      ~a:[ a_class [ "text-gray-900 text-sm font-medium" ] ]
+                      ~a:[ a_class [ "text-gray-900 text-sm font-medium truncate" ] ]
                       [ txt message ];
                     div ~a:[ a_class [ "flex text-sm space-x-2" ] ] description;
                   ];


### PR DESCRIPTION
The existing truncation of commit messages is server-side and to a constant number of characters, which is both unresponsive and ignores differing character widths in the font. This change affects the refs page and the build page, moving the truncation to pure CSS.

Related to the mobile UI in #657.