### PR TITLE
Pin version of git-unix.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -97,7 +97,7 @@
   ocaml-ci-api
   (conf-libev (<> :os "win32"))
   (opam-0install (>= "0.4.3"))
-  (git-unix (>= 3.9.0))
+  (git-unix (= 3.10.0))
   (timedesc (>= 0.9.0))
   (ocaml (>= 4.13))
   (capnp-rpc-unix (>= 1.2)))

--- a/ocaml-ci-solver.opam
+++ b/ocaml-ci-solver.opam
@@ -17,7 +17,7 @@ depends: [
   "ocaml-ci-api"
   "conf-libev" {os != "win32"}
   "opam-0install" {>= "0.4.3"}
-  "git-unix" {>= "3.9.0"}
+  "git-unix" {= "3.10.0"}
   "timedesc" {>= "0.9.0"}
   "ocaml" {>= "4.13"}
   "capnp-rpc-unix" {>= "1.2"}


### PR DESCRIPTION
Build [fails for 3.10.1](https://ci.ocamllabs.io/github/ocurrent/ocaml-ci/commit/b4dea9200ea9781ca495627167fb2946617ceccd/variant/alpine-3.16-4.14_opam-2.1#L1217-1217) 

So pinning the version until we know more.
