### PR TITLE
Bug fix proposition for 703

### DIFF
--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -228,6 +228,20 @@ let v ?ocluster ~app ~solver ~migrations () =
            let analysis =
              Analyse.examine ~solver ~platforms ~opam_repository_commit src
            in
+           let* on_cancel =
+             match ocluster with
+             | None -> Current.return None
+             | Some _ ->
+                 let+ commit = head in
+                 let gref = Git.Commit_id.gref @@ Gitlab.Api.Commit.id commit in
+                 let repo = Gitlab.Api.Commit.repo_id commit in
+                 let repo =
+                   { Ocaml_ci.Repo_id.owner = repo.owner; name = repo.name }
+                 in
+                 let hash = Gitlab.Api.Commit.hash commit in
+                 Some
+                   (fun _ -> Index.record_summary_on_cancel ~repo ~gref ~hash)
+           in
            let builds =
              let repo =
                Current.map
@@ -238,7 +252,8 @@ let v ?ocluster ~app ~solver ~migrations () =
                    })
                  repo
              in
-             build_with_docker ?ocluster ~repo ~analysis ~platforms src
+             build_with_docker ?ocluster ?on_cancel ~repo ~analysis ~platforms
+               src
            in
            let summary = Current.map summarise builds in
            let status =

--- a/lib/cluster_build.mli
+++ b/lib/cluster_build.mli
@@ -9,6 +9,7 @@ val config :
 
 val v :
   t ->
+  ?on_cancel:(string -> unit) ->
   platforms:Platform.t list Current.t ->
   repo:Repo_id.t Current.t ->
   spec:Spec.t Current.t ->
@@ -19,4 +20,5 @@ val v :
     platform. [~repo] is the ID of the repository-under-test on a Git Forge
     (e.g. GitHub or GitLab).
 
+    @param on_cancel The callback function to call if the job is cancelled.
     @param repo The ID of the repository-under-test on GitHub. *)

--- a/lib/index.mli
+++ b/lib/index.mli
@@ -142,6 +142,13 @@ val record :
     at [jobs]. It also updates a Commit_cache with aggregated build data. If the
     build has finished, it also writes an entry to the build_summary table. *)
 
+val record_summary_on_cancel :
+  repo:Repo_id.t -> gref:string -> hash:string -> unit
+(** [record_summary_on_cancel ~repo ~gref ~hash] store a pending state within
+    the database. It MUST be set before any build run to make surethe invariant
+    that a data is into the database is preserved when calling
+    [record_on_cancel]. *)
+
 val get_jobs :
   owner:string ->
   name:string ->

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -60,8 +60,8 @@ let get_job_id x =
   let+ md = Current.Analysis.metadata x in
   match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
 
-let build_with_docker ?ocluster ~(repo : Repo_id.t Current.t) ~analysis
-    ~platforms source =
+let build_with_docker ?ocluster ?on_cancel ~(repo : Repo_id.t Current.t)
+    ~analysis ~platforms source =
   Current.with_context analysis @@ fun () ->
   let specs =
     let+ analysis = Current.state ~hidden:true analysis in
@@ -118,7 +118,7 @@ let build_with_docker ?ocluster ~(repo : Repo_id.t Current.t) ~analysis
              | None -> Build.v ~platforms ~repo ~spec source
              | Some ocluster ->
                  let src = Current.map Git.Commit.id source in
-                 Cluster_build.v ocluster ~platforms ~repo ~spec src
+                 Cluster_build.v ocluster ?on_cancel ~platforms ~repo ~spec src
            and+ spec in
            (Spec.label spec, result))
   in

--- a/lib/pipeline.mli
+++ b/lib/pipeline.mli
@@ -20,6 +20,7 @@ val get_job_id : 'a Current.t -> string option Current.t
 
 val build_with_docker :
   ?ocluster:Cluster_build.t ->
+  ?on_cancel:(string -> unit) ->
   repo:Repo_id.t Current.t ->
   analysis:Analyse.Analysis.t Current.t ->
   platforms:Platform.t list Current.t ->
@@ -31,4 +32,6 @@ val build_with_docker :
 
     The builds created will depend on the [platforms] available and the solver
     [analysis] for those platforms. Optionally the builds can be peformed
-    locally in docker or on an OCluster instance. *)
+    locally in docker or on an OCluster instance.
+
+    [on_cancel] is only called when [ocluster] is [Some cluster]. *)

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -1,5 +1,6 @@
 open Current.Syntax
 open Ocaml_ci
+open Pipeline
 module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
@@ -22,17 +23,10 @@ let opam_repository_commit =
   let repo = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } in
   Github.Api.Anonymous.head_of repo @@ `Ref "refs/heads/master"
 
-(* Check whether a variant is considered experimental.
-   If it is experimental we allow those builds to fail without
-   failing the overall build for a commit.
-*)
-let experimental_variant variant =
-  Astring.String.is_prefix ~affix:"macos-homebrew" variant
-
 let pp_fail prefix f m = Fmt.pf f "%s: %s" prefix (Ansi.strip m)
 
 let github_status_of_state ~head result results =
-  let+ head = head and+ result = result and+ results = results in
+  let+ head and+ result and+ results in
   let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
   let commit_id = Github.Api.Commit.id head in
   let gref = Current_git.Commit_id.gref commit_id in
@@ -68,7 +62,7 @@ let github_status_of_state ~head result results =
       Github.Api.CheckRunStatus.v ~url (`Completed (`Failure m)) ~summary
 
 let set_active_installations installations =
-  let+ installations = installations in
+  let+ installations in
   installations
   |> List.fold_left
        (fun acc i -> Index.Owner_set.add (Github.Installation.account i) acc)
@@ -77,7 +71,7 @@ let set_active_installations installations =
   installations
 
 let set_active_repos ~installation repos =
-  let+ installation = installation and+ repos = repos in
+  let+ installation and+ repos in
   let owner = Github.Installation.account installation in
   repos
   |> List.fold_left
@@ -96,7 +90,7 @@ let ref_name c =
   | _ -> failwith "Commit is neither a branch nor a PR"
 
 let set_active_refs ~repo refs default_ref =
-  let+ repo = repo and+ xs = refs and+ default = default_ref in
+  let+ repo and+ xs = refs and+ default = default_ref in
   let github_repo = Github.Api.Repo.id repo in
   let repo = { Repo_id.owner = github_repo.owner; name = github_repo.name } in
   let refs =
@@ -114,144 +108,16 @@ let set_active_refs ~repo refs default_ref =
   Index.set_active_refs ~repo refs (ref_from_commit default);
   xs
 
-let get_job_id x =
-  let+ md = Current.Analysis.metadata x in
-  match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
-
-let build_with_docker ?ocluster ?on_cancel ~repo ~analysis ~platforms source =
-  let repo' =
-    Current.map
-      (fun r ->
-        { Repo_id.owner = r.Github.Repo_id.owner; Repo_id.name = r.name })
-      repo
-  in
-  Current.with_context analysis @@ fun () ->
-  let specs =
-    let+ analysis = Current.state ~hidden:true analysis in
-    match analysis with
-    | Error _ ->
-        (* If we don't have the analysis yet, just use the empty list. *)
-        []
-    | Ok analysis -> (
-        match Analyse.Analysis.selections analysis with
-        | `Opam_monorepo builds ->
-            let lint_selection =
-              Opam_monorepo.selection_of_config (List.hd builds)
-            in
-            Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis
-              (`Lint `Fmt)
-            :: Spec.opam_monorepo builds
-        | `Opam_build selections ->
-            let lint_selection = List.hd selections in
-            let lint_ocamlformat =
-              match Analyse.Analysis.ocamlformat_selection analysis with
-              | None -> lint_selection
-              | Some selection -> selection
-            in
-            let builds =
-              selections
-              |> Selection.filter_duplicate_opam_versions
-              |> List.map (fun selection ->
-                     let label =
-                       Variant.to_string selection.Selection.variant
-                     in
-                     Spec.opam ~label ~selection ~analysis `Build)
-            and lint =
-              [
-                Spec.opam ~label:"(lint-fmt)" ~selection:lint_ocamlformat
-                  ~analysis (`Lint `Fmt);
-                Spec.opam ~label:"(lint-doc)" ~selection:lint_selection
-                  ~analysis (`Lint `Doc);
-                Spec.opam ~label:"(lint-opam)" ~selection:lint_selection
-                  ~analysis (`Lint `Opam);
-              ]
-            in
-            lint @ builds)
-  in
-  let builds =
-    specs
-    |> Current.list_map
-         (module Spec)
-         (fun spec ->
-           let+ result =
-             match ocluster with
-             | None -> Build.v ~platforms ~repo:repo' ~spec source
-             | Some ocluster ->
-                 let src = Current.map Git.Commit.id source in
-                 Cluster_build.v ocluster ?on_cancel ~platforms ~repo:repo'
-                   ~spec src
-           and+ spec = spec in
-           (Spec.label spec, result))
-  in
-  let+ builds = builds
-  and+ analysis_result =
-    Current.state ~hidden:true (Current.map (fun _ -> `Checked) analysis)
-  and+ analysis_id = get_job_id analysis in
-  builds @ [ ("(analysis)", (analysis_result, analysis_id)) ]
-
-let list_errors ~ok errs =
-  let groups =
-    (* Group by error message *)
-    List.sort compare errs
-    |> List.fold_left
-         (fun acc (msg, l) ->
-           match acc with
-           | (m2, ls) :: acc' when m2 = msg -> (m2, l :: ls) :: acc'
-           | _ -> (msg, [ l ]) :: acc)
-         []
-  in
-  Error
-    (`Msg
-      (match groups with
-      | [] -> "No builds at all!"
-      | [ (msg, _) ] when ok = 0 ->
-          msg (* Everything failed with the same error *)
-      | [ (msg, ls) ] ->
-          Fmt.str "%a failed: %s" Fmt.(list ~sep:(any ", ") string) ls msg
-      | _ ->
-          (* Multiple error messages; just list everything that failed. *)
-          let pp_label f (_, l) = Fmt.string f l in
-          Fmt.str "%a failed" Fmt.(list ~sep:(any ", ") pp_label) errs))
-
-let summarise results =
-  results
-  |> List.fold_left
-       (fun (ok, pending, err, skip) -> function
-         | _, Ok `Checked ->
-             (ok, pending, err, skip) (* Don't count lint checks *)
-         | _, Ok `Built -> (ok + 1, pending, err, skip)
-         | l, Error (`Msg m) when Astring.String.is_prefix ~affix:"[SKIP]" m ->
-             (ok, pending, err, (m, l) :: skip)
-         | l, Error (`Msg _) when experimental_variant l ->
-             (ok + 1, pending, err, skip)
-         (* Don't fail the commit if an experimental build failed. *)
-         | l, Error (`Msg m) -> (ok, pending, (m, l) :: err, skip)
-         | _, Error (`Active _) -> (ok, pending + 1, err, skip))
-       (0, 0, [], [])
-  |> fun (ok, pending, err, skip) ->
-  if pending > 0 then Error (`Active `Running)
-  else
-    match (ok, err, skip) with
-    | 0, [], skip ->
-        list_errors ~ok:0
-          skip (* Everything was skipped - treat skips as errors *)
-    | _, [], _ -> Ok () (* No errors and at least one success *)
-    | ok, err, _ -> list_errors ~ok err (* Some errors found - report *)
-
 let local_test ~solver repo () =
   let platforms = Conf.fetch_platforms ~include_macos:false () in
   let src = Git.Local.head_commit repo in
-  let repo = Current.return { Github.Repo_id.owner = "local"; name = "test" }
+  let repo = Current.return { Repo_id.owner = "local"; name = "test" }
   and analysis =
     Analyse.examine ~solver ~platforms ~opam_repository_commit src
   in
   Current.component "summarise"
   |> let> results = build_with_docker ~repo ~analysis ~platforms src in
-     let result =
-       results
-       |> List.map (fun (variant, (build, _job)) -> (variant, build))
-       |> summarise
-     in
+     let result = results |> summarise in
      Current_incr.const (result, None)
 
 let v ?ocluster ~app ~solver ~migrations () =
@@ -266,17 +132,12 @@ let v ?ocluster ~app ~solver ~migrations () =
   Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->
-  let installations =
-    Github.App.installations app |> set_active_installations
-  in
-  installations
+  Github.App.installations app
+  |> set_active_installations
   |> Current.list_iter ~collapse_key:"org" (module Github.Installation)
      @@ fun installation ->
-     let repos =
-       Github.Installation.repositories installation
-       |> set_active_repos ~installation
-     in
-     repos
+     Github.Installation.repositories installation
+     |> set_active_repos ~installation
      |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo)
         @@ fun repo ->
         let default = Github.Api.Repo.head_commit repo in
@@ -306,41 +167,40 @@ let v ?ocluster ~app ~solver ~migrations () =
                  Some
                    (fun _ -> Index.record_summary_on_cancel ~repo ~gref ~hash)
            in
-
            let builds =
-             let repo = Current.map Github.Api.Repo.id repo in
+             let repo =
+               Current.map
+                 (fun x ->
+                   Github.Api.Repo.id x |> fun repo ->
+                   { Repo_id.owner = repo.owner; name = repo.name })
+                 repo
+             in
              build_with_docker ?ocluster ?on_cancel ~repo ~analysis ~platforms
                src
            in
-           let summary =
-             builds
-             |> Current.map
-                  (List.map (fun (variant, (build, _job)) -> (variant, build)))
-             |> Current.map summarise
-           in
+           let summary = Current.map summarise builds in
            let status =
-             let+ summary = summary in
+             let+ summary in
              match summary with
              | Ok () -> `Passed
              | Error (`Active `Running) -> `Pending
              | Error (`Msg _) -> `Failed
            in
            let index =
-             let+ commit = head and+ builds = builds and+ status = status in
+             let+ commit = head and+ builds and+ status in
              let gref = ref_from_commit commit in
-             let repo = Current_github.Api.Commit.repo_id commit in
              let repo =
-               { Ocaml_ci.Repo_id.owner = repo.owner; name = repo.name }
+               Current_github.Api.Commit.repo_id commit |> fun repo ->
+               { Repo_id.owner = repo.owner; name = repo.name }
              in
              let hash = Current_github.Api.Commit.hash commit in
              let jobs =
-               builds
-               |> List.map (fun (variant, (_, job_id)) -> (variant, job_id))
+               List.map (fun (variant, (_, job_id)) -> (variant, job_id)) builds
              in
              Index.record ~repo ~hash ~status ~gref jobs
            and set_github_status =
              builds
              |> github_status_of_state ~head summary
              |> Github.Api.CheckRun.set_status head "ocaml-ci"
-           and set_matrix_status = Current.return () in
-           Current.all [ index; set_github_status; set_matrix_status ]
+           in
+           Current.all [ index; set_github_status ]

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -1,6 +1,5 @@
 open Current.Syntax
 open Ocaml_ci
-open Pipeline
 module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
@@ -23,10 +22,17 @@ let opam_repository_commit =
   let repo = { Github.Repo_id.owner = "ocaml"; name = "opam-repository" } in
   Github.Api.Anonymous.head_of repo @@ `Ref "refs/heads/master"
 
+(* Check whether a variant is considered experimental.
+   If it is experimental we allow those builds to fail without
+   failing the overall build for a commit.
+*)
+let experimental_variant variant =
+  Astring.String.is_prefix ~affix:"macos-homebrew" variant
+
 let pp_fail prefix f m = Fmt.pf f "%s: %s" prefix (Ansi.strip m)
 
 let github_status_of_state ~head result results =
-  let+ head and+ result and+ results in
+  let+ head = head and+ result = result and+ results = results in
   let { Github.Repo_id.owner; name } = Github.Api.Commit.repo_id head in
   let commit_id = Github.Api.Commit.id head in
   let gref = Current_git.Commit_id.gref commit_id in
@@ -62,7 +68,7 @@ let github_status_of_state ~head result results =
       Github.Api.CheckRunStatus.v ~url (`Completed (`Failure m)) ~summary
 
 let set_active_installations installations =
-  let+ installations in
+  let+ installations = installations in
   installations
   |> List.fold_left
        (fun acc i -> Index.Owner_set.add (Github.Installation.account i) acc)
@@ -71,7 +77,7 @@ let set_active_installations installations =
   installations
 
 let set_active_repos ~installation repos =
-  let+ installation and+ repos in
+  let+ installation = installation and+ repos = repos in
   let owner = Github.Installation.account installation in
   repos
   |> List.fold_left
@@ -90,7 +96,7 @@ let ref_name c =
   | _ -> failwith "Commit is neither a branch nor a PR"
 
 let set_active_refs ~repo refs default_ref =
-  let+ repo and+ xs = refs and+ default = default_ref in
+  let+ repo = repo and+ xs = refs and+ default = default_ref in
   let github_repo = Github.Api.Repo.id repo in
   let repo = { Repo_id.owner = github_repo.owner; name = github_repo.name } in
   let refs =
@@ -108,16 +114,144 @@ let set_active_refs ~repo refs default_ref =
   Index.set_active_refs ~repo refs (ref_from_commit default);
   xs
 
+let get_job_id x =
+  let+ md = Current.Analysis.metadata x in
+  match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
+
+let build_with_docker ?ocluster ?on_cancel ~repo ~analysis ~platforms source =
+  let repo' =
+    Current.map
+      (fun r ->
+        { Repo_id.owner = r.Github.Repo_id.owner; Repo_id.name = r.name })
+      repo
+  in
+  Current.with_context analysis @@ fun () ->
+  let specs =
+    let+ analysis = Current.state ~hidden:true analysis in
+    match analysis with
+    | Error _ ->
+        (* If we don't have the analysis yet, just use the empty list. *)
+        []
+    | Ok analysis -> (
+        match Analyse.Analysis.selections analysis with
+        | `Opam_monorepo builds ->
+            let lint_selection =
+              Opam_monorepo.selection_of_config (List.hd builds)
+            in
+            Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis
+              (`Lint `Fmt)
+            :: Spec.opam_monorepo builds
+        | `Opam_build selections ->
+            let lint_selection = List.hd selections in
+            let lint_ocamlformat =
+              match Analyse.Analysis.ocamlformat_selection analysis with
+              | None -> lint_selection
+              | Some selection -> selection
+            in
+            let builds =
+              selections
+              |> Selection.filter_duplicate_opam_versions
+              |> List.map (fun selection ->
+                     let label =
+                       Variant.to_string selection.Selection.variant
+                     in
+                     Spec.opam ~label ~selection ~analysis `Build)
+            and lint =
+              [
+                Spec.opam ~label:"(lint-fmt)" ~selection:lint_ocamlformat
+                  ~analysis (`Lint `Fmt);
+                Spec.opam ~label:"(lint-doc)" ~selection:lint_selection
+                  ~analysis (`Lint `Doc);
+                Spec.opam ~label:"(lint-opam)" ~selection:lint_selection
+                  ~analysis (`Lint `Opam);
+              ]
+            in
+            lint @ builds)
+  in
+  let builds =
+    specs
+    |> Current.list_map
+         (module Spec)
+         (fun spec ->
+           let+ result =
+             match ocluster with
+             | None -> Build.v ~platforms ~repo:repo' ~spec source
+             | Some ocluster ->
+                 let src = Current.map Git.Commit.id source in
+                 Cluster_build.v ocluster ?on_cancel ~platforms ~repo:repo'
+                   ~spec src
+           and+ spec = spec in
+           (Spec.label spec, result))
+  in
+  let+ builds = builds
+  and+ analysis_result =
+    Current.state ~hidden:true (Current.map (fun _ -> `Checked) analysis)
+  and+ analysis_id = get_job_id analysis in
+  builds @ [ ("(analysis)", (analysis_result, analysis_id)) ]
+
+let list_errors ~ok errs =
+  let groups =
+    (* Group by error message *)
+    List.sort compare errs
+    |> List.fold_left
+         (fun acc (msg, l) ->
+           match acc with
+           | (m2, ls) :: acc' when m2 = msg -> (m2, l :: ls) :: acc'
+           | _ -> (msg, [ l ]) :: acc)
+         []
+  in
+  Error
+    (`Msg
+      (match groups with
+      | [] -> "No builds at all!"
+      | [ (msg, _) ] when ok = 0 ->
+          msg (* Everything failed with the same error *)
+      | [ (msg, ls) ] ->
+          Fmt.str "%a failed: %s" Fmt.(list ~sep:(any ", ") string) ls msg
+      | _ ->
+          (* Multiple error messages; just list everything that failed. *)
+          let pp_label f (_, l) = Fmt.string f l in
+          Fmt.str "%a failed" Fmt.(list ~sep:(any ", ") pp_label) errs))
+
+let summarise results =
+  results
+  |> List.fold_left
+       (fun (ok, pending, err, skip) -> function
+         | _, Ok `Checked ->
+             (ok, pending, err, skip) (* Don't count lint checks *)
+         | _, Ok `Built -> (ok + 1, pending, err, skip)
+         | l, Error (`Msg m) when Astring.String.is_prefix ~affix:"[SKIP]" m ->
+             (ok, pending, err, (m, l) :: skip)
+         | l, Error (`Msg _) when experimental_variant l ->
+             (ok + 1, pending, err, skip)
+         (* Don't fail the commit if an experimental build failed. *)
+         | l, Error (`Msg m) -> (ok, pending, (m, l) :: err, skip)
+         | _, Error (`Active _) -> (ok, pending + 1, err, skip))
+       (0, 0, [], [])
+  |> fun (ok, pending, err, skip) ->
+  if pending > 0 then Error (`Active `Running)
+  else
+    match (ok, err, skip) with
+    | 0, [], skip ->
+        list_errors ~ok:0
+          skip (* Everything was skipped - treat skips as errors *)
+    | _, [], _ -> Ok () (* No errors and at least one success *)
+    | ok, err, _ -> list_errors ~ok err (* Some errors found - report *)
+
 let local_test ~solver repo () =
   let platforms = Conf.fetch_platforms ~include_macos:false () in
   let src = Git.Local.head_commit repo in
-  let repo = Current.return { Repo_id.owner = "local"; name = "test" }
+  let repo = Current.return { Github.Repo_id.owner = "local"; name = "test" }
   and analysis =
     Analyse.examine ~solver ~platforms ~opam_repository_commit src
   in
   Current.component "summarise"
   |> let> results = build_with_docker ~repo ~analysis ~platforms src in
-     let result = results |> summarise in
+     let result =
+       results
+       |> List.map (fun (variant, (build, _job)) -> (variant, build))
+       |> summarise
+     in
      Current_incr.const (result, None)
 
 let v ?ocluster ~app ~solver ~migrations () =
@@ -132,12 +266,17 @@ let v ?ocluster ~app ~solver ~migrations () =
   Current.with_context migrations @@ fun () ->
   Current.with_context opam_repository_commit @@ fun () ->
   Current.with_context platforms @@ fun () ->
-  Github.App.installations app
-  |> set_active_installations
+  let installations =
+    Github.App.installations app |> set_active_installations
+  in
+  installations
   |> Current.list_iter ~collapse_key:"org" (module Github.Installation)
      @@ fun installation ->
-     Github.Installation.repositories installation
-     |> set_active_repos ~installation
+     let repos =
+       Github.Installation.repositories installation
+       |> set_active_repos ~installation
+     in
+     repos
      |> Current.list_iter ~collapse_key:"repo" (module Github.Api.Repo)
         @@ fun repo ->
         let default = Github.Api.Repo.head_commit repo in
@@ -153,39 +292,43 @@ let v ?ocluster ~app ~solver ~migrations () =
            let analysis =
              Analyse.examine ~solver ~platforms ~opam_repository_commit src
            in
-           let builds =
-             let repo =
-               Current.map
-                 (fun x ->
-                   Github.Api.Repo.id x |> fun repo ->
-                   { Repo_id.owner = repo.owner; name = repo.name })
-                 repo
-             in
-             build_with_docker ?ocluster ~repo ~analysis ~platforms src
+           let on_cancel =
+             match ocluster with None -> None | Some _ -> Some ignore
            in
-           let summary = Current.map summarise builds in
+           let builds =
+             let repo = Current.map Github.Api.Repo.id repo in
+             build_with_docker ?ocluster ?on_cancel ~repo ~analysis ~platforms
+               src
+           in
+           let summary =
+             builds
+             |> Current.map
+                  (List.map (fun (variant, (build, _job)) -> (variant, build)))
+             |> Current.map summarise
+           in
            let status =
-             let+ summary in
+             let+ summary = summary in
              match summary with
              | Ok () -> `Passed
              | Error (`Active `Running) -> `Pending
              | Error (`Msg _) -> `Failed
            in
            let index =
-             let+ commit = head and+ builds and+ status in
+             let+ commit = head and+ builds = builds and+ status = status in
              let gref = ref_from_commit commit in
+             let repo = Current_github.Api.Commit.repo_id commit in
              let repo =
-               Current_github.Api.Commit.repo_id commit |> fun repo ->
-               { Repo_id.owner = repo.owner; name = repo.name }
+               { Ocaml_ci.Repo_id.owner = repo.owner; name = repo.name }
              in
              let hash = Current_github.Api.Commit.hash commit in
              let jobs =
-               List.map (fun (variant, (_, job_id)) -> (variant, job_id)) builds
+               builds
+               |> List.map (fun (variant, (_, job_id)) -> (variant, job_id))
              in
              Index.record ~repo ~hash ~status ~gref jobs
            and set_github_status =
              builds
              |> github_status_of_state ~head summary
              |> Github.Api.CheckRun.set_status head "ocaml-ci"
-           in
-           Current.all [ index; set_github_status ]
+           and set_matrix_status = Current.return () in
+           Current.all [ index; set_github_status; set_matrix_status ]

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -292,9 +292,21 @@ let v ?ocluster ~app ~solver ~migrations () =
            let analysis =
              Analyse.examine ~solver ~platforms ~opam_repository_commit src
            in
-           let on_cancel =
-             match ocluster with None -> None | Some _ -> Some ignore
+           let* on_cancel =
+             match ocluster with
+             | None -> Current.return None
+             | Some _ ->
+                 let+ commit = head in
+                 let gref = ref_from_commit commit in
+                 let repo = Current_github.Api.Commit.repo_id commit in
+                 let repo =
+                   { Ocaml_ci.Repo_id.owner = repo.owner; name = repo.name }
+                 in
+                 let hash = Current_github.Api.Commit.hash commit in
+                 Some
+                   (fun _ -> Index.record_summary_on_cancel ~repo ~gref ~hash)
            in
+
            let builds =
              let repo = Current.map Github.Api.Repo.id repo in
              build_with_docker ?ocluster ?on_cancel ~repo ~analysis ~platforms


### PR DESCRIPTION
## Context

This PR intends to fix #703 and avoid losing the information when the job is auto cancelled. To summarise a bit of the issue here, if the job is cancelled by `ocurrent`, we don't trigger `Index.record`, and we take the last entry (`Pending`).

## Step to reproduce the bug

On a repository tracked by `ocaml-ci`:

1. Push a commit to a specific branch.
2. Wait for the job to start and before it's finished, push another commit.
3.  The aggregate state and the history will stay in the `Pending` state.

## Solution

The solution adds a hook to the cancel mechanism and inserts a new entry to the `ci_build_summary` database when triggered by `ocurrent`. It is executed when the job is not reported as `Job complete`.

This solution is, IMO, _ugly_. However, I didn't find a better one. The other possibility was to clean the state when this information is required by `ocaml-ci-web` and update the database, but we would have lost a lot of information about the commit at this point.

I would be happy to replace it with another implementation if there is a better one :owl: 


