### PR TITLE
Web-ui: remanent bugs from the past

### DIFF
--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -122,6 +122,19 @@ let gitlab_routes gitlab =
         | _ ->
             Dream.log "Form validation failed";
             Dream.empty `Bad_Request);
+    Dream.get "/api/gitlab/:org/:repo/commit/:hash/variant/:variant"
+      (fun request ->
+        Api_controller.Gitlab.show_step
+          ~org:(Dream.param request "org")
+          ~repo:(Dream.param request "repo")
+          ~hash:(Dream.param request "hash")
+          ~variant:(Dream.param request "variant")
+          gitlab);
+    Dream.get "/api/gitlab/:org/:repo/commit/:hash" (fun request ->
+        let org = Dream.param request "org" in
+        let repo = Dream.param request "repo" in
+        let hash = Dream.param request "hash" in
+        Api_controller.Gitlab.list_steps ~org ~repo ~hash gitlab);
   ]
 
 let github_routes github =

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -2,11 +2,18 @@ open Lwt.Infix
 
 (* ocaml-crunch is used to generate the module Static.
    See also https://github.com/aantron/dream/tree/master/example/w-one-binary *)
-let loader root path _request =
+let loader ?(caching = false) root path _request =
   Dream.log "In loader. root: %s path: %s" root path;
   match Static.read (Filename.concat root path) with
   | None -> Dream.empty `Not_Found
-  | Some asset -> Dream.respond asset
+  | Some asset ->
+      let headers =
+        if caching then
+          (* Kept in cache for a month. The ocaml-ci changes are regular so we don't keep it too long. . *)
+          [ ("Cache-Control", "max-age=2419200") ]
+        else []
+      in
+      Dream.respond ~headers asset
 
 (* All routes relating to GitLab hosted projects. *)
 let gitlab_routes gitlab =
@@ -291,7 +298,8 @@ let create ~github ~gitlab =
        Dream.get "/css/**" @@ Dream.static ~loader "/css";
        Dream.get "/images/**" @@ Dream.static ~loader "/images";
        Dream.get "/js/**" @@ Dream.static ~loader "/js";
-       Dream.get "/fonts/**" @@ Dream.static ~loader "/fonts";
+       Dream.get "/fonts/**"
+       @@ Dream.static ~loader:(loader ~caching:true) "/fonts";
        Dream.get "/profile-pictures/**" @@ Dream.static "profile-pictures";
        Dream.get "/" (fun _ ->
            match (github, gitlab) with

--- a/web-ui/static/fonts/inter.css
+++ b/web-ui/static/fonts/inter.css
@@ -2,7 +2,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 100;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Thin.woff2?v=3.19") format("woff2"),
        url("Inter-Thin.woff?v=3.19") format("woff");
 }
@@ -10,7 +10,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 100;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-ThinItalic.woff2?v=3.19") format("woff2"),
        url("Inter-ThinItalic.woff?v=3.19") format("woff");
 }
@@ -19,7 +19,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-ExtraLight.woff2?v=3.19") format("woff2"),
        url("Inter-ExtraLight.woff?v=3.19") format("woff");
 }
@@ -27,7 +27,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 200;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-ExtraLightItalic.woff2?v=3.19") format("woff2"),
        url("Inter-ExtraLightItalic.woff?v=3.19") format("woff");
 }
@@ -36,7 +36,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 300;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Light.woff2?v=3.19") format("woff2"),
        url("Inter-Light.woff?v=3.19") format("woff");
 }
@@ -44,7 +44,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 300;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-LightItalic.woff2?v=3.19") format("woff2"),
        url("Inter-LightItalic.woff?v=3.19") format("woff");
 }
@@ -53,7 +53,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Regular.woff2?v=3.19") format("woff2"),
        url("Inter-Regular.woff?v=3.19") format("woff");
 }
@@ -61,7 +61,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 400;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Italic.woff2?v=3.19") format("woff2"),
        url("Inter-Italic.woff?v=3.19") format("woff");
 }
@@ -70,7 +70,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Medium.woff2?v=3.19") format("woff2"),
        url("Inter-Medium.woff?v=3.19") format("woff");
 }
@@ -78,7 +78,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 500;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-MediumItalic.woff2?v=3.19") format("woff2"),
        url("Inter-MediumItalic.woff?v=3.19") format("woff");
 }
@@ -87,7 +87,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-SemiBold.woff2?v=3.19") format("woff2"),
        url("Inter-SemiBold.woff?v=3.19") format("woff");
 }
@@ -95,7 +95,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 600;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-SemiBoldItalic.woff2?v=3.19") format("woff2"),
        url("Inter-SemiBoldItalic.woff?v=3.19") format("woff");
 }
@@ -104,7 +104,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Bold.woff2?v=3.19") format("woff2"),
        url("Inter-Bold.woff?v=3.19") format("woff");
 }
@@ -112,7 +112,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 700;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-BoldItalic.woff2?v=3.19") format("woff2"),
        url("Inter-BoldItalic.woff?v=3.19") format("woff");
 }
@@ -121,7 +121,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 800;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-ExtraBold.woff2?v=3.19") format("woff2"),
        url("Inter-ExtraBold.woff?v=3.19") format("woff");
 }
@@ -129,7 +129,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 800;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-ExtraBoldItalic.woff2?v=3.19") format("woff2"),
        url("Inter-ExtraBoldItalic.woff?v=3.19") format("woff");
 }
@@ -138,7 +138,7 @@
   font-family: 'Inter';
   font-style:  normal;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-Black.woff2?v=3.19") format("woff2"),
        url("Inter-Black.woff?v=3.19") format("woff");
 }
@@ -146,7 +146,7 @@
   font-family: 'Inter';
   font-style:  italic;
   font-weight: 900;
-  font-display: swap;
+  font-display: block;
   src: url("Inter-BlackItalic.woff2?v=3.19") format("woff2"),
        url("Inter-BlackItalic.woff?v=3.19") format("woff");
 }
@@ -163,7 +163,7 @@ Usage:
 @font-face {
   font-family: 'Inter var';
   font-weight: 100 900;
-  font-display: swap;
+  font-display: block;
   font-style: normal;
   font-named-instance: 'Regular';
   src: url("Inter-roman.var.woff2?v=3.19") format("woff2");
@@ -171,7 +171,7 @@ Usage:
 @font-face {
   font-family: 'Inter var';
   font-weight: 100 900;
-  font-display: swap;
+  font-display: block;
   font-style: italic;
   font-named-instance: 'Italic';
   src: url("Inter-italic.var.woff2?v=3.19") format("woff2");
@@ -194,7 +194,7 @@ explicitly, e.g.
 @font-face {
   font-family: 'Inter var experimental';
   font-weight: 100 900;
-  font-display: swap;
+  font-display: block;
   font-style: oblique 0deg 10deg;
   src: url("Inter.var.woff2?v=3.19") format("woff2");
 }

--- a/web-ui/view/index.ml
+++ b/web-ui/view/index.ml
@@ -53,12 +53,8 @@ let list_orgs prefix orgs =
             ];
         ];
       div
-        ~a:[ a_class [ "flex mb-4" ] ]
-        [
-          div
-            ~a:[ a_id "table"; a_class [ "flex-col space-y-6" ] ]
-            (rows prefix orgs);
-        ];
+        ~a:[ a_id "table"; a_class [ "mt-8 grid gap-x-4 md:grid-cols-2" ] ]
+        (rows prefix orgs);
     ]
 
 (** TODO: this function can be factorized with the one above. *)

--- a/web-ui/view/index.ml
+++ b/web-ui/view/index.ml
@@ -39,7 +39,7 @@ let list_orgs prefix orgs =
                 [ txt "Here are the organisations registered with us" ];
             ];
           div
-            ~a:[ a_class [ "form-control relative max-w-80" ] ]
+            ~a:[ a_class [ "form-control max-w-80" ] ]
             [
               Common.search;
               input
@@ -98,7 +98,7 @@ let list_all_orgs ~github_orgs ~gitlab_orgs =
               ]
             [
               div
-                ~a:[ a_class [ "form-control relative max-w-80 pb-6 md:pb-0" ] ]
+                ~a:[ a_class [ "form-control max-w-80 pb-6 md:pb-0" ] ]
                 [
                   Common.search;
                   input

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -153,15 +153,6 @@ module Make (M : Git_forge_intf.Forge) = struct
         ~total_run_time:(Timestamps_durations.pp_duration (Some total_run_time))
         ~buttons
     in
-    let steps_table_div =
-      div
-        ~a:
-          [
-            a_class [ "bg-gray-50 px-6 py-3 text-gray-500 text-xs font-medium" ];
-          ]
-          (* TODO: We need to start with no stage separation - introduce Analysis/Checks and Build steps later *)
-        [ txt "Build" ]
-    in
     let steps_table =
       List.fold_left
         (fun l j ->
@@ -185,7 +176,7 @@ module Make (M : Git_forge_intf.Forge) = struct
               Build.step_row ~step_title:j.variant ~created_at ~queued_for
                 ~ran_for ~status:j.outcome ~step_uri;
             ])
-        [ steps_table_div ] jobs
+        [] jobs
     in
     Template.instance
       [

--- a/web-ui/view/template.ml
+++ b/web-ui/view/template.ml
@@ -19,9 +19,13 @@ let head =
         ();
       script ~a:[ a_defer (); a_src "/js/alpine-clipboard.js" ] (txt "");
       script ~a:[ a_defer (); a_src "/js/alpine.js" ] (txt "");
-      link ~rel:[ `Stylesheet ] ~href:"/fonts/inter.css" ();
-      link ~rel:[ `Stylesheet ] ~href:"/css/main.css" ();
-      link ~rel:[ `Stylesheet ] ~href:"/css/ansi.css" ();
+      link
+        ~a:[ a_media [ `All ] ]
+        ~rel:[ `Stylesheet ] ~href:"/fonts/inter.css" ();
+      link
+        ~a:[ a_media [ `Screen ] ]
+        ~rel:[ `Stylesheet ] ~href:"/css/main.css" ();
+      link ~a:[ a_media [ `All ] ] ~rel:[ `Stylesheet ] ~href:"/css/ansi.css" ();
     ]
 
 let header ~full =


### PR DESCRIPTION
This PR fixes two bugs:
- Partial fix for #626. There were two bugs in one. The `Build` header for the table disappeared as the JS script did not rebuild it. This PR completely removes the header, as it's not needed in the current version (correction 1). This bug didn't appear in the GitLab version, as the links to the API weren't available in the GitLab routes. This PR introduces these links in the GitLab router (correction2). @benmandrew mentioned that we could merge the router as the behaviour is the same, and I agree with his suggestion as it will make the code easier to maintain. 
- It also fixes a bug in the `Organisation` page by conforming it with the "two organisations" pages. Indeed, the design for one organisation differs from the one from the mixed organisation page. These two functions should be merged at some point and display the organisation we ask.
- Fixes #626 for good. It improves the rendering by caching the fonts for a month (for now, as we still move fast), blocking the rendering until the font is loaded and specifying the type of screen for render optimisation.

I opened an issue to track the refactoring we could do: #746