### PR TITLE
Install docker-buildx-plugin along with docker-ce.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
+RUN apt-get update && apt-get install docker-ce docker-buildx-plugin -y --no-install-recommends
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-service"]
 ENV OCAMLRUNPARAM=a=2

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -56,7 +56,7 @@ FROM debian:11
 RUN apt-get update && apt-get install libev4 openssh-client curl gnupg2 dumb-init git graphviz libsqlite3-dev ca-certificates netbase -y --no-install-recommends
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
 RUN echo 'deb https://download.docker.com/linux/debian buster stable' >> /etc/apt/sources.list
-RUN apt-get update && apt-get install docker-ce -y --no-install-recommends
+RUN apt-get update && apt-get install docker-ce docker-buildx-plugin -y --no-install-recommends
 WORKDIR /var/lib/ocurrent
 ENTRYPOINT ["dumb-init", "/usr/local/bin/ocaml-ci-gitlab"]
 ENV OCAMLRUNPARAM=a=2


### PR DESCRIPTION
Recently the docker pull for opam-vars started failing with this error:
```
2023-02-15 00:40.31: New job: opam vars of ubuntu-22.10-5.0_opam-2.1
                     (ocaml/opam@sha256:a5a1dbb59a383cd67195b360aa4ae57c4bdd3c275a1be950068f54d60e4bbafc)
2023-02-15 00:40.31: Exec: "docker" "build" "--pull" "-t" "ocurrent/ocaml-ci:ubuntu-22.10-ocaml-5.0" 
                           "-"
ERROR: BuildKit is enabled but the buildx component is missing or broken.
       Install the buildx component to build images with BuildKit:
       https://docs.docker.com/go/buildx/
2023-02-15 00:40.31: Job failed: Command "docker" "build" "--pull" "-t" "ocurrent/ocaml-ci:ubuntu-22.10-ocaml-5.0" 
"-" exited with status 1
```

We need to install additional docker packages to get the buildx component. 
The [docker docs](https://docs.docker.com/engine/install/ubuntu/. ) recommend installing all of `docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin`. However I've tested with just `docker-ce docker-buildx-plugin` which is working. 