### PR TITLE
Fix 'steps to reproduce' code block

### DIFF
--- a/web-ui/static/js/add-repro-steps.js
+++ b/web-ui/static/js/add-repro-steps.js
@@ -17,7 +17,7 @@ function extractStepsToReproduce() {
 
   for (let i = (startIndex); i < (finishIndex - 1); i++) {
     // Remove line-number, whitespace and possible newlines from the row
-    const newContent = document.createTextNode(rows[i].innerText.replace(/\d+\s*\n?/, ''));
+    const newContent = document.createTextNode(rows[i].innerText.replace(/\s*\n?/, ''));
     reproDiv.appendChild(newContent);
     reproDiv.appendChild(br.cloneNode());
   }

--- a/web-ui/static/js/add-repro-steps.js
+++ b/web-ui/static/js/add-repro-steps.js
@@ -19,7 +19,9 @@ function extractStepsToReproduce() {
     // Remove line-number, whitespace and possible newlines from the row
     const newContent = document.createTextNode(rows[i].innerText.replace(/\s*\n?/, ''));
     reproDiv.appendChild(newContent);
-    reproDiv.appendChild(br.cloneNode());
+    if (i > startIndex) {
+      reproDiv.appendChild(br.cloneNode());
+    }
   }
 }
 

--- a/web-ui/static/js/log-highlight.js
+++ b/web-ui/static/js/log-highlight.js
@@ -23,54 +23,57 @@ document.addEventListener('alpine:init', () => {
         },
 
         positionCopyButton(e) {
-            this.$refs.copyLinkBtn.style.top = `${e.layerY-15}px`;
+          this.$refs.copyLinkBtn.style.top = `${e.layerY-15}px`;
         },
 
         highlightLine(e) {
-            if (e) {
-              const currentLine = e.target.dataset.lineNumber;
-              const currentID = parseInt(currentLine.substring(1, currentLine.length));
-              this.manualSelection = true;
-              this.positionCopyButton(e);
+          if (e) {
+            var currentLine = e.target.dataset.lineNumber;
+            if (currentLine == undefined) {
+              currentLine = e.target.parentNode.dataset.lineNumber;
+            }
+            const currentID = parseInt(currentLine.substring(1, currentLine.length));
+            this.manualSelection = true;
+            this.positionCopyButton(e);
 
-              if (!this.startingLine) {
+            if (!this.startingLine) {
+              this.startingLine = currentID;
+              this.endingLine = currentID;
+            }
+
+            if (this.startingLine) {
+              if (e.shiftKey) {
+                if (currentID > this.startingLine) {
+                  this.endingLine = currentID;
+                } else if (currentID < this.startingLine) {
+                  this.endingLine = this.startingLine;
+                  this.startingLine = currentID;
+                } else {
                   this.startingLine = currentID;
                   this.endingLine = currentID;
-              }
-
-              if (this.startingLine) {
-                  if (e.shiftKey) {
-                      if (currentID > this.startingLine) {
-                          this.endingLine = currentID;
-                      } else if (currentID < this.startingLine) {
-                          this.endingLine = this.startingLine;
-                          this.startingLine = currentID;
-                      } else {
-                          this.startingLine = currentID;
-                          this.endingLine = currentID;
-                      }
-                  } else {
-                      this.startingLine = currentID;
-                      this.endingLine = currentID;
-                      this.linkCopied = false;
-                  }
-              }
-            } else {
-              const index = this.url.indexOf("#")+2;
-
-              if (index >= 0) {
-                const lines = this.url.substring(index, this.url.length);
-                const lineNumbers = lines.split("-");
-                this.startingLine = parseInt(lineNumbers[0]);
-                this.endingLine = parseInt(lineNumbers[1]);
-              }
-
-              if (this.startingLine) {
-                setTimeout(() => {
-                  document.getElementById(`L${this.startingLine}`).scrollIntoView();
-                }, 500)
+                }
+              } else {
+                this.startingLine = currentID;
+                this.endingLine = currentID;
+                this.linkCopied = false;
               }
             }
+          } else {
+            const index = this.url.indexOf("#")+2;
+
+            if (index >= 0) {
+              const lines = this.url.substring(index, this.url.length);
+              const lineNumbers = lines.split("-");
+              this.startingLine = parseInt(lineNumbers[0]);
+              this.endingLine = parseInt(lineNumbers[1]);
+            }
+
+            if (this.startingLine) {
+              setTimeout(() => {
+                document.getElementById(`L${this.startingLine}`).scrollIntoView();
+              }, 500)
+            }
+          }
         }
     }))
 })

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -347,7 +347,7 @@ module Make (M : Git_forge_intf.Forge) = struct
                     Tyxml_helpers.x_ref "container1";
                     Tyxml_helpers.x_bind_style
                       "stepsToRepro == 1 ? 'max-height: ' + \
-                       $refs.container1.scrollHeight + 'px' : ''";
+                       ($refs.container1.scrollHeight + 20) + 'px' : ''";
                   ]
                 [
                   div

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -439,14 +439,14 @@ module Make (M : Git_forge_intf.Forge) = struct
                 ];
             ])
       in
-      let link_copied_notification =
+      let notification ~variable ~text =
         Tyxml.Html.(
           div
             ~a:
               [
                 a_class [ "notification dark:bg-gray-850" ];
                 Tyxml_helpers.x_cloak;
-                Tyxml_helpers.x_show "linkCopied";
+                Tyxml_helpers.x_show variable;
                 Tyxml_helpers.x_transition;
               ]
             [
@@ -480,13 +480,13 @@ module Make (M : Git_forge_intf.Forge) = struct
                               [];
                           ]);
                     ];
-                  div [ txt "Link copied" ];
+                  div [ txt text ];
                 ];
               Tyxml.Html.button
                 ~a:
                   [
                     a_class [ "icon-button" ];
-                    Tyxml_helpers.at_click "linkCopied=false";
+                    Tyxml_helpers.at_click (Printf.sprintf "%s=false" variable);
                   ]
                 [
                   Tyxml.Svg.(
@@ -539,7 +539,8 @@ module Make (M : Git_forge_intf.Forge) = struct
                      manualSelection: false}";
                 ]
               [
-                link_copied_notification;
+                notification ~variable:"linkCopied" ~text:"Link Copied";
+                notification ~variable:"codeCopied" ~text:"Code Copied";
                 div
                   ~a:
                     [


### PR DESCRIPTION
Fix for #728.

With the introduction of CSS line numbers, the JS trying to strip out real line numbers lead to the removal of numbers in the logs themselves.