### PR TITLE
Add lower-bounds builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
 	branch = master
 [submodule "solver-service"]
 	path = solver-service
-	url = https://github.com/ocurrent/solver-service.git
-	branch = solver-ci
+	url = https://github.com/benmandrew/solver-service.git
+	branch = lower-bound

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,5 +16,5 @@
 	branch = master
 [submodule "solver-service"]
 	path = solver-service
-	url = https://github.com/benmandrew/solver-service.git
-	branch = lower-bound
+	url = https://github.com/ocurrent/solver-service.git
+	branch = solver-ci

--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -9,7 +9,8 @@ module Analysis : sig
 
   val selections :
     t ->
-    [ `Opam_build of Selection.t list
+    [ `Opam_build of
+      [ `Default of Selection.t list ] * [ `Lower_bound of Selection.t list ]
     | `Opam_monorepo of Opam_monorepo.config list ]
 
   val of_dir :

--- a/lib/dune
+++ b/lib/dune
@@ -20,4 +20,5 @@
   current_ocluster
   ocluster-api
   solver-worker
-  obuilder-spec))
+  obuilder-spec
+  dockerfile-opam))

--- a/test/service/test_analyse.ml
+++ b/test/service/test_analyse.ml
@@ -43,7 +43,8 @@ module Analysis = struct
   let selections (t : t) =
     match selections t with
     | `Opam_monorepo _ -> []
-    | `Opam_build s -> List.map selection s
+    | `Opam_build (`Default s, _) ->
+        List.map selection s (* TODO: Add testing of lower_bound analysis *)
 
   (* Make the [t] type concrete from the observable fields for easier testing *)
   type t = {


### PR DESCRIPTION
We do a second call to `solver-service` to get the lower-bounds selection of packages. This PR depends on https://github.com/ocurrent/solver-service/pull/34.

Currently all variants are built twice, once normally and once with lower bounds. However this is expensive and it may be more practical to only build lower-bounds variants with the earliest listed version of OCaml.