### PR TITLE
Step: cancel mechanism.

### DIFF
--- a/test/test_build_representation.ml
+++ b/test/test_build_representation.ml
@@ -24,7 +24,7 @@ let test_simple () =
     }
   in
   let expected_1 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"variant":"analysis"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"can_cancel":false,"variant":"analysis"}|}
   in
   let step_info_2 : Client.job_info =
     {
@@ -36,7 +36,7 @@ let test_simple () =
     }
   in
   let expected_2 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m06s","can_rebuild":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m06s","can_rebuild":false,"can_cancel":false,"variant":"variant"}|}
   in
   let step_info_3 : Client.job_info =
     {
@@ -48,7 +48,7 @@ let test_simple () =
     }
   in
   let expected_3 =
-    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m56s","can_rebuild":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m56s","can_rebuild":false,"can_cancel":false,"variant":"variant"}|}
   in
   let jobs = [ step_info_1; step_info_2; step_info_3 ] in
   let build_status : Client.State.t = Failed "for reasons" in

--- a/test/test_step_representation.ml
+++ b/test/test_step_representation.ml
@@ -2,10 +2,11 @@ module Step = Representation.Step
 module Client = Ocaml_ci_api.Client
 module Run_time = Ocaml_ci_client_lib.Run_time
 
-let test_to_json (step_info, run_time, can_rebuild, expected) =
+let test_to_json (step_info, run_time, can_rebuild, can_cancel, expected) =
   let result =
     Step.to_json
     @@ Step.from_status_info_run_time ~step_info ~run_time ~can_rebuild
+         ~can_cancel
   in
   Alcotest.(check string) "to_json" expected result
 
@@ -13,6 +14,7 @@ let test_to_json (step_info, run_time, can_rebuild, expected) =
    by adding timedesc-tzlocal.utc to the dune file. See the README for timedesc *)
 let test_simple () =
   let can_rebuild = true in
+  let can_cancel = false in
   let step_info_1 : Client.job_info option =
     Some
       {
@@ -27,7 +29,7 @@ let test_simple () =
     Some (Running { queued_for = 42.2; ran_for = 0. })
   in
   let expected_1 =
-    {|{"version":"1.0","status":"active","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"0s","can_rebuild":true,"variant":"variant"}|}
+    {|{"version":"1.0","status":"active","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"0s","can_rebuild":true,"can_cancel":false,"variant":"variant"}|}
   in
   let step_info_2 : Client.job_info option =
     Some
@@ -43,7 +45,7 @@ let test_simple () =
     Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
   in
   let expected_2 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"5s","can_rebuild":true,"variant":"variant"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant"}|}
   in
   let step_info_3 : Client.job_info option =
     Some
@@ -59,14 +61,14 @@ let test_simple () =
     Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
   in
   let expected_3 =
-    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true,"variant":"variant"}|}
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant"}|}
   in
 
   List.iter test_to_json
     [
-      (step_info_1, run_time_1, can_rebuild, expected_1);
-      (step_info_2, run_time_2, can_rebuild, expected_2);
-      (step_info_3, run_time_3, can_rebuild, expected_3);
+      (step_info_1, run_time_1, can_rebuild, can_cancel, expected_1);
+      (step_info_2, run_time_2, can_rebuild, can_cancel, expected_2);
+      (step_info_3, run_time_3, can_rebuild, can_cancel, expected_3);
     ]
 
 let tests = [ Alcotest_lwt.test_case_sync "simple" `Quick test_simple ]

--- a/web-ui/controller/api/git_forge.ml
+++ b/web-ui/controller/api/git_forge.ml
@@ -66,6 +66,7 @@ module Make (Api : Api) = struct
         timestamps
     in
     Api.show_step ~step_info ~run_time ~can_rebuild:status.can_rebuild
+      ~can_cancel:status.can_cancel
 
   let list_steps ~org ~repo ~hash ci =
     Controller.Backend.ci ci >>= fun ci ->

--- a/web-ui/representation/step.ml
+++ b/web-ui/representation/step.ml
@@ -12,11 +12,12 @@ type t = {
   queued_for : string;
   ran_for : string;
   can_rebuild : bool;
+  can_cancel : bool;
   variant : string;
 }
 [@@deriving yojson]
 
-let from_status_info_run_time ~step_info ~run_time ~can_rebuild =
+let from_status_info_run_time ~step_info ~run_time ~can_rebuild ~can_cancel =
   {
     version;
     status =
@@ -36,6 +37,7 @@ let from_status_info_run_time ~step_info ~run_time ~can_rebuild =
     ran_for =
       Timestamps_durations.pp_duration (Option.map Run_time.ran_for run_time);
     can_rebuild;
+    can_cancel;
     variant =
       Option.fold ~none:""
         ~some:(fun i -> Fmt.str "%s" i.Client.variant)
@@ -58,5 +60,6 @@ let from_status_info ~step_info ~build_created_at =
     Option.map (Run_time.run_times_from_timestamps ~build_created_at) timestamps
   in
   from_status_info_run_time ~step_info ~run_time ~can_rebuild:false
+    ~can_cancel:false
 
 let to_json t = Yojson.Safe.to_string @@ to_yojson t

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -63,6 +63,19 @@ let gitlab_routes gitlab =
           ~org:(Dream.param request "org")
           ~repo:(Dream.param request "repo")
           ~gref gitlab);
+    Dream.post "/gitlab/:org/:repo/commit/:hash/variant/:variant/cancel"
+      (fun request ->
+        Dream.form request >>= function
+        | `Ok _ ->
+            Controller.Gitlab.cancel_step
+              ~org:(Dream.param request "org")
+              ~repo:(Dream.param request "repo")
+              ~hash:(Dream.param request "hash")
+              ~variant:(Dream.param request "variant")
+              request gitlab
+        | _ ->
+            Dream.log "Form validation failed";
+            Dream.empty `Bad_Request);
     Dream.post "/gitlab/:org/:repo/commit/:hash/variant/:variant/rebuild"
       (fun request ->
         Dream.form request >>= function
@@ -182,6 +195,19 @@ let github_routes github =
           List.hd (Astring.String.cuts ~sep:"/-/" (Dream.target request))
         in
         Dream.redirect request target);
+    Dream.post "/github/:org/:repo/commit/:hash/variant/:variant/cancel"
+      (fun request ->
+        Dream.form request >>= function
+        | `Ok _ ->
+            Controller.Github.cancel_step
+              ~org:(Dream.param request "org")
+              ~repo:(Dream.param request "repo")
+              ~hash:(Dream.param request "hash")
+              ~variant:(Dream.param request "variant")
+              request github
+        | _ ->
+            Dream.log "Form validation failed";
+            Dream.empty `Bad_Request);
     Dream.post "/github/:org/:repo/commit/:hash/variant/:variant/rebuild"
       (fun request ->
         Dream.form request >>= function

--- a/web-ui/static/js/step-page-poll.js
+++ b/web-ui/static/js/step-page-poll.js
@@ -47,6 +47,12 @@ function poll(api_path, timeout, interval) {
               .getElementById("rebuild-step")
               .style.removeProperty("display");
           }
+        if (data["can_cancel"]) {
+            document
+              .getElementById("cancel-step")
+              .style.removeProperty("display");
+          }
+
           console.log("Build has finished. Stop polling.");
         }
 

--- a/web-ui/view/api/git_forge.ml
+++ b/web-ui/view/api/git_forge.ml
@@ -6,6 +6,7 @@ module type Api = sig
     step_info:Client.job_info option ->
     run_time:Run_time.run_time_info option ->
     can_rebuild:bool ->
+    can_cancel:bool ->
     Dream.response Lwt.t
 
   val list_steps :
@@ -36,10 +37,11 @@ module Make (M : M_Git_forge) = struct
   let step_route_prefix ~org ~repo ~hash =
     Fmt.str "/%s/%s/%s/commit/%s/variant" M.prefix org repo hash
 
-  let show_step ~step_info ~run_time ~can_rebuild =
+  let show_step ~step_info ~run_time ~can_rebuild ~can_cancel =
     Dream.json
     @@ Step.to_json
     @@ Step.from_status_info_run_time ~step_info ~run_time ~can_rebuild
+         ~can_cancel
 
   let list_steps ~org ~repo ~hash ~jobs ~build_status =
     let step_route_prefix = step_route_prefix ~org ~repo ~hash in

--- a/web-ui/view/common.ml
+++ b/web-ui/view/common.ml
@@ -102,6 +102,23 @@ let form_for ~x_ref ~action ~csrf_token ~submit_button ~input_value =
           ();
       ])
 
+let form_cancel_step ~variant ~csrf_token ?(show = true) () =
+  let display_none = if show then "" else "display:none" in
+  let submit_button =
+    Tyxml.Html.(
+      button
+        [ txt "Cancel" ]
+        ~a:
+          [
+            a_id "cancel-step";
+            a_class [ "btn btn-primary" ];
+            a_style display_none;
+            Tyxml_helpers.at_click "$refs.cancelStepForm.submit()";
+          ])
+  in
+  form_for ~csrf_token ~x_ref:"cancelForm" ~action:(variant ^ "/cancel")
+    ~submit_button ~input_value:"Cancel"
+
 let form_rebuild_step ~variant ~csrf_token ?(show = true) () =
   let display_none = if show then "" else "display:none" in
   let submit_button =
@@ -116,7 +133,6 @@ let form_rebuild_step ~variant ~csrf_token ?(show = true) () =
             Tyxml_helpers.at_click "$refs.rebuildStepForm.submit()";
           ])
   in
-
   form_for ~csrf_token ~submit_button ~x_ref:"rebuildStepForm"
     ~action:(variant ^ "/rebuild") ~input_value:"Rebuild"
 


### PR DESCRIPTION
This PR introduces the capacity for a step to be cancelled.  The cancelling button is available only if the step is running. Once it's done, the step will appear as `Job cancelled`. It takes a bit of time before the step is visible as cancelled in the `backend` machinery, so the propagation might take a bit of time before being visible.