### PR TITLE
Repos page UI fixes

### DIFF
--- a/web-ui/static/js/repo-page.js
+++ b/web-ui/static/js/repo-page.js
@@ -71,23 +71,23 @@ var body = null;
 const chartOptions = {
   maintainAspectRatio: false,
   legend: {
-    display: false
+    display: false,
   },
   tooltips: {
-    enabled: false
+    enabled: false,
   },
   elements: {
     point: {
-      radius: 0
-    }
+      radius: 0,
+    },
   },
   scales: {
     xAxes: [{
       gridLines: false,
       scaleLabel: false,
       ticks: {
-        display: false
-      }
+        display: false,
+      },
     }],
     yAxes: [{
       gridLines: false,
@@ -95,9 +95,9 @@ const chartOptions = {
       ticks: {
         display: false,
         suggestedMin: 0,
-        suggestedMax: 10
-      }
-    }]
+        suggestedMax: 10,
+      },
+    }],
   },
 };
 

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -261,8 +261,9 @@ module Make (M : Git_forge_intf.Forge) = struct
       | _ -> "\"rgba(226, 232, 240, 1)\","
     in
     let js_of_history fmt (name, data) =
-      assert (List.compare_length_with data 15 <= 0);
-      let data = List.map fmt data in
+      let data =
+        List.filteri (fun i _ -> i < 15) data
+        |> List.map fmt in
       [ "\""; name; "\":[" ] ++ data ++ [ "]," ]
     in
     (* The chart is left-to-right old-to-new, which is the opposite direction to the provided data *)

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -119,17 +119,16 @@ module Make (M : Git_forge_intf.Forge) = struct
       | Some v -> Printf.sprintf "%f" v
     in
     let speed =
+      let fmt v symbol =
+        [
+          txt (Printf.sprintf "%.1f" v);
+          span ~a:[ a_class [ "text-sm pl-0.5" ] ] [ txt symbol ];
+        ]
+      in
       if Float.is_nan statistics.speed then [ txt "N/A" ]
-      else if statistics.speed > 60. then
-        [
-          txt (Printf.sprintf "%.1f" (statistics.speed /. 60.));
-          span ~a:[ a_class [ "text-sm pl-0.5" ] ] [ txt "min" ];
-        ]
-      else
-        [
-          txt (Printf.sprintf "%.1f" statistics.speed);
-          span ~a:[ a_class [ "text-sm pl-0.5" ] ] [ txt "sec" ];
-        ]
+      else if statistics.speed > 3600. then fmt (statistics.speed /. 3600.) "hr"
+      else if statistics.speed > 60. then fmt (statistics.speed /. 60.) "min"
+      else fmt statistics.speed "sec"
     in
     let reliability =
       if Float.is_nan statistics.reliability then [ txt "N/A" ]
@@ -266,12 +265,16 @@ module Make (M : Git_forge_intf.Forge) = struct
       let data = List.map fmt data in
       [ "\""; name; "\":[" ] ++ data ++ [ "]," ]
     in
+    (* The chart is left-to-right old-to-new, which is the opposite direction to the provided data *)
+    let rev_data =
+      List.map (fun (repo, history) -> (repo, List.rev history)) data
+    in
     let chart_labels = List.init 15 (fun x -> Printf.sprintf "%d," (x + 1)) in
     let chart_data =
-      List.map (js_of_history commit_data) data |> List.flatten
+      List.map (js_of_history commit_data) rev_data |> List.flatten
     in
     let chart_colours =
-      List.map (js_of_history commit_colour) data |> List.flatten
+      List.map (js_of_history commit_colour) rev_data |> List.flatten
     in
     [ "var chart_labels = [" ]
     ++ chart_labels


### PR DESCRIPTION
- Reverse the order of the build history chart so that oldest-to-newest is left-to-right.
- Allow the average speed to be rendered in hours when it is above 60 minutes.