### PR TITLE
History buttons per ref.

### DIFF
--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -12,7 +12,7 @@ module type Controller = sig
   val list_history :
     org:string ->
     repo:string ->
-    gref:[ `Branch of string | `Pull of string ] ->
+    gref:[ `Branch of string | `Request of int ] ->
     Backend.t ->
     Dream.response Lwt.t
 
@@ -131,7 +131,7 @@ module Make (View : View) = struct
     let ref =
       match gref with
       | `Branch b -> Fmt.str "refs/heads/%s" b
-      | `Pull n -> Fmt.str "refs/pull/%s/head" n
+      | `Request n -> Fmt.str "refs/%s/%d/head" View.request_prefix n
     in
     Client.Repo.history_of_ref repo_cap ref >>!= fun history ->
     let head_commit =
@@ -139,7 +139,7 @@ module Make (View : View) = struct
       | [] -> None
       | head_ref_info :: _ -> Some head_ref_info.Client.Repo.hash
     in
-    Dream.respond @@ View.list_history ~org ~repo ~ref ~head_commit ~history
+    Dream.respond @@ View.list_history ~org ~repo ~gref ~head_commit ~history
 
   let show_step ~org ~repo ~hash ~variant request ci =
     Backend.ci ci >>= fun ci ->

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -43,20 +43,26 @@ let gitlab_routes gitlab =
         let rec f = function
           | [] -> Dream.empty `Not_Found
           | "branch" :: refs ->
-              let gref = String.concat Filename.dir_sep refs in
-              Controller.Github.list_history
+              let gref = 
+                  let branch = String.concat Filename.dir_sep refs in
+                  `Branch branch
+              in
+              Controller.Gitlab.list_history
                 ~org:(Dream.param request "org")
                 ~repo:(Dream.param request "repo")
-                ~gref:(`Branch gref) gitlab
+                ~gref gitlab
           | _ :: paths -> f paths
         in
         f fpath);
-    Dream.get "/github/:org/:repo/history/merge-request/:number" (fun request ->
-        let number = Dream.param request "number" in
-        Controller.Github.list_history
+    Dream.get "/gitlab/:org/:repo/history/merge-request/:number" (fun request ->
+        let gref =
+            let id  = Dream.param request "number" |> int_of_string in
+            `Request id
+        in
+        Controller.Gitlab.list_history
           ~org:(Dream.param request "org")
           ~repo:(Dream.param request "repo")
-          ~gref:(`Pull number) gitlab);
+          ~gref gitlab);
     Dream.post "/gitlab/:org/:repo/commit/:hash/variant/:variant/rebuild"
       (fun request ->
         Dream.form request >>= function
@@ -126,20 +132,26 @@ let github_routes github =
         let rec f = function
           | [] -> Dream.empty `Not_Found
           | "branch" :: refs ->
-              let gref = String.concat Filename.dir_sep refs in
+              let gref = 
+                  let branch = String.concat Filename.dir_sep refs in
+                  `Branch branch
+              in
               Controller.Github.list_history
                 ~org:(Dream.param request "org")
                 ~repo:(Dream.param request "repo")
-                ~gref:(`Branch gref) github
+                ~gref github
           | _ :: paths -> f paths
         in
         f fpath);
     Dream.get "/github/:org/:repo/history/pull/:number" (fun request ->
-        let number = Dream.param request "number" in
+        let gref =
+            let id = Dream.param request "number" |> int_of_string in
+            `Request id
+        in
         Controller.Github.list_history
           ~org:(Dream.param request "org")
           ~repo:(Dream.param request "repo")
-          ~gref:(`Pull number) github);
+          ~gref github);
     Dream.get "/github/:org/:repo/commit/:hash" (fun request ->
         Controller.Github.list_steps
           ~org:(Dream.param request "org")

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -38,6 +38,25 @@ let gitlab_routes gitlab =
           ~hash:(Dream.param request "hash")
           ~variant:(Dream.param request "variant")
           request gitlab);
+    Dream.get "/gitlab/:org/:repo/history/branch/**" (fun request ->
+        let fpath = Dream.target request |> Dream.from_path in
+        let rec f = function
+          | [] -> Dream.empty `Not_Found
+          | "branch" :: refs ->
+              let gref = String.concat Filename.dir_sep refs in
+              Controller.Github.list_history
+                ~org:(Dream.param request "org")
+                ~repo:(Dream.param request "repo")
+                ~gref:(`Branch gref) gitlab
+          | _ :: paths -> f paths
+        in
+        f fpath);
+    Dream.get "/github/:org/:repo/history/merge-request/:number" (fun request ->
+        let number = Dream.param request "number" in
+        Controller.Github.list_history
+          ~org:(Dream.param request "org")
+          ~repo:(Dream.param request "repo")
+          ~gref:(`Pull number) gitlab);
     Dream.post "/gitlab/:org/:repo/commit/:hash/variant/:variant/rebuild"
       (fun request ->
         Dream.form request >>= function

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -43,9 +43,9 @@ let gitlab_routes gitlab =
         let rec f = function
           | [] -> Dream.empty `Not_Found
           | "branch" :: refs ->
-              let gref = 
-                  let branch = String.concat Filename.dir_sep refs in
-                  `Branch branch
+              let gref =
+                let branch = String.concat Filename.dir_sep refs in
+                `Branch branch
               in
               Controller.Gitlab.list_history
                 ~org:(Dream.param request "org")
@@ -56,8 +56,8 @@ let gitlab_routes gitlab =
         f fpath);
     Dream.get "/gitlab/:org/:repo/history/merge-request/:number" (fun request ->
         let gref =
-            let id  = Dream.param request "number" |> int_of_string in
-            `Request id
+          let id = Dream.param request "number" |> int_of_string in
+          `Request id
         in
         Controller.Gitlab.list_history
           ~org:(Dream.param request "org")
@@ -132,9 +132,9 @@ let github_routes github =
         let rec f = function
           | [] -> Dream.empty `Not_Found
           | "branch" :: refs ->
-              let gref = 
-                  let branch = String.concat Filename.dir_sep refs in
-                  `Branch branch
+              let gref =
+                let branch = String.concat Filename.dir_sep refs in
+                `Branch branch
               in
               Controller.Github.list_history
                 ~org:(Dream.param request "org")
@@ -145,8 +145,8 @@ let github_routes github =
         f fpath);
     Dream.get "/github/:org/:repo/history/pull/:number" (fun request ->
         let gref =
-            let id = Dream.param request "number" |> int_of_string in
-            `Request id
+          let id = Dream.param request "number" |> int_of_string in
+          `Request id
         in
         Controller.Github.list_history
           ~org:(Dream.param request "org")

--- a/web-ui/static/css/style_v1.css
+++ b/web-ui/static/css/style_v1.css
@@ -132,6 +132,10 @@ select {
   @apply space-x-1 text-sm h-9 px-3;
 }
 
+.btn-xs {
+  @apply space-x-1 text-xs h-5 px-2;
+}
+
 .btn-default {
   @apply text-gray-500 hover:bg-gray-100;
 }

--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -1,27 +1,12 @@
 let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
     ~ran_for ~total_run_time ~buttons ~history_url ~show_history_button =
+  ignore history_url;
+  ignore show_history_button;
   let heading =
-    let without_history_button =
-      Tyxml.Html.(
-        div
-          ~a:[ a_class [ "flex items-center truncate" ] ]
-          [ h1 ~a:[ a_class [ "text-xl truncate" ] ] [ txt card_title ] ])
-    in
-    if show_history_button then
-      Tyxml.Html.(
-        div
-          ~a:[ a_class [ "flex items-center truncate" ] ]
-          [
-            h1 ~a:[ a_class [ "text-xl truncate" ] ] [ txt card_title ];
-            a
-              ~a:
-                [
-                  a_class [ "btn btn-secondary btn-sm ml-4" ];
-                  a_href history_url;
-                ]
-              [ txt "Build History" ];
-          ])
-    else without_history_button
+    Tyxml.Html.(
+      div
+        ~a:[ a_class [ "flex items-center truncate" ] ]
+        [ h1 ~a:[ a_class [ "text-xl truncate" ] ] [ txt card_title ] ])
   in
   let ref_links =
     let initial =

--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -1,7 +1,5 @@
 let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
-    ~ran_for ~total_run_time ~buttons ~history_url ~show_history_button =
-  ignore history_url;
-  ignore show_history_button;
+    ~ran_for ~total_run_time ~buttons =
   let heading =
     Tyxml.Html.(
       div

--- a/web-ui/view/common.ml
+++ b/web-ui/view/common.ml
@@ -497,3 +497,13 @@ let duration (status : Build_status.t) t =
     | Undefined _ -> "In queue for"
   in
   Printf.sprintf "%s %s" text (Timestamps_durations.pp_duration t)
+
+let build_history_button history_url =
+  Tyxml.Html.(
+    a
+      ~a:
+        [
+          a_class [ "btn btn-secondary btn-xs rounded-full" ];
+          a_href history_url;
+        ]
+      [ txt "Build History" ])

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -7,6 +7,7 @@ module Make (F : Forge) : View = struct
   module History = History.Make (F)
 
   let prefix = F.prefix
+  let request_prefix = F.request_prefix
   let list_history = History.list
   let list_repos = Repo.list
   let list_refs = Ref.list

--- a/web-ui/view/git_forge_intf.ml
+++ b/web-ui/view/git_forge_intf.ml
@@ -11,7 +11,6 @@ module type Forge = sig
 
   val request_abbrev : string
   val request_prefix : string
-  
   val org_url : org:string -> string
   val repo_url : org:string -> repo:string -> string
   val commit_url : org:string -> repo:string -> hash:string -> string
@@ -55,7 +54,7 @@ module type View = sig
   val list_history :
     org:string ->
     repo:string ->
-    gref:[`Branch of string | `Request of int ] ->
+    gref:[ `Branch of string | `Request of int ] ->
     head_commit:string option ->
     history:Client.Repo.ref_info list ->
     string

--- a/web-ui/view/git_forge_intf.ml
+++ b/web-ui/view/git_forge_intf.ml
@@ -10,6 +10,8 @@ module type Forge = sig
   include Forge_prefix
 
   val request_abbrev : string
+  val request_prefix : string
+  
   val org_url : org:string -> string
   val repo_url : org:string -> repo:string -> string
   val commit_url : org:string -> repo:string -> hash:string -> string

--- a/web-ui/view/git_forge_intf.ml
+++ b/web-ui/view/git_forge_intf.ml
@@ -20,12 +20,11 @@ module type Forge = sig
 
   val parse_ref :
     string -> [ `Branch of string | `Request of int | `Unknown of string ]
-
-  val ref_path : string -> (string, string) result
 end
 
 module type View = sig
   val prefix : string
+  val request_prefix : string
 
   val cancel_success_message :
     Client.job_info list -> [> `Div | `Ul ] Tyxml_html.elt
@@ -56,7 +55,7 @@ module type View = sig
   val list_history :
     org:string ->
     repo:string ->
-    ref:string ->
+    gref:[`Branch of string | `Request of int ] ->
     head_commit:string option ->
     history:Client.Repo.ref_info list ->
     string

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -23,4 +23,4 @@ include Git_forge.Make (struct
         let id = int_of_string id in
         `Request id
     | _ -> `Unknown r
-  end)
+end)

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -3,6 +3,7 @@ include Git_forge.Make (struct
   let request_abbrev = "PR"
   let org_url ~org = Printf.sprintf "https://github.com/%s" org
   let repo_url ~org ~repo = Printf.sprintf "https://github.com/%s/%s" org repo
+  let request_prefix = "pull"
 
   let branch_url ~org ~repo ref =
     Printf.sprintf "https://github.com/%s/%s/tree/%s" org repo ref

--- a/web-ui/view/github.ml
+++ b/web-ui/view/github.ml
@@ -23,14 +23,4 @@ include Git_forge.Make (struct
         let id = int_of_string id in
         `Request id
     | _ -> `Unknown r
-
-  let ref_path r =
-    match Astring.String.cuts ~sep:"/" r with
-    | "refs" :: "heads" :: branch ->
-        let branch = Astring.String.concat ~sep:"/" branch in
-        Ok (Printf.sprintf "branch/%s" branch)
-    | [ "refs"; "pull"; id; "head" ] ->
-        let id = int_of_string id in
-        Ok (Printf.sprintf "pull/%d" id)
-    | _ -> Error (Printf.sprintf "Could not parse ref %s" r)
-end)
+  end)

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -2,7 +2,6 @@ include Git_forge.Make (struct
   let prefix = "gitlab"
   let request_abbrev = "MR"
   let request_prefix = "merge-request"
-
   let org_url ~org = Printf.sprintf "https://gitlab.com/%s" org
   let repo_url ~org ~repo = Printf.sprintf "https://gitlab.com/%s/%s" org repo
 

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -24,14 +24,4 @@ include Git_forge.Make (struct
         let id = int_of_string id in
         `Request id
     | _ -> `Unknown r
-
-  let ref_path r =
-    match Astring.String.cuts ~sep:"/" r with
-    | "refs" :: "heads" :: branch ->
-        let branch = Astring.String.concat ~sep:"/" branch in
-        Ok (Printf.sprintf "branch/%s" branch)
-    | [ "refs"; "merge-requests"; id; "head" ] ->
-        let id = int_of_string id in
-        Ok (Printf.sprintf "merge-request/%d" id)
-    | _ -> Error (Printf.sprintf "Could not parse ref %s" r)
 end)

--- a/web-ui/view/gitlab.ml
+++ b/web-ui/view/gitlab.ml
@@ -1,6 +1,8 @@
 include Git_forge.Make (struct
   let prefix = "gitlab"
   let request_abbrev = "MR"
+  let request_prefix = "merge-request"
+
   let org_url ~org = Printf.sprintf "https://gitlab.com/%s" org
   let repo_url ~org ~repo = Printf.sprintf "https://gitlab.com/%s/%s" org repo
 

--- a/web-ui/view/history.ml
+++ b/web-ui/view/history.ml
@@ -84,11 +84,12 @@ module Make (M : Git_forge_intf.Forge) = struct
     table_head :: List.map f history
 
   let top_matter ~org ~repo ~gref ~tref =
-    let external_url = match gref with
-    | `Branch branch -> M.branch_url ~org ~repo branch
-    | `Request id ->
-            let id = string_of_int id in
-            M.request_url ~org ~repo id
+    let external_url =
+      match gref with
+      | `Branch branch -> M.branch_url ~org ~repo branch
+      | `Request id ->
+          let id = string_of_int id in
+          M.request_url ~org ~repo id
     in
     div
       ~a:[ a_class [ "justify-between items-center flex space-x-4" ] ]
@@ -133,9 +134,11 @@ module Make (M : Git_forge_intf.Forge) = struct
       ]
 
   let list ~org ~repo ~gref ~head_commit ~history =
-    let tref = match gref with
-    | `Branch branch -> Printf.sprintf "branch/%s" branch
-    | `Request id -> Printf.sprintf "%s/%d" M.request_prefix id in
+    let tref =
+      match gref with
+      | `Branch branch -> Printf.sprintf "branch/%s" branch
+      | `Request id -> Printf.sprintf "%s/%d" M.request_prefix id
+    in
     let breadcrumbs =
       match head_commit with
       | None -> [ (M.prefix, M.prefix); (org, org); (repo, repo) ]

--- a/web-ui/view/history.ml
+++ b/web-ui/view/history.ml
@@ -83,8 +83,13 @@ module Make (M : Git_forge_intf.Forge) = struct
     in
     table_head :: List.map f history
 
-  let top_matter ~org ~repo ~ref ~tref =
-    let external_url = M.branch_url ~org ~repo ref in
+  let top_matter ~org ~repo ~gref ~tref =
+    let external_url = match gref with
+    | `Branch branch -> M.branch_url ~org ~repo branch
+    | `Request id ->
+            let id = string_of_int id in
+            M.request_url ~org ~repo id
+    in
     div
       ~a:[ a_class [ "justify-between items-center flex space-x-4" ] ]
       [
@@ -127,8 +132,10 @@ module Make (M : Git_forge_intf.Forge) = struct
           ];
       ]
 
-  let list ~org ~repo ~ref ~head_commit ~history =
-    let pretty_ref = Result.value ~default:"branch" (M.ref_path ref) in
+  let list ~org ~repo ~gref ~head_commit ~history =
+    let tref = match gref with
+    | `Branch branch -> Printf.sprintf "branch/%s" branch
+    | `Request id -> Printf.sprintf "%s/%d" M.request_prefix id in
     let breadcrumbs =
       match head_commit with
       | None -> [ (M.prefix, M.prefix); (org, org); (repo, repo) ]
@@ -137,14 +144,13 @@ module Make (M : Git_forge_intf.Forge) = struct
             (M.prefix, M.prefix);
             (org, org);
             (repo, repo);
-            (pretty_ref, Printf.sprintf "commit/%s" commit);
+            (tref, Printf.sprintf "commit/%s" commit);
           ]
     in
-    let tref = Result.get_ok @@ M.ref_path ref in
     Template_v1.instance
       [
         Common.breadcrumbs breadcrumbs "Build History";
-        top_matter ~org ~repo ~ref ~tref;
+        top_matter ~org ~repo ~gref ~tref;
         Common.tabulate_div @@ history_v ~org ~repo ~history;
       ]
 end

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -84,14 +84,13 @@ module Make (M : Git_forge_intf.Forge) = struct
             ]
       | `Request id ->
           let id = string_of_int id in
-
           span
             ~a:[ a_class [ "flex flex-row items-center space-x-2" ] ]
             [
               span [ txt (M.request_abbrev ^ "#" ^ id) ];
               Common.build_history_button
                 (Url.history_url M.prefix ~org ~repo
-                   ~ref:(Printf.sprintf "pull/%s" id));
+                   ~ref:(Printf.sprintf "%s/%s" M.request_prefix id));
               a
                 ~a:
                   [


### PR DESCRIPTION
After deploying the history button to production, I've noticed that we've got a problem for commits that are associated to multiple refs.

![Screenshot 2022-12-08 at 3 16 08 pm](https://user-images.githubusercontent.com/181086/206369329-a9eee9aa-a0ab-4342-9703-452ee9f34265.png)

Here it is not clear what the single build history button should do. It goes to one of the two refs and if you want to see the history of the other ref, you can't.

When we originally designed this we talked about collecting information about which ref you've arrived from in the url of the build page. On reflection this is complicated and is error prone and is introducing state into an inherently stateless resource (the build page). 

So, I propose showing a smaller button next to the ref:

![Screenshot 2022-12-08 at 4 46 23 pm](https://user-images.githubusercontent.com/181086/206369852-547057df-4e1e-4daf-a498-bac7d04b0992.png)
![Screenshot 2022-12-08 at 4 47 31 pm](https://user-images.githubusercontent.com/181086/206369862-6e64573e-803b-481a-83aa-821e0aab5266.png)

This is simpler, and now removes the need to find ways of encoding state information into URLs, thus maintaining their RESTfulness. :) 