### PR TITLE
Mobile version: repo page

### DIFF
--- a/web-ui/static/css/style_v1.css
+++ b/web-ui/static/css/style_v1.css
@@ -44,7 +44,7 @@ table {
 .custom-table tr th,
 .custom-table tr td {
   padding: 5px;
-  @apply px-6 py-4 border-b border-gray-200;
+  @apply md:px-6 md:py-4 border-b border-gray-200;
 }
 
 .custom-table tr th {

--- a/web-ui/view/git_forge_intf.ml
+++ b/web-ui/view/git_forge_intf.ml
@@ -10,6 +10,8 @@ module type Forge = sig
   include Forge_prefix
 
   val request_abbrev : string
+  val org_url : org:string -> string
+  val repo_url : org:string -> repo:string -> string
   val commit_url : org:string -> repo:string -> hash:string -> string
   val branch_url : org:string -> repo:string -> string -> string
   val request_url : org:string -> repo:string -> string -> string

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -1,6 +1,8 @@
 include Git_forge.Make (struct
   let prefix = "github"
   let request_abbrev = "PR"
+  let org_url ~org = Printf.sprintf "https://github.com/%s" org
+  let repo_url ~org ~repo = Printf.sprintf "https://github.com/%s/%s" org repo
 
   let branch_url ~org ~repo ref =
     Printf.sprintf "https://github.com/%s/%s/tree/%s" org repo ref

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -1,18 +1,17 @@
-let gitlab_branch_url ~org ~repo ref =
-  Fmt.str "https://gitlab.com/%s/%s/-/tree/%s" org repo ref
-
-let gitlab_mr_url ~org ~repo id =
-  Fmt.str "https://gitlab.com/%s/%s/-/merge_requests/%s" org repo id
-
-let gitlab_commit_url ~org ~repo ~hash =
-  Printf.sprintf "https://gitlab.com/%s/%s/-/commit/%s" org repo hash
-
 include Git_forge.Make (struct
   let prefix = "gitlab"
   let request_abbrev = "MR"
-  let commit_url = gitlab_commit_url
-  let branch_url = gitlab_branch_url
-  let request_url = gitlab_mr_url
+  let org_url ~org = Printf.sprintf "https://gitlab.com/%s" org
+  let repo_url ~org ~repo = Printf.sprintf "https://gitlab.com/%s/%s" org repo
+
+  let commit_url ~org ~repo ~hash =
+    Printf.sprintf "https://gitlab.com/%s/%s/-/commit/%s" org repo hash
+
+  let branch_url ~org ~repo ref =
+    Fmt.str "https://gitlab.com/%s/%s/-/tree/%s" org repo ref
+
+  let request_url ~org ~repo id =
+    Fmt.str "https://gitlab.com/%s/%s/-/merge_requests/%s" org repo id
 
   let parse_ref r =
     match Astring.String.cuts ~sep:"/" r with

--- a/web-ui/view/organisation.ml
+++ b/web-ui/view/organisation.ml
@@ -12,7 +12,9 @@ module Make (M : Forge_prefix) = struct
       | Ok b -> b
       | Error _ -> false
     in
+    Logs.warn (fun l -> l "Looking for %s@." local_image);
     let url = if local_image_exists then local_image else fallback_image in
+    Logs.warn (fun l -> l "Image is %S" url);
     Tyxml.Html.(
       img
         ~a:[ a_class [ "w-20 h-20 rounded-full" ] ]

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -10,12 +10,6 @@ module Make (M : Git_forge_intf.Forge) = struct
     | "gitlab" -> Common.gitlab_logo
     | _ -> raise Not_found
 
-  let git_forge_url ~org ~repo =
-    match M.prefix with
-    | "github" -> Printf.sprintf "https://github.com/%s/%s" org repo
-    | "gitlab" -> Printf.sprintf "https://gitlab.com/%s/%s" org repo
-    | _ -> raise Not_found
-
   let row ~ref ~short_hash ~started_at ~ran_for ~status ~ref_uri ~message =
     (* messages are of arbitrary length - let's truncate them *)
     let message = Common.truncate ~len:72 message in
@@ -158,7 +152,7 @@ module Make (M : Git_forge_intf.Forge) = struct
       (table, n_prs)
     in
     let top_matter =
-      let external_url = git_forge_url ~org ~repo in
+      let external_url = M.repo_url ~org ~repo in
       div
         ~a:[ a_class [ "justify-between items-center flex" ] ]
         [

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -9,7 +9,9 @@ module Make (M : Git_forge_intf.Forge) = struct
     in
     let fallback_image = Printf.sprintf "/images/%s-logo-500.png" M.prefix in
     let local_image_exists =
-      Result.is_ok @@ Bos.OS.File.exists (Fpath.v local_image)
+      match Bos.OS.File.exists (Fpath.v local_image) with
+      | Ok b -> b
+      | Error _ -> false
     in
     let url = if local_image_exists then local_image else fallback_image in
     Tyxml.Html.(
@@ -52,7 +54,7 @@ module Make (M : Git_forge_intf.Forge) = struct
           ~a:[ a_class [ "flex items-center justify-between space-x-3" ] ]
           [
             div
-              ~a:[ a_class [ "form-control relative w-80 py-6 md:py-0" ] ]
+              ~a:[ a_class [ "form-control relative max-w-80 py-6 md:py-0" ] ]
               [
                 Common.search;
                 input
@@ -173,7 +175,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                 a_class
                   [
                     "custom-table table-auto border border-gray-200 border-t-0 \
-                     rounded-lg w-full";
+                     rounded-lg w-full min-w-0";
                   ];
                 a_id "table";
               ]

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -26,7 +26,10 @@ module Make (M : Git_forge_intf.Forge) = struct
   let title ~org =
     let org_url = M.org_url ~org in
     div
-      ~a:[ a_class [ "justify-between items-center flex" ] ]
+      ~a:
+        [
+          a_class [ "flex flex-col md:flex-row justify-between items-center " ];
+        ]
       [
         div
           ~a:[ a_class [ "flex space-x-4" ] ]
@@ -49,7 +52,7 @@ module Make (M : Git_forge_intf.Forge) = struct
           ~a:[ a_class [ "flex items-center justify-between space-x-3" ] ]
           [
             div
-              ~a:[ a_class [ "form-control relative w-80" ] ]
+              ~a:[ a_class [ "form-control relative w-80 py-6 md:py-0" ] ]
               [
                 Common.search;
                 input

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -23,10 +23,8 @@ module Make (M : Git_forge_intf.Forge) = struct
         ~alt:(Printf.sprintf "%s profile picture" org)
         ())
 
-  let org_url org = Printf.sprintf "https://%s.com/%s" M.prefix org
-
   let title ~org =
-    let org_url = org_url org in
+    let org_url = M.org_url ~org in
     div
       ~a:[ a_class [ "justify-between items-center flex" ] ]
       [


### PR DESCRIPTION
This is part of #656. It supersedes a part of #657.

It factorizes some parts of the code and adds support for the repo page in the mobile version.

It requires #662 to be merged first, as it uses some CSS changes made on the general value.