### PR TITLE
Introduce issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,0 +1,10 @@
+---
+name: Blank issue
+about: Empty issue
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: type/bug
+assignees: ''
+
+---
+
+## Context
+
+<!-- A clear and concise description of what the bug is. -->
+
+## Step(s) to reproduce
+
+<!-- The instruction to reproduce the bug. If you can't explain why here. -->
+
+## Expected behaviour
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Technical details
+
+<!-- Any technical details that could help us with this issue e.g OS, browser, etc -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->
+
+## Screenshots
+
+<!-- If applicable, add screenshots to help explain your problem. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Missing feature you'd like to see
+title: ''
+labels: type/enhancement
+assignees: ''
+
+---
+
+## Context
+
+<!-- A clear and concise description of what the problem is.  -->
+
+## Expected behaviour 
+
+<!-- A clear and concise description of what you want to happen. -->
+
+## Example
+
+<!-- An example that describes the behaviour.  -->
+
+## Additional context
+
+<!-- Add any other context or screenshots about the feature request here. -->


### PR DESCRIPTION
Being through the various PRs and issues, it was hard to sort out the difference between the requests, discussions and bugs. This is a proposal for the new coming issues that will be raised in the future. Having a bug report and feature request model can make things a bit clearer for us by already assigning the right label and having a common pattern to understand the issue or the request.

My hope is that it will force reporters (us included) to describe the problem in a more structured way. The `blank issue` is here to keep the possibility of opening a specific issue.

WDYT?