### PR TITLE
Aggregation bugfix

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -19,4 +19,5 @@
   opam-0install
   current_ocluster
   ocluster-api
-  obuilder-spec))
+  obuilder-spec
+  dream))

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -88,7 +88,8 @@ module Aggregate : sig
 
   val get_ref_state : repo:Repo_id.t -> ref:string -> ref_state
   val get_repo_state : repo:Repo_id.t -> repo_state
-  val get_repo_default_ref : repo_state -> string
+  val get_repo_default_ref : repo_state -> string option
+  val set_repo_default_ref : repo:Repo_id.t -> string -> unit
 end
 
 module Commit_cache : sig

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -419,8 +419,11 @@ let make_org ~engine owner =
                     get_repo_default_ref @@ get_repo_state ~repo:{ owner; name })
                 in
                 let history =
-                  Index.get_build_history ~owner ~name ~gref:default_ref
-                  |> List.map (history_f default_ref)
+                  match default_ref with
+                  | None -> []
+                  | Some default_ref ->
+                      Index.get_build_history ~owner ~name ~gref:default_ref
+                      |> List.map (history_f default_ref)
                 in
                 ignore (history_set_list slot history));
          Service.return response


### PR DESCRIPTION
The correct default ref was not being stored for each repository, leading to the aggregated state being taken from a seemingly random ref.