### PR TITLE
Replace usage of `socketpair` for IPC

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -99,7 +99,7 @@
   (opam-0install (>= "0.4.3"))
   (git-unix (>= 3.9.0))
   (timedesc (>= 0.9.0))
-  (ocaml (>= 4.13))
+  (ocaml (>= 4.14.0))
   (capnp-rpc-unix (>= 1.2)))
  (conflicts
   (carton (< 0.4.2))) ; workaround for mirage/ocaml-git#514

--- a/ocaml-ci-solver.opam
+++ b/ocaml-ci-solver.opam
@@ -19,7 +19,7 @@ depends: [
   "opam-0install" {>= "0.4.3"}
   "git-unix" {>= "3.9.0"}
   "timedesc" {>= "0.9.0"}
-  "ocaml" {>= "4.13"}
+  "ocaml" {>= "4.14.0"}
   "capnp-rpc-unix" {>= "1.2"}
   "odoc" {with-doc}
 ]


### PR DESCRIPTION
On Windows, using a socket as standard input file descriptor is daring. Even if it may be possible, Lwt will currently outright reject it. We can, instead of passing a file descriptor to the spawned process, pass the address of the UNIX domain socket as an argument so that the sub process may open a socket itself and connect to that address.

UNIX domain sockets are supported on Windows 10 and OCaml 4.14.

This is a "backport" from code intended to go in solver-service, but I'm also trying it here in the meantime. I've just realized that there's still a minor problem on Windows.