### PR TITLE
Reinit opam (image default is 2.0, but we're using 2.1) follow-ups

### DIFF
--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -140,7 +140,7 @@ module Query = struct
   let run No_context job { Key.docker_context; variant }
       { Value.image; host_image } =
     Current.Job.start job ~level:Current.Level.Mostly_harmless >>= fun () ->
-    let prep_image = Fmt.str "ocaml-ci-%a" Variant.pp variant in
+    let prep_image = Fmt.str "ocurrent/ocaml-ci:%a" Variant.pp variant in
     prepare_image ~job ~docker_context ~tag:prep_image variant host_image
     >>!= fun host_image ->
     let cmd = get_ocaml_package ~docker_context host_image in


### PR DESCRIPTION
Follow-up PR to #661.
cc @kit-ty-kate

I may expose the default opam versions of the Docker images in ocaml-dockerfile to be able to skip this step if unnecessary.