### PR TITLE
Prerequisites for ocaml-ci-local on Windows

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -226,7 +226,8 @@ module Analysis = struct
   let of_dir ~solver ~job ~platforms ~opam_repository_commit dir =
     let solve = solve ~opam_repository_commit ~job ~solver in
     let ty = type_of_dir dir in
-    let cmd = ("", [| "find"; "."; "-maxdepth"; "3"; "-name"; "*.opam" |]) in
+    let find = if Sys.win32 then {|C:\cygwin64\bin\find.exe|} else "find" in
+    let cmd = ("", [| find; "."; "-maxdepth"; "3"; "-name"; "*.opam" |]) in
     Current.Process.check_output ~cwd:dir ~cancellable:true ~job cmd
     >>!= fun output ->
     let opam_files =

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -158,6 +158,13 @@ let platforms ~include_macos opam_version =
       (* The first one in this list is used for lint actions *)
       let ovs = List.rev OV.Releases.recent @ OV.Releases.unreleased_betas in
       List.map make_release ovs @ distros
+  | `Dev when Sys.win32 ->
+      (* Assume we're building using native Windows images. *)
+      let distro =
+        DD.tag_of_distro (`Windows (`Mingw, DD.win10_latest_image) :> DD.t)
+      in
+      let ov = OV.with_just_major_and_minor OV.Releases.latest in
+      [ v (OV.to_string ov) distro ov ]
   | `Dev ->
       let[@warning "-8"] (latest :: previous :: _) =
         List.rev OV.Releases.recent

--- a/service/local.ml
+++ b/service/local.ml
@@ -1,7 +1,7 @@
 (* Utility program for testing the CI pipeline on a local repository. *)
 
 let setup_log default_level =
-  Unix.putenv "DOCKER_BUILDKIT" "1";
+  if not Sys.win32 then Unix.putenv "DOCKER_BUILDKIT" "1";
   Unix.putenv "PROGRESS_NO_TRUNC" "1";
   Prometheus_unix.Logging.init ?default_level ()
 


### PR DESCRIPTION
Minor changes:
- use native Windows images;
- call Cygwin's `find` utility (located at `C:\cygwin64\bin\find.exe`);
- disable Docker BuildKit (unsupported on Windows native).

The `find` could eventually be replaced with #316, to be revisited.
The rest of the pipeline is blocked on the analyze step not understanding the compiler packages in opam-repository-mingw.