### PR TITLE
Fix pasting logs into GitHub code blocks.

### DIFF
--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -597,7 +597,9 @@ module Make (M : Git_forge_intf.Forge) = struct
       in
       Printf.sprintf "%s%s"
         (List.fold_left aux
-           "<table class='flex steps-table fg-default bg-default'><tbody>" data)
+           "<table data-paste-markdown-skip class='flex steps-table fg-default \
+            bg-default'><tbody>"
+           data)
         "</tbody></table>"
     in
     let open Lwt.Infix in


### PR DESCRIPTION
Fixes #654 

GitHub support pointed to https://github.com/github/paste-markdown#excluding-tables so we're adding the magic data attribute to the logs table as directed.