### PR TITLE
Limit the number of analysis by solver-service

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -5,7 +5,7 @@ module Worker = Ocaml_ci_api.Worker
 (* This pool ensures we don't overload the Forge API. *)
 let pool = Current.Pool.create ~label:"analyse" 20
 
-(* This pool ensures we don't overload the solver service by opening to many connections. *)
+(* This pool ensures we don't overload the solver service by opening too many connections. *)
 let pool_service = Current.Pool.create ~label:"solver" 140
 
 let is_empty_file x =


### PR DESCRIPTION
Currently, the solver service is overloaded by the number of requests sent.

The limit is set at 140 as the solver-service capacity is 120, and we want to keep a small queue to avoid delay.
