### PR TITLE
Update deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:8e2bda1bc44c16fadb0b039a7708fb5699236922ac91918e30aed2fa92b9ea54 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:9d23dacfe3b4ff8e45c2aa9ebdb347ae019c89202762e8f6b906b6cacd746885 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard e0171a799fbb4458db77a10f76a6279727aac521 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3842dad2f04210bf969bc2c047aa2f2f322bd8d9 && opam update
 COPY --chown=opam \
 	ocurrent/current_docker.opam \
 	ocurrent/current_github.opam \

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:8e2bda1bc44c16fadb0b039a7708fb5699236922ac91918e30aed2fa92b9ea54 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:9d23dacfe3b4ff8e45c2aa9ebdb347ae019c89202762e8f6b906b6cacd746885 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard e0171a799fbb4458db77a10f76a6279727aac521 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3842dad2f04210bf969bc2c047aa2f2f322bd8d9 && opam update
 COPY --chown=opam \
 	ocurrent/current_docker.opam \
 	ocurrent/current_github.opam \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,6 +1,6 @@
-FROM ocaml/opam:debian-11-ocaml-4.14@sha256:8e2bda1bc44c16fadb0b039a7708fb5699236922ac91918e30aed2fa92b9ea54 AS build
+FROM ocaml/opam:debian-11-ocaml-4.14@sha256:9d23dacfe3b4ff8e45c2aa9ebdb347ae019c89202762e8f6b906b6cacd746885 AS build
 RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libgmp-dev libssl-dev libsqlite3-dev -y --no-install-recommends
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard e0171a799fbb4458db77a10f76a6279727aac521 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 3842dad2f04210bf969bc2c047aa2f2f322bd8d9 && opam update
 COPY --chown=opam \
 	ocurrent/current_rpc.opam \
 	/src/ocurrent/

--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -45,7 +45,7 @@ module Conf = Ocaml_ci_service.Conf
 
 let setup_log default_level =
   Prometheus_unix.Logging.init ?default_level ();
-  Mirage_crypto_rng_unix.initialize ();
+  Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna);
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
   match Conf.ci_profile with
   | `Production -> Logs.info (fun f -> f "Using production configuration")

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -40,8 +40,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 pin-depends: [
-  ["dream.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
-  ["dream-httpaf.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
-  ["dream-pure.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+  ["dream.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
+  ["dream-httpaf.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
+  ["dream-pure.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#97ec16bb4933ec3eaf2cfd2b89e38dfbb3a9cf8e"]
 ]

--- a/ocaml-ci-web.opam.template
+++ b/ocaml-ci-web.opam.template
@@ -1,6 +1,6 @@
 pin-depends: [
-  ["dream.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
-  ["dream-httpaf.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
-  ["dream-pure.dev" "git+https://github.com/novemberkilo/dream#4976439384c9da03300abdbc9ffb8528ac917982"]
+  ["dream.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
+  ["dream-httpaf.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
+  ["dream-pure.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#97ec16bb4933ec3eaf2cfd2b89e38dfbb3a9cf8e"]
 ]

--- a/service/main.ml
+++ b/service/main.ml
@@ -44,7 +44,7 @@ open Ocaml_ci_service
 
 let setup_log default_level =
   Prometheus_unix.Logging.init ?default_level ();
-  Mirage_crypto_rng_unix.initialize ();
+  Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna);
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
   match Conf.ci_profile with
   | `Production -> Logs.info (fun f -> f "Using production configuration")


### PR DESCRIPTION
This PR makes two changes:
* Change the `ocurrent` submodule to the `0.6.4` changes.
* Restore the pointer to the official `dream` repository. 