### PR TITLE
Remove intermediate line breaks from in-progress logs

### DIFF
--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -621,7 +621,7 @@ module Make (M : Git_forge_intf.Forge) = struct
       | log_line -> Astring.String.cuts ~sep:"\r" log_line |> last
     in
     let process_logs data =
-      data
+      Astring.String.(with_range ~len:(length data - 1)) data
       |> Astring.String.cuts ~sep:"\n"
       |> List.map (fun l -> collapse_carriage_returns l |> Ansi.process ansi)
       |> tabulate


### PR DESCRIPTION
Fixes the issue raised in https://github.com/ocurrent/ocaml-ci/issues/607#issuecomment-1446745199 where extra line breaks appear in the logs. This happens because when data is streamed in, it has a newline added to it so that there is a bit of space at the bottom of the logs; when new data comes in that padding remains.

One potential issue is that there is now no longer much padding at the bottom of the logs (but seemingly only for in-progress builds...). I spent too long trying to figure out how the CSS works so I've just left it as-is.

<img width="423" alt="Screenshot 2023-03-16 at 15 32 43" src="https://user-images.githubusercontent.com/13054139/225650250-4bc48e15-4b37-40f8-b51e-adfeaa7beda9.png">
