### PR TITLE
Mobile version for step page

### DIFF
--- a/web-ui/static/css/style_v1.css
+++ b/web-ui/static/css/style_v1.css
@@ -218,14 +218,13 @@ select {
 }
 
 .code-line__number {
-  @apply bg-gray-200 px-6 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
+  @apply bg-gray-200 px-1 md:px-6 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
 }
 
 .code-line__code {
-  @apply px-6 text-gray-800 whitespace-pre bg-transparent border-none text-sm;
+  @apply px-3 md:px-6 text-gray-800 whitespace-pre bg-transparent border-none text-sm;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   border-left: 1px solid transparent;
-
 }
 
 .code-line.highlight {
@@ -292,7 +291,7 @@ select {
 .notification {
   @apply bg-white fixed bottom-6 right-6 flex items-center text-sm font-medium rounded-lg shadow-lg p-4 justify-between;
   z-index: 9999;
-  min-width: 400px;
+  min-width: 300px;
 }
 
 .flash-message {

--- a/web-ui/view/common.ml
+++ b/web-ui/view/common.ml
@@ -450,7 +450,8 @@ let breadcrumbs steps page_title =
         [
           a_class
             [
-              "flex items-center mb-7 text-xs md:text-sm font-medium space-x-2";
+              "flex flex-wrap items-center mb-7 text-xs md:text-sm font-medium \
+               space-x-0 md:space-x-2";
             ];
         ]
       (List.rev steps))

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -31,10 +31,11 @@ module Make (M : Git_forge_intf.Forge) = struct
                           *)
                         ];
                       div
-                        ~a:[ a_class [ "text-gray-500" ] ]
+                        ~a:[ a_class [ "hidden md:block text-gray-500" ] ]
                         [
                           div
-                            ~a:[ a_class [ "flex text-sm space-x-2" ] ]
+                            ~a:
+                              [ a_class [ "hidden md:flex text-sm space-x-2" ] ]
                             [
                               div
                                 ~a:[ a_id "step-created-at" ]
@@ -61,14 +62,13 @@ module Make (M : Git_forge_intf.Forge) = struct
                 ];
             ];
           div
-            ~a:
-              [
-                a_class
-                  [ "hidden md:flex items-center justify-between space-x-4" ];
-              ]
+            ~a:[ a_class [ "flex items-center justify-between space-x-4" ] ]
             [
               div
-                ~a:[ a_id "step-ran-for"; a_class [ "text-sm" ] ]
+                ~a:
+                  [
+                    a_id "step-ran-for"; a_class [ "hidden md:inline text-sm" ];
+                  ]
                 [ txt @@ Fmt.str "Ran for %s" ran_for ];
               rebuild_button;
             ];

--- a/web-ui/view/template_v1.ml
+++ b/web-ui/view/template_v1.ml
@@ -73,7 +73,7 @@ let header ~full =
 
 let instance ?(full = false) contents =
   let constrained = "container-fluid py-8 md:py-12" in
-  let maximised = "flex-basis px-12 py-12" in
+  let maximised = "flex-basis px-3 md:px-12 py-12" in
   let klass = if full then maximised else constrained in
   html_to_string
     (html head


### PR DESCRIPTION
Fixes #656 as it is the last part for the mobile version. It removes many components from the user view, but the bet is that many users use the mobile version only for viewing and debugging purposes. WDYT?

![step](https://user-images.githubusercontent.com/22150236/206732571-7b83ab1e-1aee-42ae-b2e0-d63fdb316860.gif)
