### PR TITLE
Allow packages to choose to accept failures on experimental distros

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -174,9 +174,7 @@ module Analysis = struct
           else Some pkg_version
         in
         match List.filter_map has_no_platform root_pkgs with
-        | [] ->
-            let root_pkgs = List.map fst root_pkgs in
-            Ok (List.map (Selection.of_worker ~root_pkgs) x)
+        | [] -> Ok (List.map Selection.of_worker x)
         | missing_pkgs ->
             Fmt.error_msg "No solution found for %a on any supported platform"
               Fmt.(list ~sep:comma Dump.string)

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -31,7 +31,8 @@ let commit_from_ocamlformat_source ocamlformat_source =
 
 let fmt_spec ~base ~ocamlformat_source ~selection =
   let open Obuilder_spec in
-  let { Selection.packages = _; commit; variant = _; only_packages = _ } =
+  let { Selection.packages = _; commit; variant = _; compatible_root_pkgs = _ }
+      =
     selection
   in
   let commit =
@@ -79,9 +80,9 @@ let doc_spec ~base ~opam_files ~selection =
   let open Obuilder_spec in
   let to_name x = OpamPackage.of_string x |> OpamPackage.name_to_string in
   let only_packages =
-    match selection.Selection.only_packages with
-    | [] -> ""
-    | pkgs -> " --only-packages=" ^ String.concat "," (List.map to_name pkgs)
+    " --only-packages="
+    ^ String.concat ","
+        (List.map to_name selection.Selection.compatible_root_pkgs)
   in
   stage ~from:base
   @@ comment "%s" (Fmt.str "%a" Variant.pp selection.Selection.variant)

--- a/lib/selection.ml
+++ b/lib/selection.ml
@@ -1,19 +1,22 @@
 type t = {
   variant : Variant.t;  (** The variant image to build on. *)
   packages : string list;  (** The selected packages ("name.version"). *)
-  only_packages : string list; [@default []]
-      (** Local root packages to include (empty to include all). *)
+  compatible_root_pkgs : string list;  (** Local root packages to include. *)
   commit : string;  (** A commit in opam-repository to use. *)
 }
 [@@deriving yojson, ord]
 (** A set of packages for a single build. *)
 
-let of_worker ~root_pkgs w =
+let of_worker w =
   let module W = Ocaml_ci_api.Worker.Selection in
   let { W.id; compat_pkgs; packages; commits } = w in
   let variant = Variant.of_string id in
-  let only_packages = if root_pkgs = compat_pkgs then [] else compat_pkgs in
-  { variant; only_packages; packages; commit = snd (List.hd commits) }
+  {
+    variant;
+    compatible_root_pkgs = compat_pkgs;
+    packages;
+    commit = snd (List.hd commits);
+  }
 
 let remove_package t ~package =
   {

--- a/lib/selection.mli
+++ b/lib/selection.mli
@@ -3,14 +3,13 @@
 type t = {
   variant : Variant.t;  (** The variant image to build on. *)
   packages : string list;  (** The selected packages ("name.version"). *)
-  only_packages : string list; [@default []]
-      (** Local root packages to include (empty to include all). *)
+  compatible_root_pkgs : string list;  (** Local root packages to include. *)
   commit : string;  (** A commit in opam-repository to use. *)
 }
 [@@deriving yojson, ord]
 (** A set of packages for a single build. *)
 
-val of_worker : root_pkgs:string list -> Ocaml_ci_api.Worker.Selection.t -> t
+val of_worker : Ocaml_ci_api.Worker.Selection.t -> t
 
 val remove_package : t -> package:string -> t
 (** [remove_package t] by package name from the selection. *)

--- a/test/service/test_analyse.ml
+++ b/test/service/test_analyse.ml
@@ -25,7 +25,7 @@ module Analysis = struct
 
   type selection = {
     ocaml_version : string;
-    only_packages : string list; [@default []]
+    compatible_root_pkgs : string list;
   }
   [@@deriving yojson, eq]
 
@@ -38,7 +38,7 @@ module Analysis = struct
     let ocaml_version =
       Ocaml_version.to_string (Ocaml_ci.Variant.ocaml_version t.variant)
     in
-    { ocaml_version; only_packages = t.only_packages }
+    { ocaml_version; compatible_root_pkgs = t.compatible_root_pkgs }
 
   let selections (t : t) =
     match selections t with
@@ -192,8 +192,8 @@ let test_simple =
         selection_type = "opam";
         selections =
           [
-            { ocaml_version = "4.10"; only_packages = [] };
-            { ocaml_version = "4.09"; only_packages = [] };
+            { ocaml_version = "4.10"; compatible_root_pkgs = [ "example.dev" ] };
+            { ocaml_version = "4.09"; compatible_root_pkgs = [ "example.dev" ] };
           ];
         ocamlformat_source_type = Some (Opam { version = "0.12" });
       }
@@ -226,8 +226,16 @@ let test_multiple_opam =
         selection_type = "opam";
         selections =
           [
-            { ocaml_version = "4.10"; only_packages = [] };
-            { ocaml_version = "4.09"; only_packages = [] };
+            {
+              ocaml_version = "4.10";
+              compatible_root_pkgs =
+                [ "example.dev"; "example-foo.dev"; "example-bar.dev" ];
+            };
+            {
+              ocaml_version = "4.09";
+              compatible_root_pkgs =
+                [ "example.dev"; "example-foo.dev"; "example-bar.dev" ];
+            };
           ];
         ocamlformat_source_type = None;
       }
@@ -252,8 +260,11 @@ let test_filter_packages =
         selection_type = "opam";
         selections =
           [
-            { ocaml_version = "4.10"; only_packages = [] };
-            { ocaml_version = "4.09"; only_packages = [ "example.dev" ] };
+            {
+              ocaml_version = "4.10";
+              compatible_root_pkgs = [ "example.dev"; "example-new.dev" ];
+            };
+            { ocaml_version = "4.09"; compatible_root_pkgs = [ "example.dev" ] };
           ];
         ocamlformat_source_type = None;
       }
@@ -315,7 +326,10 @@ let test_opam_monorepo_no_version =
       {
         opam_files = [ "example.opam" ];
         selection_type = "opam";
-        selections = [ { ocaml_version = "4.10"; only_packages = [] } ];
+        selections =
+          [
+            { ocaml_version = "4.10"; compatible_root_pkgs = [ "example.dev" ] };
+          ];
         ocamlformat_source_type = None;
       }
   in
@@ -334,8 +348,14 @@ let test_ocamlformat_self =
         selection_type = "opam";
         selections =
           [
-            { ocaml_version = "4.10"; only_packages = [] };
-            { ocaml_version = "4.09"; only_packages = [] };
+            {
+              ocaml_version = "4.10";
+              compatible_root_pkgs = [ "ocamlformat.dev" ];
+            };
+            {
+              ocaml_version = "4.09";
+              compatible_root_pkgs = [ "ocamlformat.dev" ];
+            };
           ];
         ocamlformat_source_type = Some (Vendored { path = "." });
       }

--- a/test/service/test_spec.ml
+++ b/test/service/test_spec.ml
@@ -1,6 +1,9 @@
+let macos_distro = "macos-homebrew"
+
 (* Expected obuilder spec for macos build of bondi. *)
 let expected_macos_spec =
-  {|
+  Printf.sprintf
+    {|
 ((from macos-homebrew-ocaml-4.14)
  (comment macos-homebrew-4.14.0_opam-2.1)
  (user (uid 1000) (gid 1000)) (env CLICOLOR_FORCE 1)
@@ -23,13 +26,27 @@ let expected_macos_spec =
       (network host)
       (shell "opam install $DEPS"))
  (copy (src .) (dst ./src))
- (run (shell "cd ./src && opam exec -- dune build @install @check @runtest && rm -rf _build"))
-)
-           |}
+ (run (shell "cd ./src && opam exec -- dune build --only-packages=bondi @install @check @runtest;
+res=$?;
+test \"$res\" != 1 && exit \"$res\";
+ret=1;
+for pkg in bondi; do
+  if opam show -f x-ci-accept-failures: \"$pkg\" | grep -qF \"\\\"%s\\\"\"; then
+    echo -e \"The package \\033[1m$pkg\\033[0m failed, but has been disabled for CI on \\033[1m%s\\033[0m using the \\033[1mx-ci-accept-failures\\033[0m field in its opam file.\";
+    ret=0;
+  fi;
+done;
+exit \"$ret\";
+&& rm -rf _build"))
+)|}
+    macos_distro macos_distro
+
+let linux_distro = "debian-11"
 
 (* Expected obuilder spec for linux (debian-11) build of bondi. *)
 let expected_linux_spec =
-  {|
+  Printf.sprintf
+    {|
 ((from ocaml/opam@sha256:03668731d460043acc763d35e1d5dfc6e6fe68a02f987849ac74f855e3e42c10)
  (comment debian-11-4.14.0_opam-2.1)
  (user (uid 1000) (gid 1000)) (env CLICOLOR_FORCE 1)
@@ -55,9 +72,20 @@ let expected_linux_spec =
       (network host)
       (shell "opam install $DEPS"))
  (copy (src .) (dst /src))
- (run (shell "opam exec -- dune build @install @check @runtest && rm -rf _build"))
-)
-|}
+ (run (shell "opam exec -- dune build --only-packages=bondi @install @check @runtest;
+res=$?;
+test \"$res\" != 1 && exit \"$res\";
+ret=1;
+for pkg in bondi; do
+  if opam show -f x-ci-accept-failures: \"$pkg\" | grep -qF \"\\\"%s\\\"\"; then
+    echo -e \"The package \\033[1m$pkg\\033[0m failed, but has been disabled for CI on \\033[1m%s\\033[0m using the \\033[1mx-ci-accept-failures\\033[0m field in its opam file.\";
+    ret=0;
+  fi;
+done;
+exit \"$ret\";
+&& rm -rf _build"))
+)|}
+    linux_distro linux_distro
 
 (* Create testable Sexp for Alcotest. *)
 let sexp = Alcotest.testable Sexplib0__Sexp.pp_hum Sexplib0__Sexp.equal
@@ -66,13 +94,14 @@ let test_macos_spec () =
   let open Ocaml_ci in
   let expected = Sexplib__Pre_sexp.of_string expected_macos_spec in
   let variant =
-    Variant.v ~arch:`X86_64 ~distro:"macos-homebrew"
+    Variant.v ~arch:`X86_64 ~distro:macos_distro
       ~ocaml_version:Ocaml_version.Releases.v4_14_0 ~opam_version:`V2_1
     |> Result.get_ok
   in
   let actual =
-    Opam_build.spec ~base:"macos-homebrew-ocaml-4.14" ~opam_version:`V2_1
-      ~opam_files:[ "bondi.opam" ]
+    Opam_build.spec
+      ~base:(macos_distro ^ "-ocaml-4.14")
+      ~opam_version:`V2_1 ~opam_files:[ "bondi.opam" ]
       ~selection:
         Selection.
           {
@@ -92,7 +121,7 @@ let test_macos_spec () =
                 "ocaml-config.2";
                 "ocaml-options-vanilla.1";
               ];
-            only_packages = [];
+            compatible_root_pkgs = [ "bondi.dev" ];
             commit = "f207d3f018d642d1fcddb2c118e7fa8e65f4e366";
           }
     |> Obuilder_spec.sexp_of_t
@@ -103,7 +132,7 @@ let test_linux_spec () =
   let open Ocaml_ci in
   let expected = Sexplib__Pre_sexp.of_string expected_linux_spec in
   let variant =
-    Variant.v ~arch:`X86_64 ~distro:"debian-11"
+    Variant.v ~arch:`X86_64 ~distro:linux_distro
       ~ocaml_version:Ocaml_version.Releases.v4_14_0 ~opam_version:`V2_1
     |> Result.get_ok
   in
@@ -131,7 +160,7 @@ let test_linux_spec () =
                 "ocaml-config.2";
                 "ocaml-options-vanilla.1";
               ];
-            only_packages = [];
+            compatible_root_pkgs = [ "bondi.dev" ];
             commit = "f207d3f018d642d1fcddb2c118e7fa8e65f4e366";
           }
     |> Obuilder_spec.sexp_of_t


### PR DESCRIPTION
This PR supports projects including the `x-ci-accept-failures` field in their `.opam` files, for example:
```
x-ci-accept-failures: [
  "macos-homebrew"
]
```
This allows them to specify distros that the package itself is experimental on so that the CI doesn't fail for distros that the maintainers don't want to support. (It's a little jarring to see a big green tick mark by something that's actually failed, but we currently don't have a way of saying "this failed but no big deal".)

The inspiration for the implementation comes from https://github.com/ocurrent/opam-repo-ci/pull/62. Writing the logic in bash is fairly ugly but I'm unsure of another way of testing whether the build fails or not.

Currently we only allow users to specify distros that they want to ignore the results of (following `opam-repo-ci`'s example), but this could be extended to include the architecture for example (`amd64`, `arm64`, etc.).

All feedback welcomed.