### PR TITLE
Update to latest dream

### DIFF
--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -39,8 +39,8 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 pin-depends: [
-  ["dream.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
-  ["dream-httpaf.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
-  ["dream-pure.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
+  ["dream.dev" "git+https://github.com/aantron/dream#ff97ac7583cb939caeac35da1210bf18411cb9b9"]
+  ["dream-httpaf.dev" "git+https://github.com/aantron/dream#ff97ac7583cb939caeac35da1210bf18411cb9b9"]
+  ["dream-pure.dev" "git+https://github.com/aantron/dream#ff97ac7583cb939caeac35da1210bf18411cb9b9"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#97ec16bb4933ec3eaf2cfd2b89e38dfbb3a9cf8e"]
 ]

--- a/ocaml-ci-web.opam.template
+++ b/ocaml-ci-web.opam.template
@@ -1,6 +1,6 @@
 pin-depends: [
-  ["dream.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
-  ["dream-httpaf.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
-  ["dream-pure.dev" "git+https://github.com/aantron/dream#74efe19b8890fd5880a5b2e24c4cafcac8d1840c"]
+  ["dream.dev" "git+https://github.com/aantron/dream#ff97ac7583cb939caeac35da1210bf18411cb9b9"]
+  ["dream-httpaf.dev" "git+https://github.com/aantron/dream#ff97ac7583cb939caeac35da1210bf18411cb9b9"]
+  ["dream-pure.dev" "git+https://github.com/aantron/dream#ff97ac7583cb939caeac35da1210bf18411cb9b9"]
   ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#97ec16bb4933ec3eaf2cfd2b89e38dfbb3a9cf8e"]
 ]


### PR DESCRIPTION
The current pointed commit curiously doesn't belong to the dream repo, but rather to a fork?
https://github.com/aantron/dream/commit/74efe19b8890fd5880a5b2e24c4cafcac8d1840c
Hopefully the latest version works for us.