### PR TITLE
Patch gitlab temporarily.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,3 +18,6 @@
 	path = solver-service
 	url = https://github.com/ocurrent/solver-service.git
 	branch = solver-ci
+[submodule "ocaml-gitlab"]
+	path = ocaml-gitlab
+	url = https://github.com/tmcgilchrist/ocaml-gitlab.git

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -23,11 +23,17 @@ COPY --chown=opam \
 	ocaml-version/ocaml-version.opam \
 	/src/ocaml-version/
 COPY --chown=opam \
+	ocaml-gitlab/gitlab.opam \
+	ocaml-gitlab/gitlab-unix.opam \
+	/src/ocaml-gitlab/
+COPY --chown=opam \
 	ocaml-dockerfile/dockerfile*.opam \
 	/src/ocaml-dockerfile/
 WORKDIR /src
 RUN opam pin add -yn current_docker.dev "./ocurrent" && \
     opam pin add -yn current_github.dev "./ocurrent" && \
+    opam pin add -yn gitlab.dev "./ocaml-gitlab/" && \
+    opam pin add -yn gitlab-unix.dev "./ocaml-gitlab/" && \
     opam pin add -yn current_gitlab.dev "./ocurrent" && \
     opam pin add -yn current_git.dev "./ocurrent" && \
     opam pin add -yn current.dev "./ocurrent" && \

--- a/dune
+++ b/dune
@@ -20,5 +20,6 @@
  opam-0install-solver
  ocluster
  ocaml-version
+ ocaml-gitlab
  solver-service
  ocaml-dockerfile)


### PR DESCRIPTION
Bugfix release pending on opam-repository gitlab,gitlab-unix 0.1.7.

See https://github.com/tmcgilchrist/ocaml-gitlab/pull/75. 
Fixes issues with deserialising the projects introduced with https://github.com/ocurrent/ocaml-ci/pull/749