### PR TITLE
Repo chart tooltips

### DIFF
--- a/web-ui/static/js/repo-page.js
+++ b/web-ui/static/js/repo-page.js
@@ -74,7 +74,85 @@ const chartOptions = {
     display: false
   },
   tooltips: {
-    enabled: false
+    // Hide the on-canvas tooltip
+    enabled: false,
+    custom: function(tooltipModel) {
+      // Tooltip Element
+      var tooltipEl = document.getElementById('chartjs-tooltip');
+
+      // Create element on first render
+      if (!tooltipEl) {
+          tooltipEl = document.createElement('div');
+          tooltipEl.id = 'chartjs-tooltip';
+          tooltipEl.innerHTML = "";
+          // tooltipEl.innerHTML = '<table></table>';
+          document.body.appendChild(tooltipEl);
+      }
+
+      // Hide if no tooltip
+      if (tooltipModel.opacity === 0) {
+          tooltipEl.style.opacity = 0;
+          return;
+      }
+
+      // Set caret Position
+      tooltipEl.classList.remove('above', 'below', 'no-transform');
+      if (tooltipModel.yAlign) {
+          tooltipEl.classList.add(tooltipModel.yAlign);
+      } else {
+          tooltipEl.classList.add('no-transform');
+      }
+
+      function getBody(bodyItem) {
+          return bodyItem.lines;
+      }
+
+      // Set Text
+      if (tooltipModel.body) {
+          // var titleLines = tooltipModel.title || [];
+          var bodyLines = tooltipModel.body.map(getBody);
+
+
+          // console.log(titleLines);
+          // console.log(bodyLines);
+
+          // var innerHtml = '<thead>';
+
+          // titleLines.forEach(function(title) {
+          //     innerHtml += '<tr><th>' + title + '</th></tr>';
+          // });
+          // innerHtml += '</thead><tbody>';
+
+          // bodyLines.forEach(function(body, i) {
+          //     var colors = tooltipModel.labelColors[i];
+          //     var style = 'background:' + colors.backgroundColor;
+          //     style += '; border-color:' + colors.borderColor;
+          //     style += '; border-width: 2px';
+          //     var span = '<span style="' + style + '"></span>';
+          //     innerHtml += '<tr><td>' + span + body + '</td></tr>';
+          // });
+          // innerHtml += '</tbody>';
+
+          innerHtml = "<p>" + bodyLines[0][0] + "</p>";
+
+          // var tableRoot = tooltipEl.querySelector('table');
+          tooltipEl.innerHTML = innerHtml;
+      }
+
+      // `this` will be the overall tooltip
+      var position = this._chart.canvas.getBoundingClientRect();
+
+      // Display, position, and set styles for font
+      tooltipEl.style.opacity = 1;
+      tooltipEl.style.position = 'absolute';
+      tooltipEl.style.left = position.left + window.pageXOffset + tooltipModel.caretX + 'px';
+      tooltipEl.style.top = position.top + window.pageYOffset + tooltipModel.caretY + 'px';
+      tooltipEl.style.fontFamily = tooltipModel._bodyFontFamily;
+      tooltipEl.style.fontSize = tooltipModel.bodyFontSize + 'px';
+      tooltipEl.style.fontStyle = tooltipModel._bodyFontStyle;
+      tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px';
+      tooltipEl.style.pointerEvents = 'none';
+  },
   },
   elements: {
     point: {
@@ -96,8 +174,8 @@ const chartOptions = {
         display: false,
         suggestedMin: 0,
         suggestedMax: 10
-      }
-    }]
+      },
+    }],
   },
 };
 
@@ -164,7 +242,4 @@ window.onload = function() {
   body = table_root.lastChild;
 
   charts_init();
-  // Hack to make the bar charts consistently sized, without this on
-  // page load they are of different sizes until the window is resized.
-  window.dispatchEvent(new Event('resize'));
 }

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -119,17 +119,16 @@ module Make (M : Git_forge_intf.Forge) = struct
       | Some v -> Printf.sprintf "%f" v
     in
     let speed =
+      let fmt v symbol =
+        [
+          txt (Printf.sprintf "%.1f" v);
+          span ~a:[ a_class [ "text-sm pl-0.5" ] ] [ txt symbol ];
+        ]
+      in
       if Float.is_nan statistics.speed then [ txt "N/A" ]
-      else if statistics.speed > 60. then
-        [
-          txt (Printf.sprintf "%.1f" (statistics.speed /. 60.));
-          span ~a:[ a_class [ "text-sm pl-0.5" ] ] [ txt "min" ];
-        ]
-      else
-        [
-          txt (Printf.sprintf "%.1f" statistics.speed);
-          span ~a:[ a_class [ "text-sm pl-0.5" ] ] [ txt "sec" ];
-        ]
+      else if statistics.speed > 3600. then fmt (statistics.speed /. 3600.) "hr"
+      else if statistics.speed > 60. then fmt (statistics.speed /. 60.) "min"
+      else fmt statistics.speed "sec"
     in
     let reliability =
       if Float.is_nan statistics.reliability then [ txt "N/A" ]
@@ -262,12 +261,16 @@ module Make (M : Git_forge_intf.Forge) = struct
       let data = List.map fmt data in
       [ "\""; name; "\":[" ] ++ data ++ [ "]," ]
     in
+    (* The chart is left-to-right old-to-new, which is the opposite direction to the provided data *)
+    let rev_data =
+      List.map (fun (repo, history) -> (repo, List.rev history)) data
+    in
     let chart_labels = List.init 15 (fun x -> Printf.sprintf "%d," (x + 1)) in
     let chart_data =
-      List.map (js_of_history commit_data) data |> List.flatten
+      List.map (js_of_history commit_data) rev_data |> List.flatten
     in
     let chart_colours =
-      List.map (js_of_history commit_colour) data |> List.flatten
+      List.map (js_of_history commit_colour) rev_data |> List.flatten
     in
     [ "var chart_labels = [" ]
     ++ chart_labels


### PR DESCRIPTION
Tooltips in Chart.JS are more complex than anticipated. They are typically rendered on the canvas but as our canvas is too small they get cut off at the edges, so we have to write a custom handler that generates HTML instead.

(Also included is a fix to correct the order of commits in the chart, and one allowing speeds to be rendered in hours.)