### PR TITLE
Change forge prefix in breadcrumbs to read 'Organisations'

### DIFF
--- a/web-ui/view/history.ml
+++ b/web-ui/view/history.ml
@@ -157,7 +157,7 @@ module Make (M : Git_forge_intf.Forge) = struct
       | None -> [ (M.prefix, M.prefix); (org, org); (repo, repo) ]
       | Some commit ->
           [
-            (M.prefix, M.prefix);
+            ("Organisations", M.prefix);
             (org, org);
             (repo, repo);
             (tref, Printf.sprintf "commit/%s" commit);

--- a/web-ui/view/ref.ml
+++ b/web-ui/view/ref.ml
@@ -210,7 +210,7 @@ module Make (M : Git_forge_intf.Forge) = struct
     in
 
     [
-      Common.breadcrumbs [ (M.prefix, M.prefix); (org, org) ] repo;
+      Common.breadcrumbs [ ("Organisations", M.prefix); (org, org) ] repo;
       top_matter;
       Common.tabulate_div default_table;
     ]

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -389,7 +389,7 @@ module Make (M : Git_forge_intf.Forge) = struct
         script ~a:[ a_src "/js/chart.js" ] (txt "");
         script (Unsafe.data (js_of_histories ~org histories));
         script ~a:[ a_src "/js/repo-page.js" ] (txt "");
-        Common.breadcrumbs [ (M.prefix, M.prefix) ] org;
+        Common.breadcrumbs [ ("Organisations", M.prefix) ] org;
         title ~org;
         tabulate table_head table;
       ]

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -182,7 +182,7 @@ module Make (M : Git_forge_intf.Forge) = struct
       [
         Tyxml.Html.script ~a:[ a_src "/js/build-page-poll.js" ] (txt "");
         Common.breadcrumbs
-          [ (M.prefix, M.prefix); (org, org); (repo, repo) ]
+          [ ("Organisations", M.prefix); (org, org); (repo, repo) ]
           (Printf.sprintf "%s" (Common.short_hash hash));
         title_card;
         Common.flash_messages flash_messages;
@@ -510,7 +510,7 @@ module Make (M : Git_forge_intf.Forge) = struct
             Tyxml.Html.script ~a:[ a_src "/js/step-page-poll.js" ] (txt "");
             Common.breadcrumbs
               [
-                (M.prefix, M.prefix);
+                ("Organisations", M.prefix);
                 (org, org);
                 (repo, repo);
                 ( Printf.sprintf "%s (%s)" (Common.short_hash hash) branch,


### PR DESCRIPTION
Currently on the far left of the breadcrumbs we show the forge that the organisation belongs to (`github` or `gitlab`). However, clicking on this link simply takes the user back to the organisations page containing orgs of both forges. Changing the text to read `Organisations` potentially makes this more consistent.

The actual link being the forge prefix is still preserved due to the way that the breadcrumbs links are constructed. Changing the links entirely to remove the forge would be a breaking change. I'm open to other ways of solving this as this isn't perfect.

<img width="404" alt="Screenshot 2023-02-17 at 12 41 54" src="https://user-images.githubusercontent.com/13054139/219644819-a386f74d-b3ab-4a3b-a32e-06751b8ecd50.png">
