### PR TITLE
Adding build-repro section to the step page.

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -109,7 +109,7 @@ module Op = struct
           (Fmt.str
              "@.To reproduce locally:@.@.cd $(mktemp -d)@.%a@.cat > Dockerfile \
               <<'END-OF-DOCKERFILE'@.\o033[34m%s\o033[0mEND-OF-DOCKERFILE@.docker \
-              build .@.@."
+              build .@.END-REPRO-BLOCK@.@."
              Current_git.Commit_id.pp_user_clone
              (Current_git.Commit.id commit)
              (make_dockerfile ~for_user:true));

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -85,7 +85,7 @@ module Op = struct
       (Fmt.str
          "@.To reproduce locally:@.@.%a@.cat > Dockerfile \
           <<'END-OF-DOCKERFILE'@.\o033[34m%s\o033[0m@.END-OF-DOCKERFILE@.docker \
-          build .@.@."
+          build .@.END-REPRO-BLOCK@.@."
          Current_git.Commit_id.pp_user_clone commit
          (Obuilder_spec.Docker.dockerfile_of_spec ~buildkit:false ~os:`Unix
             build_spec));

--- a/web-ui/static/js/add-repro-steps.js
+++ b/web-ui/static/js/add-repro-steps.js
@@ -1,22 +1,23 @@
-function extractStepsToReproduce () {
-    const tableRows = document.getElementById("steps-table");
-    const start = document.getElementsByClassName("repro-block-start");
-    const finish = document.getElementsByClassName("repro-block-end");
-    if ((start.length === 0) || (finish.length === 0)) {
-        return null
-    };
-    const startIndex = parseInt(start[0].parentElement.id.split('L')[1], 10);
-    const finishIndex = parseInt(finish[0].parentElement.id.split('L')[1], 10);
+function extractStepsToReproduce() {
+  const tableRows = document.getElementById("steps-table");
+  const start = document.getElementsByClassName("repro-block-start");
+  const finish = document.getElementsByClassName("repro-block-end");
+  if ((start.length === 0) || (finish.length === 0)) {
+    document.getElementById("build-repro-container").style.display = 'none';
+    return null
+  };
+  const startIndex = parseInt(start[0].parentElement.id.split('L')[1], 10);
+  const finishIndex = parseInt(finish[0].parentElement.id.split('L')[1], 10);
 
-    const br = document.createElement("br")
-    const reproDiv = document.getElementById("build-repro")
+  const br = document.createElement("br");
+  const reproDiv = document.getElementById("build-repro");
 
-    for (let i=(startIndex); i < (finishIndex - 1); i++) {
-        // Remove line-number, whitespace and possible newlines from the row
-        const newContent = document.createTextNode(tableRows.rows[i].innerText.replace(/\d+\s*\n?/,''))
-        reproDiv.appendChild(newContent)
-        reproDiv.appendChild(br.cloneNode())
-    }
+  for (let i = (startIndex); i < (finishIndex - 1); i++) {
+    // Remove line-number, whitespace and possible newlines from the row
+    const newContent = document.createTextNode(tableRows.rows[i].innerText.replace(/\d+\s*\n?/, ''));
+    reproDiv.appendChild(newContent);
+    reproDiv.appendChild(br.cloneNode());
+  }
 }
 
 extractStepsToReproduce();

--- a/web-ui/static/js/add-repro-steps.js
+++ b/web-ui/static/js/add-repro-steps.js
@@ -1,0 +1,22 @@
+function extractStepsToReproduce () {
+    const tableRows = document.getElementById("steps-table");
+    const start = document.getElementsByClassName("repro-block-start");
+    const finish = document.getElementsByClassName("repro-block-end");
+    if ((start.length === 0) || (finish.length === 0)) {
+        return null
+    };
+    const startIndex = parseInt(start[0].parentElement.id.split('L')[1], 10);
+    const finishIndex = parseInt(finish[0].parentElement.id.split('L')[1], 10);
+
+    const br = document.createElement("br")
+    const reproDiv = document.getElementById("build-repro")
+
+    for (let i=(startIndex); i < (finishIndex - 1); i++) {
+        // Remove line-number, whitespace and possible newlines from the row
+        const newContent = document.createTextNode(tableRows.rows[i].innerText.replace(/\d+\s*\n?/,''))
+        reproDiv.appendChild(newContent)
+        reproDiv.appendChild(br.cloneNode())
+    }
+}
+
+extractStepsToReproduce();

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -241,6 +241,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                     "shadow-sm rounded-lg overflow-hidden border \
                      border-gray-200 divide-x divide-gray-20";
                   ];
+                a_id "build-repro-container";
               ]
             [
               div

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -231,6 +231,260 @@ module Make (M : Git_forge_intf.Forge) = struct
                (Option.map Run_time.ran_for run_time))
           ~button
       in
+      let steps_to_reproduce_build =
+        Tyxml.Html.(
+          div
+            ~a:
+              [
+                a_class
+                  [
+                    "shadow-sm rounded-lg overflow-hidden border \
+                     border-gray-200 divide-x divide-gray-20";
+                  ];
+              ]
+            [
+              div
+                ~a:
+                  [
+                    a_class
+                      [ "flex items-center justify-between px-4 py-3 bg-white" ];
+                  ]
+                [
+                  div
+                    ~a:
+                      [
+                        Tyxml_helpers.at_click "stepsToRepro = !stepsToRepro";
+                        a_class
+                          [
+                            "text-gray-900 text-base font-medium border-b-none \
+                             border-gray-200 flex items-center space-x-3 \
+                             flex-1 cursor-pointer";
+                          ];
+                      ]
+                    [
+                      Tyxml.Svg.(
+                        Tyxml.Html.svg
+                          ~a:
+                            [
+                              a_class [ "h-5 w-5 rotate-180" ];
+                              Tyxml_helpers.a_svg_custom ":class"
+                                "{ 'rotate-180': stepsToRepro == 1 }";
+                              a_fill `None;
+                              a_viewBox (0., 0., 24., 24.);
+                              a_stroke `CurrentColor;
+                              a_stroke_width (2., Some `Px);
+                            ]
+                          [
+                            path
+                              ~a:
+                                [
+                                  a_stroke_linecap `Round;
+                                  a_stroke_linejoin `Round;
+                                  a_d "M19 9l-7 7-7-7";
+                                ]
+                              [];
+                          ]);
+                      div [ txt "Steps to Reproduce" ];
+                    ];
+                  div
+                    [
+                      Tyxml.Html.button
+                        ~a:
+                          [
+                            a_class [ "btn btn-sm btn-default" ];
+                            Tyxml_helpers.at_click
+                              "codeCopied = true, \
+                               $clipboard($refs.reproCode.innerText)";
+                          ]
+                        [
+                          Tyxml.Svg.(
+                            Tyxml.Html.svg
+                              ~a:
+                                [
+                                  a_class [ "h-5 w-5" ];
+                                  a_fill `None;
+                                  a_viewBox (0., 0., 24., 24.);
+                                  a_stroke `CurrentColor;
+                                  a_stroke_width (2., Some `Px);
+                                ]
+                              [
+                                path
+                                  ~a:
+                                    [
+                                      a_stroke_linecap `Round;
+                                      a_stroke_linejoin `Round;
+                                      a_d
+                                        "M8 16H6a2 2 0 01-2-2V6a2 2 0 \
+                                         012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 \
+                                         002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 \
+                                         2v8a2 2 0 002 2z";
+                                    ]
+                                  [];
+                              ]);
+                          txt "Copy code";
+                        ];
+                    ];
+                ];
+              div
+                ~a:
+                  [
+                    a_class
+                      [
+                        "flex relative overflow-hidden transition-all max-h-0 \
+                         duration-700";
+                      ];
+                    Tyxml_helpers.x_ref "container1";
+                    Tyxml_helpers.x_bind_style
+                      "stepsToRepro == 1 ? 'max-height: ' + \
+                       $refs.container1.scrollHeight + 'px' : ''";
+                  ]
+                [
+                  div
+                    ~a:
+                      [
+                        a_class
+                          [
+                            "bg-gray-900 px-6 py-3 rounded-lg rounded-l-none \
+                             text-gray-300 w-full rounded-t-none";
+                          ];
+                      ]
+                    [
+                      Tyxml.Html.code
+                        ~a:
+                          [
+                            a_id "build-repro";
+                            a_class [ "overflow-auto" ];
+                            Tyxml_helpers.x_ref "reproCode";
+                          ]
+                        [];
+                    ];
+                ];
+            ])
+      in
+      let logs_container =
+        Tyxml.Html.(
+          div
+            ~a:
+              [
+                a_class [ "mt-6 bg-gray-100 rounded-lg relative border" ];
+                Tyxml_helpers.x_data "codeLink";
+                Tyxml_helpers.x_init "highlightLine";
+              ]
+            [
+              Tyxml.Html.button
+                ~a:
+                  [
+                    a_class [ "copy-link-btn" ];
+                    Tyxml_helpers.at_click "copyCode";
+                    Tyxml_helpers.x_show "manualSelection";
+                    Tyxml_helpers.x_ref "copyLinkBtn";
+                    Tyxml_helpers.x_cloak;
+                  ]
+                [
+                  Tyxml.Svg.(
+                    Tyxml.Html.svg
+                      ~a:
+                        [
+                          a_class [ "w-4 h-4" ];
+                          a_fill `None;
+                          a_viewBox (0., 0., 24., 24.);
+                          a_stroke_width (2., Some `Px);
+                          a_stroke `CurrentColor;
+                        ]
+                      [
+                        path
+                          ~a:
+                            [
+                              a_stroke_linecap `Round;
+                              a_stroke_linejoin `Round;
+                              a_d
+                                "M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 \
+                                 4.5a4.5 4.5 0 \
+                                 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 \
+                                 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 \
+                                 001.242 7.244";
+                            ]
+                          [];
+                      ]);
+                ];
+              div
+                ~a:[ a_class [ "table-overflow overflow-auto rounded-lg" ] ]
+                [ txt "@@@" ];
+            ])
+      in
+      let link_copied_notification =
+        Tyxml.Html.(
+          div
+            ~a:
+              [
+                a_class [ "notification" ];
+                Tyxml_helpers.x_cloak;
+                Tyxml_helpers.x_show "linkCopied";
+                Tyxml_helpers.x_transition;
+              ]
+            [
+              div
+                ~a:[ a_class [ "flex items-center space-x-2" ] ]
+                [
+                  div
+                    ~a:[ a_class [ "icon-status icon-status--success" ] ]
+                    [
+                      Tyxml.Svg.(
+                        Tyxml.Html.svg
+                          ~a:
+                            [
+                              a_class [ "h-4 w-4" ];
+                              a_viewBox (0., 0., 20., 20.);
+                              a_fill (`Color ("#12B76A", None));
+                            ]
+                          [
+                            path
+                              ~a:
+                                [
+                                  Tyxml_helpers.a_svg_custom "fill-rule"
+                                    "evenodd";
+                                  Tyxml_helpers.a_svg_custom "clip-rule"
+                                    "evenodd";
+                                  a_d
+                                    "M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 \
+                                     01-1.414 0l-4-4a1 1 0 011.414-1.414L8 \
+                                     12.586l7.293-7.293a1 1 0 011.414 0z";
+                                ]
+                              [];
+                          ]);
+                    ];
+                  div [ txt "Link copied" ];
+                ];
+              Tyxml.Html.button
+                ~a:
+                  [
+                    a_class [ "icon-button" ];
+                    Tyxml_helpers.at_click "linkCopied=false";
+                  ]
+                [
+                  Tyxml.Svg.(
+                    Tyxml.Html.svg
+                      ~a:
+                        [
+                          a_fill `None;
+                          a_viewBox (0., 0., 24., 24.);
+                          a_stroke_width (2.5, Some `Px);
+                          a_stroke `CurrentColor;
+                          a_class [ "w-4 h-4" ];
+                        ]
+                      [
+                        path
+                          ~a:
+                            [
+                              a_stroke_linecap `Round;
+                              a_stroke_linejoin `Round;
+                              a_d "M4.5 19.5l15-15m-15 0l15 15";
+                            ]
+                          [];
+                      ]);
+                ];
+            ])
+      in
       let body =
         Template_v1.instance ~full:true
           [
@@ -258,77 +512,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                      manualSelection: false}";
                 ]
               [
-                div
-                  ~a:
-                    [
-                      a_class [ "notification" ];
-                      Tyxml_helpers.x_cloak;
-                      Tyxml_helpers.x_show "linkCopied";
-                      Tyxml_helpers.x_transition;
-                    ]
-                  [
-                    div
-                      ~a:[ a_class [ "flex items-center space-x-2" ] ]
-                      [
-                        div
-                          ~a:[ a_class [ "icon-status icon-status--success" ] ]
-                          [
-                            Tyxml.Svg.(
-                              Tyxml.Html.svg
-                                ~a:
-                                  [
-                                    a_class [ "h-4 w-4" ];
-                                    a_viewBox (0., 0., 20., 20.);
-                                    a_fill (`Color ("#12B76A", None));
-                                  ]
-                                [
-                                  path
-                                    ~a:
-                                      [
-                                        Tyxml_helpers.a_svg_custom "fill-rule"
-                                          "evenodd";
-                                        Tyxml_helpers.a_svg_custom "clip-rule"
-                                          "evenodd";
-                                        a_d
-                                          "M16.707 5.293a1 1 0 010 1.414l-8 \
-                                           8a1 1 0 01-1.414 0l-4-4a1 1 0 \
-                                           011.414-1.414L8 \
-                                           12.586l7.293-7.293a1 1 0 011.414 0z";
-                                      ]
-                                    [];
-                                ]);
-                          ];
-                        div [ txt "Link copied" ];
-                      ];
-                    Tyxml.Html.button
-                      ~a:
-                        [
-                          a_class [ "icon-button" ];
-                          Tyxml_helpers.at_click "linkCopied=false";
-                        ]
-                      [
-                        Tyxml.Svg.(
-                          Tyxml.Html.svg
-                            ~a:
-                              [
-                                a_fill `None;
-                                a_viewBox (0., 0., 24., 24.);
-                                a_stroke_width (2.5, Some `Px);
-                                a_stroke `CurrentColor;
-                                a_class [ "w-4 h-4" ];
-                              ]
-                            [
-                              path
-                                ~a:
-                                  [
-                                    a_stroke_linecap `Round;
-                                    a_stroke_linejoin `Round;
-                                    a_d "M4.5 19.5l15-15m-15 0l15 15";
-                                  ]
-                                [];
-                            ]);
-                      ];
-                  ];
+                link_copied_notification;
                 div
                   ~a:
                     [
@@ -339,62 +523,14 @@ module Make (M : Git_forge_intf.Forge) = struct
                     ]
                   [ h3 ~a:[ a_class [ "font-medium pb-2" ] ] [ txt "Logs" ] ];
                 div
-                  [
-                    div
-                      ~a:
-                        [
-                          a_class
-                            [ "mt-6 bg-gray-100 rounded-lg relative border" ];
-                          Tyxml_helpers.x_data "codeLink";
-                          Tyxml_helpers.x_init "highlightLine";
-                        ]
-                      [
-                        Tyxml.Html.button
-                          ~a:
-                            [
-                              a_class [ "copy-link-btn" ];
-                              Tyxml_helpers.at_click "copyCode";
-                              Tyxml_helpers.x_show "manualSelection";
-                              Tyxml_helpers.x_ref "copyLinkBtn";
-                              Tyxml_helpers.x_cloak;
-                            ]
-                          [
-                            Tyxml.Svg.(
-                              Tyxml.Html.svg
-                                ~a:
-                                  [
-                                    a_class [ "w-4 h-4" ];
-                                    a_fill `None;
-                                    a_viewBox (0., 0., 24., 24.);
-                                    a_stroke_width (2., Some `Px);
-                                    a_stroke `CurrentColor;
-                                  ]
-                                [
-                                  path
-                                    ~a:
-                                      [
-                                        a_stroke_linecap `Round;
-                                        a_stroke_linejoin `Round;
-                                        a_d
-                                          "M13.19 8.688a4.5 4.5 0 011.242 \
-                                           7.244l-4.5 4.5a4.5 4.5 0 \
-                                           01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 \
-                                           4.5 0 00-6.364-6.364l-4.5 4.5a4.5 \
-                                           4.5 0 001.242 7.244";
-                                      ]
-                                    [];
-                                ]);
-                          ];
-                        div
-                          ~a:
-                            [
-                              a_class
-                                [ "table-overflow overflow-auto rounded-lg" ];
-                            ]
-                          [ txt "@@@" ];
-                      ];
-                  ];
+                  ~a:
+                    [
+                      Tyxml_helpers.x_show "logs";
+                      Tyxml_helpers.x_data "{stepsToRepro: true}";
+                    ]
+                  [ steps_to_reproduce_build; logs_container ];
               ];
+            Tyxml.Html.script ~a:[ a_src "/js/add-repro-steps.js" ] (txt "");
           ]
       in
       Astring.String.cut ~sep:"@@@" body |> Option.get
@@ -407,7 +543,20 @@ module Make (M : Git_forge_intf.Forge) = struct
         if !last_line_blank && log_line = "" then
           (* Squash consecutive new lines *)
           l
-        else (
+        else
+          let is_start_of_steps_to_reproduce =
+            Astring.String.is_infix ~affix:"To reproduce locally:" log_line
+          in
+          let is_end_of_steps_to_reproduce =
+            Astring.String.is_infix ~affix:"END-REPRO-BLOCK" log_line
+          in
+          let code_line_class =
+            if is_start_of_steps_to_reproduce then
+              "code-line__code repro-block-start"
+            else if is_end_of_steps_to_reproduce then
+              "code-line__code repro-block-end"
+            else "code-line__code"
+          in
           last_line_blank := log_line = "";
           line_number := !line_number + 1;
           Printf.sprintf "%s\n%s" l
@@ -428,12 +577,12 @@ module Make (M : Git_forge_intf.Forge) = struct
                       ~a:[ a_class [ "code-line__number" ] ]
                       [ txt (Printf.sprintf "%d" !line_number) ];
                     td
-                      ~a:[ a_class [ "code-line__code" ] ]
+                      ~a:[ a_class [ code_line_class ] ]
                       [ pre [ Unsafe.data log_line ] ];
-                  ])))
+                  ]))
       in
       Printf.sprintf "%s%s"
-        (List.fold_left aux "<table><tbody>" data)
+        (List.fold_left aux "<table id='steps-table'><tbody>" data)
         "</tbody></table>"
     in
     let open Lwt.Infix in

--- a/web-ui/view/template_v1.ml
+++ b/web-ui/view/template_v1.ml
@@ -17,8 +17,8 @@ let head =
                maximum-scale=1.0, user-scalable=no";
           ]
         ();
-      script ~a:[ a_defer (); a_src "/js/alpine.js" ] (txt "");
       script ~a:[ a_defer (); a_src "/js/alpine-clipboard.js" ] (txt "");
+      script ~a:[ a_defer (); a_src "/js/alpine.js" ] (txt "");
       link ~rel:[ `Stylesheet ] ~href:"/fonts/inter.css" ();
       link ~rel:[ `Stylesheet ] ~href:"/css/main.css" ();
       link ~rel:[ `Stylesheet ] ~href:"/css/ansi.css" ();

--- a/web-ui/view/tyxml_helpers.ml
+++ b/web-ui/view/tyxml_helpers.ml
@@ -8,3 +8,4 @@ let at_click a = Tyxml.Html.Unsafe.string_attrib "@click" a
 let at_click_outside a = Tyxml.Html.Unsafe.string_attrib "@click.outside" a
 let a_svg_custom x y = Tyxml.Xml.string_attrib x y |> Tyxml.Svg.to_attrib
 let colon_class str = Tyxml.Html.Unsafe.string_attrib ":class" str
+let x_bind_style a = Tyxml.Html.Unsafe.string_attrib "x-bind:style" a


### PR DESCRIPTION
Extract the build-reproduction section of the logs into a collapsible section. This happens at the end of a build - i.e. when the logs have stopped streaming. The `Copy code` button then copies the text to the clipboard.

![Screenshot 2022-12-13 at 1 06 49 pm](https://user-images.githubusercontent.com/181086/207208605-b7fbc43d-a5df-4533-be93-89a1812a9fda.png)
