### PR TITLE
CSS line numbers for logs

### DIFF
--- a/web-ui/static/css/style.css
+++ b/web-ui/static/css/style.css
@@ -211,10 +211,6 @@ pre.code {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 }
 
-/* pre.code::before {
-  counter-reset: linenum;
-} */
-
 pre.code span.tr {
   display: table-row;
   counter-increment: linenum;
@@ -227,7 +223,7 @@ pre.code span.th { /* used for line numbers */
 
 pre.code span.th::before {
   content: counter(linenum);
-  @apply block text-center text-gray-900 dark:text-gray-100 bg-gray-200 dark:bg-gray-850 text-center px-1 md:px-6 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
+  @apply block text-center text-gray-900 dark:text-gray-100 bg-gray-200 dark:bg-gray-850 px-1 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
 }
 
 pre.code code {

--- a/web-ui/static/css/style.css
+++ b/web-ui/static/css/style.css
@@ -206,34 +206,69 @@ select {
   position: absolute;
 }
 
-
-.code-line:first-child .code-line__number,
-.code-line:first-child .code-line__code {
-  @apply pt-3;
+pre.code {
+  display: table;
+  table-layout: fixed;
+  width: 100%;
+  white-space: pre-wrap;
+  @apply whitespace-pre border-none text-sm;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  border-left: 1px solid transparent;
 }
 
-.code-line:last-child .code-line__number,
-.code-line:last-child .code-line__code {
-  @apply pb-3;
+pre.code::before {
+  counter-reset: linenum;
 }
 
-.code-line__number {
+pre.code span.tr {
+  display: table-row;
+  counter-increment: linenum;
+}
+
+pre.code span.th { /* used for line numbers */
+  display: table-cell;
+  user-select: none;
+  -moz-user-select: none;
+  -webkit-user-select: none;
+}
+
+pre.code span.th::before {
+  content: counter(linenum);
+  text-align: right;
+  display: block;
   @apply text-gray-900 dark:text-gray-100 bg-gray-200 dark:bg-gray-850 text-center px-1 md:px-6 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
 }
 
-.code-line__code {
+pre.code span.th {
+  width: 4em;
+}
+
+pre.code code {
+  display: table-cell;
   @apply px-3 md:px-6 whitespace-pre bg-transparent border-none text-sm ;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   border-left: 1px solid transparent;
 }
 
-.code-line.highlight {
-
-}
-
-.code-line.highlight .code-line__code {
+pre.code span.highlight code {
   background-color: rgb(168, 198, 246);
   border-left: 1px solid rgba(0, 105, 204, 0.64);
+}
+
+pre.code span.tr:first-child span.th {
+  @apply mt-3 bg-gray-200 dark:bg-gray-850;
+}
+
+pre.code span.tr:first-child code {
+  @apply pt-3;
+}
+
+pre.code span.tr:last-child span.th {
+  @apply mb-3 bg-gray-200 dark:bg-gray-850;
+}
+
+pre.code span.tr:last-child code {
+  @apply pb-3;
 }
 
 .copy-link-btn {

--- a/web-ui/static/css/style.css
+++ b/web-ui/static/css/style.css
@@ -207,18 +207,13 @@ select {
 }
 
 pre.code {
-  display: table;
-  table-layout: fixed;
-  width: 100%;
-  white-space: pre-wrap;
-  @apply whitespace-pre border-none text-sm;
+  @apply table table-fixed w-full whitespace-pre-wrap border-l border-solid border-transparent text-sm;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-  border-left: 1px solid transparent;
 }
 
-pre.code::before {
+/* pre.code::before {
   counter-reset: linenum;
-}
+} */
 
 pre.code span.tr {
   display: table-row;
@@ -226,26 +221,17 @@ pre.code span.tr {
 }
 
 pre.code span.th { /* used for line numbers */
-  display: table-cell;
-  user-select: none;
-  -moz-user-select: none;
-  -webkit-user-select: none;
+  @apply table-cell select-none;
+  width: 4em;
 }
 
 pre.code span.th::before {
   content: counter(linenum);
-  text-align: right;
-  display: block;
-  @apply text-gray-900 dark:text-gray-100 bg-gray-200 dark:bg-gray-850 text-center px-1 md:px-6 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
-}
-
-pre.code span.th {
-  width: 4em;
+  @apply block text-center text-gray-900 dark:text-gray-100 bg-gray-200 dark:bg-gray-850 text-center px-1 md:px-6 w-14 text-gray-700 text-sm cursor-pointer select-none border-none;
 }
 
 pre.code code {
-  display: table-cell;
-  @apply px-3 md:px-6 whitespace-pre bg-transparent border-none text-sm ;
+  @apply table-cell px-3 md:px-6 whitespace-pre bg-transparent border-none text-sm ;
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
   border-left: 1px solid transparent;
 }
@@ -256,23 +242,15 @@ pre.code span.highlight code {
 }
 
 pre.code span.tr:first-child span.th {
-  @apply mt-3 bg-gray-200 dark:bg-gray-850;
-}
-
-pre.code span.tr:first-child code {
-  @apply pt-3;
+  @apply pt-3 bg-gray-200 dark:bg-gray-850;
 }
 
 pre.code span.tr:last-child span.th {
-  @apply mb-3 bg-gray-200 dark:bg-gray-850;
-}
-
-pre.code span.tr:last-child code {
-  @apply pb-3;
+  @apply pb-3 bg-gray-200 dark:bg-gray-850;
 }
 
 .copy-link-btn {
-  @apply bg-white absolute -left-3 top-0 rounded w-7 h-7 flex items-center justify-center border border-gray-300 hover:text-blue-500;
+  @apply bg-white dark:bg-gray-800 absolute -left-3 top-0 rounded w-7 h-7 flex items-center justify-center border border-gray-300 hover:text-blue-500;
 }
 
 .sidebar-link {

--- a/web-ui/static/js/add-repro-steps.js
+++ b/web-ui/static/js/add-repro-steps.js
@@ -11,7 +11,7 @@ function extractStepsToReproduce() {
 
   const br = document.createElement("br");
   const reproDiv = document.getElementById("build-repro");
-  const rows = [...tables].map((t) => Array.from(t.rows)).flat(1);
+  const rows = [...tables].map((t) => Array.from(t.children)).flat(1);
 
   document.getElementById("build-repro-container").style.removeProperty('display');
 

--- a/web-ui/static/js/log-highlight.js
+++ b/web-ui/static/js/log-highlight.js
@@ -36,7 +36,6 @@ document.addEventListener('alpine:init', () => {
               if (!this.startingLine) {
                   this.startingLine = currentID;
                   this.endingLine = currentID;
-                  console.log(this.startingLine);
               }
 
               if (this.startingLine) {
@@ -68,7 +67,6 @@ document.addEventListener('alpine:init', () => {
 
               if (this.startingLine) {
                 setTimeout(() => {
-                  console.log(this.startingLine);
                   document.getElementById(`L${this.startingLine}`).scrollIntoView();
                 }, 500)
               }

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -551,10 +551,10 @@ module Make (M : Git_forge_intf.Forge) = struct
     let line_number = ref 0 in
     let last_line_blank = ref false in
     let tabulate data : string =
-      let aux (l : string) log_line =
+      let aux log_line =
         if !last_line_blank && log_line = "" then
           (* Squash consecutive new lines *)
-          l
+          None
         else
           let is_start_of_steps_to_reproduce =
             Astring.String.is_infix ~affix:"To reproduce locally:" log_line
@@ -563,55 +563,46 @@ module Make (M : Git_forge_intf.Forge) = struct
             Astring.String.is_infix ~affix:"END-REPRO-BLOCK" log_line
           in
           let code_line_class =
-            if is_start_of_steps_to_reproduce then
-              "code-line__code repro-block-start"
-            else if is_end_of_steps_to_reproduce then
-              "code-line__code repro-block-end"
-            else "code-line__code"
+            if is_start_of_steps_to_reproduce then "repro-block-start"
+            else if is_end_of_steps_to_reproduce then "repro-block-end"
+            else ""
           in
           last_line_blank := log_line = "";
           line_number := !line_number + 1;
           let line_number_id = Printf.sprintf "L%d" !line_number in
-          Printf.sprintf "%s\n%s" l
-            (Fmt.str "%a" (pp_elt ())
-               (tr
-                  ~a:
-                    [
-                      a_class [ "code-line" ];
-                      Tyxml_helpers.colon_class
-                        "parseInt($el.id.substring(1, $el.id.length)) >= \
-                         startingLine && parseInt($el.id.substring(1, \
-                         $el.id.length)) <= endingLine ? 'highlight' : ''";
-                      Tyxml_helpers.at_click "highlightLine";
-                      a_id line_number_id;
-                    ]
-                  [
-                    td
-                      ~a:
-                        [
-                          a_class [ "code-line__number" ];
-                          a_user_data "line-number" line_number_id;
-                        ]
-                      [ txt (Printf.sprintf "%d" !line_number) ];
-                    td
-                      ~a:
-                        [
-                          a_class [ code_line_class ];
-                          a_user_data "line-number" line_number_id;
-                        ]
-                      [
-                        pre
-                          ~a:[ a_user_data "line-number" line_number_id ]
-                          [ Unsafe.data log_line ];
-                      ];
-                  ]))
+          let line =
+            Fmt.str "%a" (pp_elt ())
+              (span
+                 ~a:
+                   [
+                     a_class [ "tr" ];
+                     Tyxml_helpers.colon_class
+                       "parseInt($el.id.substring(1, $el.id.length)) >= \
+                        startingLine && parseInt($el.id.substring(1, \
+                        $el.id.length)) <= endingLine ? 'highlight' : ''";
+                     Tyxml_helpers.at_click "highlightLine";
+                     a_id line_number_id;
+                   ]
+                 [
+                   span
+                     ~a:
+                       [
+                         a_class [ "th" ];
+                         a_user_data "line-number" line_number_id;
+                       ]
+                     [];
+                   code
+                     ~a:
+                       [
+                         a_class [ code_line_class ];
+                         a_user_data "line-number" line_number_id;
+                       ]
+                     [ Unsafe.data log_line ];
+                 ])
+          in
+          Some line
       in
-      Printf.sprintf "%s%s"
-        (List.fold_left aux
-           "<table data-paste-markdown-skip class='flex steps-table fg-default \
-            bg-default'><tbody class=\"bg-default\">"
-           data)
-        "</tbody></table>"
+      List.filter_map aux data |> String.concat "\n"
     in
     let open Lwt.Infix in
     Dream.stream

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -420,8 +420,23 @@ module Make (M : Git_forge_intf.Forge) = struct
                       ]);
                 ];
               div
-                ~a:[ a_class [ "table-overflow overflow-auto rounded-lg" ] ]
-                [ txt "@@@" ];
+                ~a:
+                  [
+                    a_class
+                      [
+                        "table-overflow overflow-auto rounded-lg fg-default \
+                         bg-default";
+                      ];
+                  ]
+                [
+                  pre
+                    ~a:
+                      [
+                        a_class
+                          [ "flex code steps-table fg-default bg-default" ];
+                      ]
+                    [ txt "@@@" ];
+                ];
             ])
       in
       let link_copied_notification =
@@ -551,6 +566,7 @@ module Make (M : Git_forge_intf.Forge) = struct
     let line_number = ref 0 in
     let last_line_blank = ref false in
     let tabulate data : string =
+      (* let first_idx, last_idx = (0, List.length data - 1) in *)
       let aux log_line =
         if !last_line_blank && log_line = "" then
           (* Squash consecutive new lines *)


### PR DESCRIPTION
Fix for #654 using @novemberkilo's CSS suggestion.

Copying logs no longer pulls in line numbers (tested in Safari 15.2).