### PR TITLE
Allow using tar.gz archives from GitHub in opam pin-depends

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -36,7 +36,9 @@
   current_ocluster
   ocluster-api
   obuilder-spec
-  solver-service))
+  solver-service
+  (tar (>= 2.4.0))
+  (tar-unix (>= 2.4.0))))
 
 (package
  (name ocaml-ci-service)

--- a/lib/dune
+++ b/lib/dune
@@ -23,4 +23,8 @@
   solver-worker
   obuilder-spec
   dockerfile-opam
-  timedesc))
+  timedesc
+  cohttp-lwt-unix
+  tar
+  tar-unix
+  tar.gz))

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -39,5 +39,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 pin-depends: [
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#f0d65be5f94322f48497b33bc05c057882d57977"]
+  ["tailwindcss.~dev" "https://github.com/tmattio/opam-tailwindcss/archive/f0d65be5f94322f48497b33bc05c057882d57977.tar.gz"]
 ]

--- a/ocaml-ci-web.opam.template
+++ b/ocaml-ci-web.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["tailwindcss.dev" "git+https://github.com/tmattio/opam-tailwindcss#f0d65be5f94322f48497b33bc05c057882d57977"]
+  ["tailwindcss.~dev" "https://github.com/tmattio/opam-tailwindcss/archive/f0d65be5f94322f48497b33bc05c057882d57977.tar.gz"]
 ]

--- a/ocaml-ci.opam
+++ b/ocaml-ci.opam
@@ -23,6 +23,8 @@ depends: [
   "ocluster-api"
   "obuilder-spec"
   "solver-service"
+  "tar" {>= "2.4.0"}
+  "tar-unix" {>= "2.4.0"}
   "odoc" {with-doc}
 ]
 build: [


### PR DESCRIPTION
Today's hack!
Sometimes it's nice not to have to pin a git repository: for instance with opam-tailwindcss opam has to download the entire git history, which includes all the executables committed. I thought I'd use the tarball generated by `git archive` instead. We get the snapshot from a commit, so there's still reproducibility and the possibility to bisect changes made to the opam file, with the bonus of very few metadata and unwanted data from the dependency to download.

For GitHub hosted projects, the code involves downloading a tarball and following a redirection, then extracting the opam files from a compressed tarball. The downloaded tarball is cached. Decompression is done on the fly, without decompressing on disk.

I've tried to make the download and iteration over the data efficient, there might be better ways. There's no cancellation mechanism for now, perhaps the job should be checked periodically for cancellation in the loops?

There's a bug in `tar` preventing reading the data: https://github.com/mirage/ocaml-tar/issues/113, and it's now fixed!