### PR TITLE
Cached steps should identify themselves as such.

### DIFF
--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -108,6 +108,11 @@ let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
       ])
 
 let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
+  let cached = queued_for = "0s" && ran_for = "0s" in
+  let queued_for_txt =
+    if cached then "cached" else Fmt.str "%s in queue" queued_for
+  in
+  let ran_for_txt = if cached then "Cached" else Fmt.str "Ran for %s" ran_for in
   let step_row_id = step_title in
   let status_div_id = Fmt.str "%s-%s" step_title "status" in
   Tyxml.Html.(
@@ -139,7 +144,7 @@ let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
                   [
                     div [ txt @@ Fmt.str "Created at %s" created_at ];
                     div ~a:[ a_class [ "hidden md:inline" ] ] [ txt "-" ];
-                    div [ txt @@ Fmt.str "%s in queue" queued_for ];
+                    div [ txt queued_for_txt ];
                   ];
               ];
           ];
@@ -152,9 +157,7 @@ let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
                    items-center";
                 ];
             ]
-          [
-            div [ txt @@ Fmt.str "Ran for %s" ran_for ]; Common.right_arrow_head;
-          ];
+          [ div [ txt ran_for_txt ]; Common.right_arrow_head ];
       ])
 
 let tabulate_steps step_rows =


### PR DESCRIPTION
iiuc we've been working with the principle that a cached step has no time in the queue and also has 0 running time. This seems to be corroborated by [this](https://github.com/ocurrent/ocaml-ci/blob/fe87959f28ddf1bd94abb1577a8b1f56e875b316/web-ui/view/timestamps_durations.ml#L40) (which predates the redesign work). So I have just worked with that logic to implement a simple solution.

WDYT @maiste? 