### PR TITLE
Fix default branch in build chart.

### DIFF
--- a/api/client.ml
+++ b/api/client.ml
@@ -82,6 +82,7 @@ module Org = struct
     main_status : Build_status.t;
     main_hash : string;
     main_last_updated : float option;
+    default_ref : string;
   }
 
   type ref_info = {
@@ -109,6 +110,7 @@ module Org = struct
            |> List.map @@ fun repo ->
               let open Raw.Reader.RepoInfo in
               let name = name_get repo in
+              let default_ref = default_ref_get repo in
               let main_status = main_state_get repo in
               let main_hash = main_hash_get repo in
               let main_last_updated =
@@ -117,7 +119,7 @@ module Org = struct
                 | MainLastUpdated.None | MainLastUpdated.Undefined _ -> None
                 | MainLastUpdated.Ts v -> Some v
               in
-              { name; main_status; main_hash; main_last_updated })
+              { name; main_status; main_hash; main_last_updated; default_ref })
 
   let repo_histories t =
     let open Raw.Client.Org.RepoHistories in

--- a/api/client.mli
+++ b/api/client.mli
@@ -101,6 +101,7 @@ module Org : sig
     main_status : Build_status.t;
     main_hash : string;
     main_last_updated : float option;
+    default_ref : string;
   }
 
   type ref_info = {

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -108,6 +108,7 @@ struct RepoInfo {
     ts         @3 :Float64;
     none       @4 :Void;
   }
+  defaultRef   @5 :Text;
   # The status of the repository's main branch (notStarted if there isn't one)
 }
 

--- a/dune-project
+++ b/dune-project
@@ -65,6 +65,7 @@
   solver-service
   ocluster-api
   obuilder-spec
+  (astring (>= 0.8.5))
   (timedesc (>= 0.9.0))
   (ocaml (>= 4.13))
   (conf-libev (<> :os "win32"))

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -30,6 +30,7 @@ depends: [
   "solver-service"
   "ocluster-api"
   "obuilder-spec"
+  "astring" {>= "0.8.5"}
   "timedesc" {>= "0.9.0"}
   "ocaml" {>= "4.13"}
   "conf-libev" {os != "win32"}

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -355,11 +355,20 @@ let make_org ~engine owner =
                 let repo_id = { Ocaml_ci.Repo_id.owner; name } in
                 let refs = Index.get_active_refs repo_id in
                 let repo = Index.Aggregate.get_repo_state ~repo:repo_id in
-                let default_ref =
+                let default_gref =
                   Index.get_default_gref { Ocaml_ci.Repo_id.owner; name }
                 in
+                let default_ref =
+                  let prefix = "refs/heads/" in
+                  let open Astring in
+                  if String.is_prefix ~affix:prefix default_gref then
+                    String.with_index_range ~first:(String.length prefix)
+                      default_gref
+                  else default_gref
+                in
+                default_ref_set slot default_ref;
                 let hash, status =
-                  match Index.Ref_map.find default_ref refs with
+                  match Index.Ref_map.find default_gref refs with
                   | { Index.hash; _ } ->
                       ( hash,
                         to_build_status

--- a/web-ui/view/repo.ml
+++ b/web-ui/view/repo.ml
@@ -99,7 +99,7 @@ module Make (M : Git_forge_intf.Forge) = struct
   }
 
   let row ~repo_title ~short_hash ~last_updated ~status ~description ~repo_uri
-      ~statistics =
+      ~statistics ~default_ref =
     let info =
       let hash = span ~a:[ a_class [ "font-medium" ] ] [ txt short_hash ] in
       match last_updated with
@@ -184,7 +184,7 @@ module Make (M : Git_forge_intf.Forge) = struct
         td
           ~a:[ a_class [ "text-xs space-y-1 hidden lg:table-cell" ] ]
           [
-            div [ txt "master" ];
+            div [ txt default_ref ];
             div
               ~a:[ a_class [ "shadow-sm mb-4" ] ]
               [
@@ -374,7 +374,14 @@ module Make (M : Git_forge_intf.Forge) = struct
       table_head (Printf.sprintf "Repositories (%d)" (List.length repos))
     in
     let table =
-      let f { Client.Org.name; main_status; main_hash; main_last_updated } =
+      let f
+          {
+            Client.Org.name;
+            default_ref;
+            main_status;
+            main_hash;
+            main_last_updated;
+          } =
         let history =
           snd @@ List.find (fun (repo, _) -> String.equal name repo) histories
         in
@@ -382,6 +389,7 @@ module Make (M : Git_forge_intf.Forge) = struct
           ~short_hash:(Common.short_hash main_hash)
           ~last_updated:main_last_updated ~status:main_status ~description:""
           ~repo_uri:(repo_url org name) ~statistics:(repo_statistics history)
+          ~default_ref
       in
       List.map f (List.sort repo_name_compare repos)
     in


### PR DESCRIPTION
Addresses #783 

Looks like we've been carrying a hard-coded "master" label for the default branch in the list of repos :) This PR fixes that.