### PR TITLE
Support exotic architectures removed in OCaml 5.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -17,7 +17,3 @@
 [submodule "ocaml-gitlab"]
 	path = ocaml-gitlab
 	url = https://github.com/tmcgilchrist/ocaml-gitlab.git
-[submodule "ocaml-version"]
-	path = ocaml-version
-	url = https://github.com/benmandrew/ocaml-version.git
-	branch = arch-upper

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,3 +17,7 @@
 [submodule "ocaml-gitlab"]
 	path = ocaml-gitlab
 	url = https://github.com/tmcgilchrist/ocaml-gitlab.git
+[submodule "ocaml-version"]
+	path = ocaml-version
+	url = https://github.com/benmandrew/ocaml-version.git
+	branch = arch-upper

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -53,7 +53,7 @@ module OV = Ocaml_version
 module DD = Dockerfile_opam.Distro
 
 let default_compilers =
-  OV.(List.map with_just_major_and_minor Releases.[ v4_14; v5_0 ])
+  OV.(List.map with_just_major_and_minor Releases.[ v4_14; latest ])
 
 let trunk_compiler = OV.(Sources.trunk |> without_patch)
 


### PR DESCRIPTION
Support for s390, arm32, x86_32, and ppc64 have not yet been added to OCaml 5.0, but we attempt to build these combinations anyway and fail, leaving the architectures untested. This PR uses a change in `ocaml-version` (https://github.com/ocurrent/ocaml-version/pull/61) to choose the latest version of OCaml that is supported by a given architecture.

This cannot be merged until the `ocaml-version` change is merged and released.

Fixes https://github.com/ocurrent/ocaml-ci/issues/756.