### PR TITLE
Factorize organisation code

### DIFF
--- a/web-ui/controller/index.ml
+++ b/web-ui/controller/index.ml
@@ -1,21 +1,21 @@
 module Client = Ocaml_ci_api.Client
 
-let ( >>!= ) = Git_forge.( >>!= )
+let ( >>!!= ) = Git_forge.( >>!= )
+let ( >|!= ) a f = Lwt_result.map f a
 
-let list_orgs prefix ci =
+let list_orgs ~orgs =
   let open Lwt.Infix in
-  Backend.ci ci >>= Client.CI.orgs_detailed >>!= fun orgs ->
-  let orgs = List.filter (fun o -> o.Client.CI.number_repos > 0) orgs in
-  Dream.respond @@ View.Index.list_orgs prefix orgs
-
-let list_all_orgs ~github ~gitlab =
-  let open Lwt.Infix in
-  Backend.ci gitlab >>= Client.CI.orgs_detailed >>!= fun gitlab_orgs ->
-  Backend.ci github >>= Client.CI.orgs_detailed >>!= fun github_orgs ->
-  let github_orgs =
-    List.filter (fun o -> o.Client.CI.number_repos > 0) github_orgs
+  let extract ((prefix, name, backend) : string * string * Backend.t) =
+    Backend.ci backend
+    >>= Client.CI.orgs_detailed
+    >|!= List.filter (fun o -> o.Client.CI.number_repos > 0)
+    >|!= fun orgs -> (prefix, name, orgs)
   in
-  let gitlab_orgs =
-    List.filter (fun o -> o.Client.CI.number_repos > 0) gitlab_orgs
+  let to_result_list orgs org =
+    match org with
+    | Ok org -> Result.map (fun orgs -> org :: orgs) orgs
+    | Error _ -> orgs
   in
-  Dream.respond @@ View.Index.list_all_orgs ~github_orgs ~gitlab_orgs
+  Lwt_list.map_p extract orgs
+  |> Lwt.map (fun orgs -> List.fold_left to_result_list (Ok []) orgs)
+  >>!!= fun orgs -> Dream.respond @@ View.Index.list_orgs ~orgs

--- a/web-ui/controller/index.ml
+++ b/web-ui/controller/index.ml
@@ -6,12 +6,12 @@ let list_orgs ~orgs =
   let open Lwt.Syntax in
   let extract (prefix, name, backend) =
     let* ci = Backend.ci backend in
-    let+ detailled_orgs = Client.CI.orgs_detailed ci in
+    let+ detailed_orgs = Client.CI.orgs_detailed ci in
     let filter orgs =
       let orgs = List.filter (fun o -> o.Client.CI.number_repos > 0) orgs in
       (prefix, name, orgs)
     in
-    Result.map filter detailled_orgs
+    Result.map filter detailed_orgs
   in
   let to_lwt_result acc res =
     Result.bind res (fun res -> Result.map (fun acc -> res :: acc) acc)

--- a/web-ui/controller/index.ml
+++ b/web-ui/controller/index.ml
@@ -1,21 +1,21 @@
 module Client = Ocaml_ci_api.Client
 
-let ( >>!!= ) = Git_forge.( >>!= )
-let ( >|!= ) a f = Lwt_result.map f a
+let ( >>!= ) = Git_forge.( >>!= )
 
 let list_orgs ~orgs =
-  let open Lwt.Infix in
-  let extract ((prefix, name, backend) : string * string * Backend.t) =
-    Backend.ci backend
-    >>= Client.CI.orgs_detailed
-    >|!= List.filter (fun o -> o.Client.CI.number_repos > 0)
-    >|!= fun orgs -> (prefix, name, orgs)
+  let open Lwt.Syntax in
+  let extract (prefix, name, backend) =
+    let* ci = Backend.ci backend in
+    let+ detailled_orgs = Client.CI.orgs_detailed ci in
+    let filter orgs =
+      let orgs = List.filter (fun o -> o.Client.CI.number_repos > 0) orgs in
+      (prefix, name, orgs)
+    in
+    Result.map filter detailled_orgs
   in
-  let to_result_list orgs org =
-    match org with
-    | Ok org -> Result.map (fun orgs -> org :: orgs) orgs
-    | Error _ -> orgs
+  let to_lwt_result acc res =
+    Result.bind res (fun res -> Result.map (fun acc -> res :: acc) acc)
   in
   Lwt_list.map_p extract orgs
-  |> Lwt.map (fun orgs -> List.fold_left to_result_list (Ok []) orgs)
-  >>!!= fun orgs -> Dream.respond @@ View.Index.list_orgs ~orgs
+  |> Lwt.map (fun orgs -> List.fold_left to_lwt_result (Ok []) orgs)
+  >>!= fun orgs -> Dream.respond @@ View.Index.list_orgs ~orgs

--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -306,10 +306,16 @@ let create ~github ~gitlab =
            | None, None ->
                Dream.log "No backend available";
                Dream.empty `Internal_Server_Error
-           | Some github, None -> Controller.Index.list_orgs "github" github
-           | None, Some gitlab -> Controller.Index.list_orgs "gitlab" gitlab
+           | Some github, None ->
+               let orgs = [ ("github", "GitHub", github) ] in
+               Controller.Index.list_orgs ~orgs
+           | None, Some gitlab ->
+               Controller.Index.list_orgs ~orgs:[ ("gitlab", "GitLab", gitlab) ]
            | Some github, Some gitlab ->
-               Controller.Index.list_all_orgs ~github ~gitlab);
+               let orgs =
+                 [ ("github", "GitHub", github); ("gitlab", "GitLab", gitlab) ]
+               in
+               Controller.Index.list_orgs ~orgs);
        Dream.get "/getting-started" (fun _ ->
            Dream.html @@ Controller.Documentation.getting_started);
        Dream.get "/documentation" (fun _ ->

--- a/web-ui/view/index.ml
+++ b/web-ui/view/index.ml
@@ -13,56 +13,41 @@ let rows prefix orgs =
   let orgs = List.sort compare orgs in
   List.fold_left (fun l org -> List.append l [ row ~org ]) [] orgs
 
-let list_orgs prefix orgs =
-  Template.instance
-    [
-      Tyxml.Html.script ~a:[ a_src "/js/index-page-org-search.js" ] (txt "");
-      div
-        ~a:
+let search_bar_options = function
+  | [] | [ _ ] -> []
+  | orgs ->
+      let build_option =
+        option ~a:[ a_value "all" ] (txt "all")
+        :: List.map
+             (fun (prefix, name, _) -> option ~a:[ a_value prefix ] (txt name))
+             orgs
+      in
+      [
+        div
+          ~a:[ a_class [ "relative" ] ]
           [
-            a_class [ "flex flex-col md:flex-row justify-between items-center" ];
-          ]
-        [
-          div
-            ~a:
-              [
-                a_class
-                  [
-                    "flex flex-col space-y-1 items-center md:items-start py-8 \
-                     md:py-0";
-                  ];
-              ]
-            [
-              h1 [ txt "Welcome to OCaml-CI" ];
-              div
-                ~a:[ a_class [ "text-gray-500" ] ]
-                [ txt "Here are the organisations registered with us" ];
-            ];
-          div
-            ~a:[ a_class [ "form-control max-w-80" ] ]
-            [
-              Common.search;
-              input
-                ~a:
-                  [
-                    a_input_type `Text;
-                    a_placeholder "Search for an organisation";
-                    a_oninput "search(this.value)";
-                  ]
-                ();
-            ];
-        ];
-      div
-        ~a:[ a_id "table"; a_class [ "mt-8 grid gap-x-4 md:grid-cols-2" ] ]
-        (rows prefix orgs);
-    ]
+            select
+              ~a:
+                [
+                  a_class
+                    [
+                      "input-control relative input-text text-gray-500 \
+                       dark:text-gray-300 bg-gray-100 dark:bg-gray-850 \
+                       items-center justify-between flex px-3 py-2 \
+                       appearance-none";
+                    ];
+                  a_name "Languages";
+                  a_onchange "filter(this.value)";
+                ]
+              build_option;
+          ];
+      ]
 
-(** TODO: this function can be factorized with the one above. *)
-let list_all_orgs ~github_orgs ~gitlab_orgs =
-  let github_org_rows = rows "github" github_orgs in
-  let gitlab_org_rows = rows "gitlab" gitlab_orgs in
-  let org_rows = github_org_rows @ gitlab_org_rows in
-
+let list_orgs ~orgs =
+  let org_rows =
+    let generate (prefix, _, orgs) = rows prefix orgs in
+    List.map generate orgs |> List.flatten
+  in
   Template.instance
     [
       Tyxml.Html.script ~a:[ a_src "/js/index-page-org-search.js" ] (txt "");
@@ -96,43 +81,22 @@ let list_all_orgs ~github_orgs ~gitlab_orgs =
                      space-x-3";
                   ];
               ]
-            [
-              div
-                ~a:[ a_class [ "form-control max-w-80 pb-6 md:pb-0" ] ]
-                [
-                  Common.search;
-                  input
-                    ~a:
-                      [
-                        a_input_type `Text;
-                        a_placeholder "Search for an organisation";
-                        a_oninput "search(this.value)";
-                      ]
-                    ();
-                ];
-              div
-                ~a:[ a_class [ "relative" ] ]
-                [
-                  select
-                    ~a:
-                      [
-                        a_class
-                          [
-                            "input-control relative input-text text-gray-500 \
-                             dark:text-gray-300 bg-gray-100 dark:bg-gray-850 \
-                             items-center justify-between flex px-3 py-2 \
-                             appearance-none";
-                          ];
-                        a_name "Languages";
-                        a_onchange "filter(this.value)";
-                      ]
-                    [
-                      option ~a:[ a_value "all" ] (txt "All");
-                      option ~a:[ a_value "gitlab" ] (txt "Gitlab");
-                      option ~a:[ a_value "github" ] (txt "GitHub");
-                    ];
-                ];
-            ];
+            ([
+               div
+                 ~a:[ a_class [ "form-control max-w-80 pb-6 md:pb-0" ] ]
+                 [
+                   Common.search;
+                   input
+                     ~a:
+                       [
+                         a_input_type `Text;
+                         a_placeholder "Search for an organisation";
+                         a_oninput "search(this.value)";
+                       ]
+                     ();
+                 ];
+             ]
+            @ search_bar_options orgs);
         ];
       div
         ~a:[ a_id "table"; a_class [ "mt-8 grid gap-x-4 md:grid-cols-2" ] ]

--- a/web-ui/view/index.ml
+++ b/web-ui/view/index.ml
@@ -46,7 +46,7 @@ let search_bar_options = function
 let list_orgs ~orgs =
   let org_rows =
     let generate (prefix, _, orgs) = rows prefix orgs in
-    List.map generate orgs |> List.flatten
+    List.concat_map generate orgs
   in
   Template.instance
     [

--- a/web-ui/view/index.ml
+++ b/web-ui/view/index.ml
@@ -17,7 +17,7 @@ let search_bar_options = function
   | [] | [ _ ] -> []
   | orgs ->
       let build_option =
-        option ~a:[ a_value "all" ] (txt "all")
+        option ~a:[ a_value "all" ] (txt "All")
         :: List.map
              (fun (prefix, name, _) -> option ~a:[ a_value prefix ] (txt name))
              orgs


### PR DESCRIPTION
This is a partial fix for #746. It factorizes the code for the organisation page to avoid having `list_orgs` and `list_all_orgs` separated functions. The two functions are replaced by a single function, `list_orgs`, that takes a list of `(prefix, name, backend)`.