### PR TITLE
Change default of steps-to-repro to be hidden.

### DIFF
--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -533,7 +533,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                   ~a:
                     [
                       Tyxml_helpers.x_show "logs";
-                      Tyxml_helpers.x_data "{stepsToRepro: true}";
+                      Tyxml_helpers.x_data "{stepsToRepro: false}";
                     ]
                   [ steps_to_reproduce_build; logs_container ];
               ];


### PR DESCRIPTION
This is likely to be a better UX for most since the steps-to-repro are duplicated in the logs and having to hide it so that the logs are visible will become a pain point.