### PR TITLE
Add log highlight for dark-mode

### DIFF
--- a/web-ui/static/css/style.css
+++ b/web-ui/static/css/style.css
@@ -232,8 +232,7 @@ pre.code code {
 }
 
 pre.code span.highlight code {
-  background-color: rgb(168, 198, 246);
-  border-left: 1px solid rgba(0, 105, 204, 0.64);
+  @apply bg-sky-200 dark:bg-sky-900
 }
 
 pre.code span.tr:first-child span.th {


### PR DESCRIPTION
Make it easier to read highlighted text in darkmode. I have switched to standard Tailwind colours that look about right to me, I'm open to suggestions for colour changes.

Feedback from https://github.com/ocurrent/ocaml-ci/issues/607#issuecomment-1405419235.