### PR TITLE
Mobile version: ref page

### DIFF
--- a/web-ui/static/css/style_v1.css
+++ b/web-ui/static/css/style_v1.css
@@ -44,6 +44,7 @@ table {
 .custom-table tr th,
 .custom-table tr td {
   padding: 5px;
+  min-height: 80px;
   @apply md:px-6 md:py-4 border-b border-gray-200;
 }
 
@@ -152,7 +153,7 @@ select {
 }
 
 .table-row {
-  @apply px-6 py-3 bg-white flex justify-between items-center;
+  @apply px-6 py-3 bg-white flex justify-between items-start md:items-center;
 }
 
 .table-container {

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -88,7 +88,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                     ]
                   [ txt ref_title ];
                 div
-                  ~a:[ a_class [ "flex flex-col" ] ]
+                  ~a:[ a_class [ "flex flex-col w-full" ] ]
                   [
                     div
                       ~a:

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -23,7 +23,7 @@ module Make (M : Git_forge_intf.Forge) = struct
         | Branch _ -> []
         | PR { id; _ } ->
             [
-              div [ txt "-" ];
+              div ~a:[ a_class [ "hidden md:inline" ] ] [ txt "-" ];
               div
                 ~a:[ a_class [ "flex space-x-1 items-center" ] ]
                 [ logo; div [ txt (Printf.sprintf "#%s" id) ] ];
@@ -33,8 +33,10 @@ module Make (M : Git_forge_intf.Forge) = struct
       | None -> []
       | Some _ ->
           [
-            div [ txt "-" ];
-            div [ txt (Timestamps_durations.pp_timestamp started_at) ];
+            div ~a:[ a_class [ "hidden md:inline" ] ] [ txt "-" ];
+            div
+              ~a:[ a_class [ "hidden md:inline" ] ]
+              [ txt (Timestamps_durations.pp_timestamp started_at) ];
           ]
     in
     let rhs =
@@ -47,14 +49,33 @@ module Make (M : Git_forge_intf.Forge) = struct
           ]
     in
     a
-      ~a:[ a_class [ "table-row" ]; a_href ref_uri ]
+      ~a:
+        [
+          a_class
+            [
+              "table-row flex flex-col md:flex-row space-x-0 md:space-x-3 \
+               space-y-6 md:space-y-0 truncate";
+            ];
+          a_href ref_uri;
+        ]
       [
         div
-          ~a:[ a_class [ "flex items-center space-x-3" ] ]
+          ~a:
+            [
+              a_class
+                [ "flex items-center space-x-4 md:space-x-3 truncate w-full" ];
+            ]
           [
             Common.status_icon_build status;
             div
-              ~a:[ a_class [ "flex items-center space-x-3" ] ]
+              ~a:
+                [
+                  a_class
+                    [
+                      "flex flex-col md:flex-row items-start md:items-center \
+                       space-x-0 md:space-x-3 space-y-2 md:space-y-0 truncate";
+                    ];
+                ]
               [
                 div
                   ~a:
@@ -62,7 +83,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                       a_class
                         [
                           "font-medium text-gray-700 text-sm px-2 py-1 border \
-                           border-gray-300 rounded-lg";
+                           border-gray-300 rounded-lg max-w-full truncate";
                         ];
                     ]
                   [ txt ref_title ];
@@ -70,9 +91,15 @@ module Make (M : Git_forge_intf.Forge) = struct
                   ~a:[ a_class [ "flex flex-col" ] ]
                   [
                     div
-                      ~a:[ a_class [ "text-gray-900 text-sm font-medium" ] ]
+                      ~a:
+                        [
+                          a_class
+                            [ "text-gray-900 text-sm font-medium truncate" ];
+                        ]
                       [ txt message ];
-                    div ~a:[ a_class [ "flex text-sm space-x-2" ] ] description;
+                    div
+                      ~a:[ a_class [ "flex flex-row text-sm space-x-2" ] ]
+                      description;
                   ];
               ];
           ];
@@ -81,8 +108,8 @@ module Make (M : Git_forge_intf.Forge) = struct
             [
               a_class
                 [
-                  "flex text-sm font-normal text-gray-500 space-x-8 \
-                   items-center";
+                  "hidden md:flex text-sm font-normal text-gray-500 space-x-8 \
+                   items-center self-center ";
                 ];
             ]
           rhs;
@@ -154,30 +181,30 @@ module Make (M : Git_forge_intf.Forge) = struct
     let top_matter =
       let external_url = M.repo_url ~org ~repo in
       div
-        ~a:[ a_class [ "justify-between items-center flex" ] ]
+        ~a:
+          [
+            a_class
+              [
+                "flex flex-col md:flex-row text-sm space-x-0 md:space-x-2 \
+                 items-center md:items-baseline";
+              ];
+          ]
         [
-          div
-            ~a:[ a_class [ "flex items-center space-x-2" ] ]
-            [
-              div
-                ~a:[ a_class [ "flex flex-col space-y-1" ] ]
-                [
-                  div
-                    ~a:[ a_class [ "flex text-sm space-x-2 items-baseline" ] ]
-                    [
-                      h1 ~a:[ a_class [ "text-xl" ] ] [ txt repo ];
-                      a
-                        ~a:
-                          [
-                            a_class [ "flex items-center space-x-2" ];
-                            a_href external_url;
-                          ]
-                        [ span [ txt external_url ]; Common.external_link ];
-                    ];
-                ];
-            ];
+          h1 ~a:[ a_class [ "text-xl" ] ] [ txt repo ];
+          a
+            ~a:
+              [
+                a_class
+                  [
+                    "flex flex-col md:flex-row items-center py-2 space-x-0 \
+                     md:space-x-2";
+                  ];
+                a_href external_url;
+              ]
+            [ span [ txt external_url ]; Common.external_link ];
         ]
     in
+
     [
       Common.breadcrumbs [ (M.prefix, M.prefix); (org, org) ] repo;
       top_matter;

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -54,13 +54,7 @@ module Make (M : Git_forge_intf.Forge) = struct
           ~a:[ a_class [ "flex items-center justify-between space-x-3" ] ]
           [
             div
-<<<<<<< HEAD
               ~a:[ a_class [ "form-control relative max-w-80 py-6 md:py-0" ] ]
-||||||| parent of 58dc913 (Support mobile for repo)
-              ~a:[ a_class [ "form-control relative w-80" ] ]
-=======
-              ~a:[ a_class [ "form-control relative w-80 py-6 md:py-0" ] ]
->>>>>>> 58dc913 (Support mobile for repo)
               [
                 Common.search;
                 input

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -54,7 +54,13 @@ module Make (M : Git_forge_intf.Forge) = struct
           ~a:[ a_class [ "flex items-center justify-between space-x-3" ] ]
           [
             div
+<<<<<<< HEAD
               ~a:[ a_class [ "form-control relative max-w-80 py-6 md:py-0" ] ]
+||||||| parent of 58dc913 (Support mobile for repo)
+              ~a:[ a_class [ "form-control relative w-80" ] ]
+=======
+              ~a:[ a_class [ "form-control relative w-80 py-6 md:py-0" ] ]
+>>>>>>> 58dc913 (Support mobile for repo)
               [
                 Common.search;
                 input


### PR DESCRIPTION
This is part of https://github.com/ocurrent/ocaml-ci/issues/656. It supersedes a part of https://github.com/ocurrent/ocaml-ci/pull/657.

It needs #663 to be merged first.

In the mobile version, I removed much information to make it more transparent for the users when reading on a small screen. The details information will be available on the build page. It uses parts of  Ben's CSS trick to truncate the code (#660).