### PR TITLE
Fix install command in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Get the code with:
 ```sh
 git clone --recursive https://github.com/ocurrent/ocaml-ci.git
 cd ocaml-ci
-opam install --deps-only ocaml-version ./ocaml-dockerfile ./ocluster ./ocurrent ./solver-service .
+opam install --deps-only ./ocaml-dockerfile ./ocluster ./ocurrent ./solver-service .
 ```
 
 Note: you need to clone with `--recursive` because this project uses submodules

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Get the code with:
 ```sh
 git clone --recursive https://github.com/ocurrent/ocaml-ci.git
 cd ocaml-ci
-opam install --deps-only ./ocaml-version ./ocaml-dockerfile ./ocluster ./ocurrent .
+opam install --deps-only ocaml-version ./ocaml-dockerfile ./ocluster ./ocurrent ./solver-service .
 ```
 
 Note: you need to clone with `--recursive` because this project uses submodules


### PR DESCRIPTION
Fixes two things:
 - ocaml-version is not a local package, so remove the leading "./"
 - the ./solver-service local package was missing from the command