### PR TITLE
Signpost experimental variants in web UI

### DIFF
--- a/api/client.ml
+++ b/api/client.ml
@@ -43,7 +43,19 @@ type job_info = {
   queued_at : float option;
   started_at : float option;
   finished_at : float option;
+  is_experimental : bool;
 }
+
+let create_job_info ?is_experimental variant outcome ~queued_at ~started_at
+    ~finished_at =
+  {
+    variant;
+    outcome;
+    queued_at;
+    started_at;
+    finished_at;
+    is_experimental = Option.value ~default:false is_experimental;
+  }
 
 module CI = struct
   type t = Raw.Client.CI.t Capability.t
@@ -303,7 +315,15 @@ module Commit = struct
                 | FinishedAt.None | Undefined _ -> None
                 | FinishedAt.Ts v -> Some v
               in
-              { variant; outcome; queued_at; started_at; finished_at })
+              let is_experimental = is_experimental_get job in
+              {
+                variant;
+                outcome;
+                queued_at;
+                started_at;
+                finished_at;
+                is_experimental;
+              })
 
   let refs t =
     let open Raw.Client.Commit.Refs in

--- a/api/client.ml
+++ b/api/client.ml
@@ -46,16 +46,9 @@ type job_info = {
   is_experimental : bool;
 }
 
-let create_job_info ?is_experimental variant outcome ~queued_at ~started_at
-    ~finished_at =
-  {
-    variant;
-    outcome;
-    queued_at;
-    started_at;
-    finished_at;
-    is_experimental = Option.value ~default:false is_experimental;
-  }
+let create_job_info ?(is_experimental = false) variant outcome ~queued_at
+    ~started_at ~finished_at =
+  { variant; outcome; queued_at; started_at; finished_at; is_experimental }
 
 module CI = struct
   type t = Raw.Client.CI.t Capability.t

--- a/api/client.mli
+++ b/api/client.mli
@@ -27,7 +27,17 @@ type job_info = {
   queued_at : float option;
   started_at : float option;
   finished_at : float option;
+  is_experimental : bool;
 }
+
+val create_job_info :
+  ?is_experimental:bool ->
+  variant ->
+  State.t ->
+  queued_at:float option ->
+  started_at:float option ->
+  finished_at:float option ->
+  job_info
 
 module Commit : sig
   type t = Raw.Client.Commit.t Capability.t

--- a/api/schema.capnp
+++ b/api/schema.capnp
@@ -12,41 +12,42 @@ enum BuildStatus {
 struct JobInfo {
   variant @0 :Text;
   state :union {
-    notStarted @1 :Void;
+    notStarted   @1 :Void;
 
-    passed     @2 :Void;
+    passed       @2 :Void;
 
-    failed     @3 :Text;
+    failed       @3 :Text;
     # The text is the error message.
 
-    active     @4 :Void;
+    active       @4 :Void;
     # The job is still running.
 
-    aborted    @5 :Void;
+    aborted      @5 :Void;
     # This means we couldn't find any record of the job. It probably means
     # that the server crashed while building, and when it came back up we
     # no longer wanted to test that commit anyway.
   }
 
   queuedAt  :union {
-    ts         @6 :Float64;
+    ts           @6 :Float64;
     # timestamp as seconds since epoch
-    none       @7 :Void;
+    none         @7 :Void;
   }
 
   startedAt :union {
-    ts         @8 :Float64;
+    ts           @8 :Float64;
     # timestamp as seconds since epoch
-    none       @9 :Void;
+    none         @9 :Void;
   }
 
   finishedAt :union {
-    ts         @10 :Float64;
+    ts           @10 :Float64;
     # timestamp as seconds since epoch
-    none       @11 :Void;
+    none         @11 :Void;
   }
-}
 
+  isExperimental @12 :Bool;
+}
 
 interface Commit {
   jobs  @0 () -> (jobs :List(JobInfo));

--- a/client/main.ml
+++ b/client/main.ml
@@ -91,10 +91,19 @@ let pp_timestamp f v =
     Fmt.(option ~none:(any "-") (Timedesc.pp_iso8601 ()))
     (Option.bind v Timedesc.of_timestamp_float_s)
 
-let pp_job f { Client.variant; outcome; queued_at; started_at; finished_at } =
-  Fmt.pf f "%s (%a) (Queued_at: %a) (Started_at: %a) (Finished_at: %a)" variant
-    Client.State.pp outcome pp_timestamp queued_at pp_timestamp started_at
-    pp_timestamp finished_at
+let pp_job f
+    {
+      Client.variant;
+      outcome;
+      queued_at;
+      started_at;
+      finished_at;
+      is_experimental;
+    } =
+  let experimental = if is_experimental then " (experimental)" else "" in
+  Fmt.pf f "%s (%a) (Queued_at: %a) (Started_at: %a) (Finished_at: %a)%s"
+    variant Client.State.pp outcome pp_timestamp queued_at pp_timestamp
+    started_at pp_timestamp finished_at experimental
 
 let list_variants commit =
   Client.Commit.jobs commit

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -275,7 +275,9 @@ let v ?ocluster ~app ~solver ~migrations () =
              in
              let hash = Gitlab.Api.Commit.hash commit in
              let jobs =
-               List.map (fun (s, (_, job_id)) -> (s.label, job_id)) builds
+               List.map
+                 (fun (s, (_, job_id)) -> (s.Build_info.label, job_id))
+                 builds
              in
              Index.record ~repo ~hash ~status ~gref jobs
            and set_gitlab_status =

--- a/lib/build_info.ml
+++ b/lib/build_info.ml
@@ -1,0 +1,41 @@
+type t = { label : string; variant : Variant.t option }
+(** [variant] will be [None] for utility or linting jobs without a platform, and
+    [Some v] for jobs building on a particular platform [v]. *)
+
+let of_spec = function
+  | Spec.{ label; variant; ty = _ } -> { label; variant = Some variant }
+
+let of_label label = { label; variant = None }
+
+(** Check whether a variant is considered experimental.
+
+    If it is experimental we allow those builds to fail without failing the
+    overall build for a commit. *)
+let experimental_variant s =
+  if
+    Astring.String.(
+      is_prefix ~affix:"(lint-lower-bounds)" s.label
+      || is_prefix ~affix:"(lint-opam)" s.label)
+  then true
+  else
+    match s.variant with
+    | None -> false
+    | Some v ->
+        Astring.String.equal "macos-homebrew" (Variant.distro v)
+        || Ocaml_version.(equal (v 5 1 ~patch:0)) (Variant.ocaml_version v)
+        || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"alpha1"))
+             (Variant.ocaml_version v)
+
+(** Like [experimental_variant], but takes strings for when a [build_info]
+    record is unavailable.
+
+    Prefer to use [experimental_variant] when possible, as this function can
+    potentially give false positives. *)
+let experimental_variant_str s =
+  Astring.String.(
+    is_prefix ~affix:"(lint-lower-bounds)" s
+    || is_prefix ~affix:"(lint-opam)" s
+    || is_prefix ~affix:"macos-homebrew" s
+    || is_infix ~affix:"-5.1" s
+    || is_infix ~affix:"-5.1~alpha1" s
+    || is_infix ~affix:"-5.1.0~alpha1" s)

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -20,6 +20,15 @@ let experimental_variant s =
         || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"alpha1"))
              (Variant.ocaml_version v)
 
+let experimental_variant_str s =
+  Astring.String.(
+    is_prefix ~affix:"(lint-lower-bounds)" s
+    || is_prefix ~affix:"(lint-opam)" s
+    || is_prefix ~affix:"macos-homebrew" s
+    || is_infix ~affix:"-5.1" s
+    || is_infix ~affix:"-5.1~alpha1" s
+    || is_infix ~affix:"-5.1.0~alpha1" s)
+
 let list_errors ~ok errs =
   let groups =
     (* Group by error message *)

--- a/lib/pipeline.mli
+++ b/lib/pipeline.mli
@@ -13,6 +13,13 @@ val experimental_variant : build_info -> bool
     If it is experimental we allow those builds to fail without failing the
     overall build for a commit. *)
 
+val experimental_variant_str : string -> bool
+(** Like [experimental_variant], but takes strings for when a [build_info]
+    record is unavailable.
+
+    Prefer to use [experimental_variant] when possible, as this function can
+    potentially give false positives. *)
+
 val summarise :
   (build_info
   * (([< `Built | `Checked ], [< `Active of 'a | `Msg of string ]) result * 'b))

--- a/lib/pipeline.mli
+++ b/lib/pipeline.mli
@@ -1,27 +1,7 @@
 (** Common logic for building a CI pipeline. *)
 
-type build_info = { label : string; variant : Variant.t option }
-(** [variant] will be [None] for utility or linting jobs without a platform, and
-    [Some v] for jobs building on a particular platform [v]. *)
-
-val build_info_of_spec : Spec.t -> build_info
-val build_info_of_label : string -> build_info
-
-val experimental_variant : build_info -> bool
-(** Check whether a variant is considered experimental.
-
-    If it is experimental we allow those builds to fail without failing the
-    overall build for a commit. *)
-
-val experimental_variant_str : string -> bool
-(** Like [experimental_variant], but takes strings for when a [build_info]
-    record is unavailable.
-
-    Prefer to use [experimental_variant] when possible, as this function can
-    potentially give false positives. *)
-
 val summarise :
-  (build_info
+  (Build_info.t
   * (([< `Built | `Checked ], [< `Active of 'a | `Msg of string ]) result * 'b))
   list ->
   (unit, [> `Active of [> `Running ] | `Msg of string ]) result
@@ -39,7 +19,8 @@ val build_with_docker :
   analysis:Analyse.Analysis.t Current.t ->
   platforms:Platform.t list Current.t ->
   Current_git.Commit.t Current.t ->
-  (build_info * ([> `Built | `Checked ] Current_term.Output.t * string option))
+  (Build_info.t
+  * ([> `Built | `Checked ] Current_term.Output.t * string option))
   list
   Current.t
 (** [build_with_docker ~repo ~analysis ~platforms commit] creates a suite of

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -2,6 +2,7 @@ module Rpc = Current_rpc.Impl (Current)
 module Raw = Ocaml_ci_api.Raw
 module String_map = Map.Make (String)
 module Index = Ocaml_ci.Index
+module Pipeline = Ocaml_ci.Pipeline
 module Run_time = Ocaml_ci.Run_time
 open Capnp_rpc_lwt
 
@@ -47,12 +48,14 @@ let make_commit ~engine ~owner ~name hash =
            | Some v -> S.ts_set finished_at_t v);
            let state = state_init slot in
            let module S = State in
-           match outcome with
+           (match outcome with
            | `Not_started -> S.not_started_set state
            | `Passed -> S.passed_set state
            | `Aborted -> S.aborted_set state
            | `Active -> S.active_set state
-           | `Failed msg -> S.failed_set state msg
+           | `Failed msg -> S.failed_set state msg);
+           let is_experimental = Pipeline.experimental_variant_str variant in
+           is_experimental_set slot is_experimental
          in
          jobs |> List.iteri f;
          Service.return response

--- a/service/api_impl.ml
+++ b/service/api_impl.ml
@@ -2,7 +2,7 @@ module Rpc = Current_rpc.Impl (Current)
 module Raw = Ocaml_ci_api.Raw
 module String_map = Map.Make (String)
 module Index = Ocaml_ci.Index
-module Pipeline = Ocaml_ci.Pipeline
+module Build_info = Ocaml_ci.Build_info
 module Run_time = Ocaml_ci.Run_time
 open Capnp_rpc_lwt
 
@@ -54,7 +54,7 @@ let make_commit ~engine ~owner ~name hash =
            | `Aborted -> S.aborted_set state
            | `Active -> S.active_set state
            | `Failed msg -> S.failed_set state msg);
-           let is_experimental = Pipeline.experimental_variant_str variant in
+           let is_experimental = Build_info.experimental_variant_str variant in
            is_experimental_set slot is_experimental
          in
          jobs |> List.iteri f;

--- a/test/service/test_pipeline.ml
+++ b/test/service/test_pipeline.ml
@@ -10,11 +10,11 @@ let t_ret = Alcotest.testable pp_t_ret equal_t_ret
 
 let test_summarise_success () =
   let result =
-    Ocaml_ci.Pipeline.
+    Ocaml_ci.Build_info.
       [
-        (build_info_of_label "build_1", (Result.Ok `Built, ()));
-        (build_info_of_label "build_2", (Result.Ok `Built, ()));
-        (build_info_of_label "lint_1", (Result.Ok `Checked, ()));
+        (of_label "build_1", (Result.Ok `Built, ()));
+        (of_label "build_2", (Result.Ok `Built, ()));
+        (of_label "lint_1", (Result.Ok `Checked, ()));
       ]
     |> Ocaml_ci.Pipeline.summarise
   in
@@ -23,12 +23,12 @@ let test_summarise_success () =
 
 let test_summarise_fail () =
   let result =
-    Ocaml_ci.Pipeline.
+    Ocaml_ci.Build_info.
       [
-        (build_info_of_label "build_1", (Result.Ok `Built, ()));
-        (build_info_of_label "build_2", (Result.Ok `Built, ()));
-        (build_info_of_label "lint_1", (Result.Ok `Checked, ()));
-        (build_info_of_label "build_3", (Result.Error (`Msg "msg"), ()));
+        (of_label "build_1", (Result.Ok `Built, ()));
+        (of_label "build_2", (Result.Ok `Built, ()));
+        (of_label "lint_1", (Result.Ok `Checked, ()));
+        (of_label "build_3", (Result.Error (`Msg "msg"), ()));
       ]
     |> Ocaml_ci.Pipeline.summarise
   in
@@ -37,12 +37,12 @@ let test_summarise_fail () =
 
 let test_summarise_running () =
   let result =
-    Ocaml_ci.Pipeline.
+    Ocaml_ci.Build_info.
       [
-        (build_info_of_label "build_1", (Result.Ok `Built, ()));
-        (build_info_of_label "build_2", (Result.Ok `Built, ()));
-        (build_info_of_label "lint_1", (Result.Ok `Checked, ()));
-        (build_info_of_label "lint_2", (Result.Error (`Active ()), ()));
+        (of_label "build_1", (Result.Ok `Built, ()));
+        (of_label "build_2", (Result.Ok `Built, ()));
+        (of_label "lint_1", (Result.Ok `Checked, ()));
+        (of_label "lint_2", (Result.Error (`Active ()), ()));
       ]
     |> Ocaml_ci.Pipeline.summarise
   in
@@ -51,13 +51,12 @@ let test_summarise_running () =
 
 let test_summarise_success_experimental_fail () =
   let result =
-    Ocaml_ci.Pipeline.
+    Ocaml_ci.Build_info.
       [
-        (build_info_of_label "build_1", (Result.Ok `Built, ()));
-        (build_info_of_label "build_2", (Result.Ok `Built, ()));
-        (build_info_of_label "lint_1", (Result.Ok `Checked, ()));
-        ( build_info_of_label "(lint-lower-bounds)",
-          (Result.Error (`Msg "failed"), ()) );
+        (of_label "build_1", (Result.Ok `Built, ()));
+        (of_label "build_2", (Result.Ok `Built, ()));
+        (of_label "lint_1", (Result.Ok `Checked, ()));
+        (of_label "(lint-lower-bounds)", (Result.Error (`Msg "failed"), ()));
       ]
     |> Ocaml_ci.Pipeline.summarise
   in
@@ -66,13 +65,12 @@ let test_summarise_success_experimental_fail () =
 
 let test_summarise_success_experimental_running () =
   let result =
-    Ocaml_ci.Pipeline.
+    Ocaml_ci.Build_info.
       [
-        (build_info_of_label "build_1", (Result.Ok `Built, ()));
-        (build_info_of_label "build_2", (Result.Ok `Built, ()));
-        (build_info_of_label "lint_1", (Result.Ok `Checked, ()));
-        ( build_info_of_label "(lint-lower-bounds)",
-          (Result.Error (`Active ()), ()) );
+        (of_label "build_1", (Result.Ok `Built, ()));
+        (of_label "build_2", (Result.Ok `Built, ()));
+        (of_label "lint_1", (Result.Ok `Checked, ()));
+        (of_label "(lint-lower-bounds)", (Result.Error (`Active ()), ()));
       ]
     |> Ocaml_ci.Pipeline.summarise
   in
@@ -87,10 +85,10 @@ let test_experimental () =
   in
   let v =
     Ocaml_ci.(
-      Pipeline.
+      Build_info.
         [
-          (true, build_info_of_label "(lint-lower-bounds)");
-          (false, build_info_of_label "(lint-doc)");
+          (true, of_label "(lint-lower-bounds)");
+          (false, of_label "(lint-doc)");
           ( true,
             {
               label = "";
@@ -119,7 +117,7 @@ let test_experimental () =
   in
   let expected = List.map fst v in
   let result =
-    List.map (fun v -> snd v |> Ocaml_ci.Pipeline.experimental_variant) v
+    List.map (fun v -> snd v |> Ocaml_ci.Build_info.experimental_variant) v
   in
   List.iter2 (Alcotest.(check bool) "Success") expected result
 

--- a/test/service/test_run_time.ml
+++ b/test/service/test_run_time.ml
@@ -169,14 +169,9 @@ let test_info_from_timestamps_never_ran () =
     "info_from_timestamps - finished" [ expected ] [ result ]
 
 let test_timestamps_from_job_info_queued =
-  let not_started_job : Client.job_info =
-    {
-      variant = "variant";
-      outcome = NotStarted;
-      queued_at = Some 1234567.;
-      started_at = None;
-      finished_at = None;
-    }
+  let not_started_job =
+    Client.create_job_info "variant" NotStarted ~queued_at:(Some 1234567.)
+      ~started_at:None ~finished_at:None
   in
   let expected : Run_time.Timestamp.t = Queued 1234567. in
   let result = Run_time.Timestamp.of_job_info not_started_job in
@@ -187,14 +182,9 @@ let test_timestamps_from_job_info_queued =
         "timestamps_from_job_info" [ expected ] [ result ]
 
 let test_timestamps_from_job_info_running =
-  let active_job : Client.job_info =
-    {
-      variant = "variant";
-      outcome = Active;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = None;
-    }
+  let active_job =
+    Client.create_job_info "variant" Active ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:None
   in
   let expected : Run_time.Timestamp.t =
     Running { queued_at = 1234567.; started_at = 1234570. }
@@ -207,14 +197,9 @@ let test_timestamps_from_job_info_running =
         "timestamps_from_job_info" [ expected ] [ result ]
 
 let test_timestamps_from_job_info_finished =
-  let finished_job : Client.job_info =
-    {
-      variant = "variant";
-      outcome = Passed;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = Some 1234575.;
-    }
+  let finished_job =
+    Client.create_job_info "variant" Passed ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
   in
   let expected : Run_time.Timestamp.t =
     Finished
@@ -240,6 +225,7 @@ let test_timestamps_from_job_info_finished_with_errors =
         queued_at = Some 1234567.;
         started_at = None;
         finished_at = Some 1234575.;
+        is_experimental = false;
       }
     in
     let expected : Run_time.Timestamp.t =
@@ -363,32 +349,17 @@ let test_build_created_at_empty =
     "build_created_for empty" expected result
 
 let test_build_created_at_happy_path =
-  let analysis_step : Client.job_info =
-    {
-      variant = "(analysis)";
-      outcome = Passed;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = Some 1234575.;
-    }
+  let analysis_step =
+    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
   in
-  let lint_step : Client.job_info =
-    {
-      variant = "(lint-fmt)";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234585.;
-    }
+  let lint_step =
+    Client.create_job_info "(lint-fmt)" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
-  let build_step : Client.job_info =
-    {
-      variant = "foo-11-4.14";
-      outcome = Active;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = None;
-    }
+  let build_step =
+    Client.create_job_info "foo-11-4.14" Active ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:None
   in
   let build = [ analysis_step; lint_step; build_step ] in
   let expected = Ok (Some 1234567.) in
@@ -397,32 +368,17 @@ let test_build_created_at_happy_path =
     "build_created_for happy" expected result
 
 let test_build_created_at_mangled =
-  let analysis_step : Client.job_info =
-    {
-      variant = "(analysis)";
-      outcome = Passed;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = Some 1234575.;
-    }
+  let analysis_step =
+    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
   in
-  let analysis_step_2 : Client.job_info =
-    {
-      variant = "(analysis)";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234585.;
-    }
+  let analysis_step_2 =
+    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
-  let build_step : Client.job_info =
-    {
-      variant = "foo-11-4.14";
-      outcome = Active;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = None;
-    }
+  let build_step =
+    Client.create_job_info "foo-11-4.14" Active ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:None
   in
   let build = [ analysis_step; analysis_step_2; build_step ] in
   let expected = Error "Multiple analysis steps found" in
@@ -431,32 +387,17 @@ let test_build_created_at_mangled =
     "build_created_for multiple" expected result
 
 let test_total_of_run_times =
-  let analysis_step : Client.job_info =
-    {
-      variant = "(analysis)";
-      outcome = Passed;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = Some 1234575.;
-    }
+  let analysis_step =
+    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
   in
-  let lint_step : Client.job_info =
-    {
-      variant = "(lint-fmt)";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234585.;
-    }
+  let lint_step =
+    Client.create_job_info "(lint-fmt)" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
-  let build_step : Client.job_info =
-    {
-      variant = "foo-11-4.14";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234590.;
-    }
+  let build_step =
+    Client.create_job_info "foo-11-4.14" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234590.)
   in
   let build = [ analysis_step; lint_step; build_step ] in
   let expected = 3. +. 5. +. 3. +. 6. +. 3. +. 11. in
@@ -464,35 +405,20 @@ let test_total_of_run_times =
   Alcotest.(check (float 0.001)) "total_of_run_times" expected result
 
 let test_build_run_time =
-  let analysis_step : Client.job_info =
-    {
-      variant = "(analysis)";
-      outcome = Passed;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = Some 1234575.;
-    }
-    (* thus run-time of analysis step is 3 + 5 = 8 *)
+  (* run-time of analysis step is 3 + 5 = 8 *)
+  let analysis_step =
+    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
   in
-  let lint_step : Client.job_info =
-    {
-      variant = "(lint-fmt)";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234585.;
-    }
-    (* run-time of lint_step is 3 + 6 = 9 *)
+  (* run-time of lint step is 3 + 6 = 9 *)
+  let lint_step =
+    Client.create_job_info "(lint-fmt)" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
-  let build_step : Client.job_info =
-    {
-      variant = "foo-11-4.14";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234590.;
-    }
-    (* run-time of build_step is 3 + 11 = 14 -- this is the longest running step *)
+  (* run-time of build_step is 3 + 11 = 14 -- this is the longest running step *)
+  let build_step =
+    Client.create_job_info "foo-11-4.14" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234590.)
   in
   let build = [ analysis_step; lint_step; build_step ] in
   let expected = 8. +. 14. in
@@ -501,41 +427,21 @@ let test_build_run_time =
   Alcotest.(check (float 0.001)) "build_run_time" expected result
 
 let test_first_step_queued_at =
-  let not_started : Client.job_info =
-    {
-      variant = "variant";
-      outcome = NotStarted;
-      queued_at = None;
-      started_at = None;
-      finished_at = None;
-    }
+  let not_started =
+    Client.create_job_info "variant" NotStarted ~queued_at:None ~started_at:None
+      ~finished_at:None
   in
-  let step_1 : Client.job_info =
-    {
-      variant = "variant";
-      outcome = Passed;
-      queued_at = Some 1234567.;
-      started_at = Some 1234570.;
-      finished_at = Some 1234575.;
-    }
+  let step_1 =
+    Client.create_job_info "variant" Passed ~queued_at:(Some 1234567.)
+      ~started_at:(Some 1234570.) ~finished_at:(Some 12312345754590.)
   in
-  let step_2 : Client.job_info =
-    {
-      variant = "variant";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234585.;
-    }
+  let step_2 =
+    Client.create_job_info "variant" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
-  let step_3 : Client.job_info =
-    {
-      variant = "variant-11-4.14";
-      outcome = Passed;
-      queued_at = Some 1234576.;
-      started_at = Some 1234579.;
-      finished_at = Some 1234590.;
-    }
+  let step_3 =
+    Client.create_job_info "variant-11-4.14" Passed ~queued_at:(Some 1234576.)
+      ~started_at:(Some 1234579.) ~finished_at:(Some 1234590.)
   in
   let empty = [] in
   let expected = Error "Empty build" in

--- a/test/web/test_build_representation.ml
+++ b/test/web/test_build_representation.ml
@@ -14,41 +14,27 @@ let test_to_json (jobs, build_status, build_created_at, expected) =
 (* NOTE that for the purposes of testing, the timezone has been set to UTC
    by adding timedesc-tzlocal.utc to the dune file. See the README for timedesc *)
 let test_simple () =
-  let step_info_1 : Client.job_info =
-    {
-      variant = "analysis";
-      outcome = Passed;
-      queued_at = Some 1666210392.;
-      started_at = Some 1666210434.;
-      finished_at = Some 1666210490.;
-    }
+  let step_info_1 =
+    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1666210392.)
+      ~started_at:(Some 1666210434.) ~finished_at:(Some 1666210490.)
   in
   let expected_1 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"can_cancel":false,"variant":"analysis"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"can_cancel":false,"variant":"(analysis)","is_experimental":false}|}
   in
-  let step_info_2 : Client.job_info =
-    {
-      variant = "variant";
-      outcome = Passed;
-      queued_at = Some 1666210392.;
-      started_at = Some 1666210434.;
-      finished_at = Some 1666210500.;
-    }
+  let step_info_2 =
+    Client.create_job_info "variant" Passed ~queued_at:(Some 1666210392.)
+      ~started_at:(Some 1666210434.) ~finished_at:(Some 1666210500.)
   in
   let expected_2 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m06s","can_rebuild":false,"can_cancel":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m06s","can_rebuild":false,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
-  let step_info_3 : Client.job_info =
-    {
-      variant = "variant";
-      outcome = Failed "For reasons";
-      queued_at = Some 1666210392.;
-      started_at = Some 1666210434.;
-      finished_at = Some 1666210550.;
-    }
+  let step_info_3 =
+    Client.create_job_info "variant" (Failed "For reasons")
+      ~queued_at:(Some 1666210392.) ~started_at:(Some 1666210434.)
+      ~finished_at:(Some 1666210550.)
   in
   let expected_3 =
-    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m56s","can_rebuild":false,"can_cancel":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m56s","can_rebuild":false,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
   let jobs = [ step_info_1; step_info_2; step_info_3 ] in
   let build_status : Client.State.t = Failed "for reasons" in

--- a/test/web/test_build_representation.ml
+++ b/test/web/test_build_representation.ml
@@ -36,13 +36,21 @@ let test_simple () =
   let expected_3 =
     {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m56s","can_rebuild":false,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
-  let jobs = [ step_info_1; step_info_2; step_info_3 ] in
+  let step_info_4 =
+    Client.create_job_info "variant" (Failed "For reasons")
+      ~queued_at:(Some 1666210392.) ~started_at:(Some 1666210434.)
+      ~finished_at:(Some 1666210550.) ~is_experimental:true
+  in
+  let expected_4 =
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"1m56s","can_rebuild":false,"can_cancel":false,"variant":"variant","is_experimental":true}|}
+  in
+  let jobs = [ step_info_1; step_info_2; step_info_3; step_info_4 ] in
   let build_status : Client.State.t = Failed "for reasons" in
   let build_created_at = 1666210300. in
   let expected =
-    Fmt.str "%s[%s,%s,%s],\"step_route_prefix\":\"/github/foo/bar\"}"
-      {|{"version":"1.0","status":"failed: for reasons","first_created_at":"Oct 19 20:13 +00:00","ran_for":"4m16s","total_ran_for":"6m04s","can_cancel":false,"can_rebuild":true,"steps":|}
-      expected_1 expected_2 expected_3
+    Fmt.str "%s[%s,%s,%s,%s],\"step_route_prefix\":\"/github/foo/bar\"}"
+      {|{"version":"1.0","status":"failed: for reasons","first_created_at":"Oct 19 20:13 +00:00","ran_for":"4m16s","total_ran_for":"8m42s","can_cancel":false,"can_rebuild":true,"steps":|}
+      expected_1 expected_2 expected_3 expected_4
   in
   List.iter test_to_json [ (jobs, build_status, build_created_at, expected) ]
 

--- a/test/web/test_step_representation.ml
+++ b/test/web/test_step_representation.ml
@@ -15,53 +15,39 @@ let test_to_json (step_info, run_time, can_rebuild, can_cancel, expected) =
 let test_simple () =
   let can_rebuild = true in
   let can_cancel = false in
-  let step_info_1 : Client.job_info option =
-    Some
-      {
-        variant = "variant";
-        outcome = Active;
-        queued_at = Some 1666210392.;
-        started_at = Some 1666210434.;
-        finished_at = None;
-      }
+  let step_info_1 =
+    Option.some
+    @@ Client.create_job_info "variant" Active ~queued_at:(Some 1666210392.)
+         ~started_at:(Some 1666210434.) ~finished_at:None
   in
   let run_time_1 : Run_time.TimeInfo.t option =
     Some (Running { queued_for = 42.2; ran_for = 0. })
   in
   let expected_1 =
-    {|{"version":"1.0","status":"active","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"0s","can_rebuild":true,"can_cancel":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"active","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"0s","can_rebuild":true,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
-  let step_info_2 : Client.job_info option =
-    Some
-      {
-        variant = "variant";
-        outcome = Passed;
-        queued_at = Some 1666210392.;
-        started_at = Some 1666210434.;
-        finished_at = Some 1666210500.;
-      }
+  let step_info_2 =
+    Option.some
+    @@ Client.create_job_info "variant" Passed ~queued_at:(Some 1666210392.)
+         ~started_at:(Some 1666210434.) ~finished_at:(Some 1666210500.)
   in
   let run_time_2 : Run_time.TimeInfo.t option =
     Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
   in
   let expected_2 =
-    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:15 +00:00","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
-  let step_info_3 : Client.job_info option =
-    Some
-      {
-        variant = "variant";
-        outcome = Failed "For reasons";
-        queued_at = Some 1666210392.;
-        started_at = Some 1666210434.;
-        finished_at = None;
-      }
+  let step_info_3 =
+    Option.some
+    @@ Client.create_job_info "variant" (Failed "For reasons")
+         ~queued_at:(Some 1666210392.) ~started_at:(Some 1666210434.)
+         ~finished_at:None
   in
   let run_time_3 : Run_time.TimeInfo.t option =
     Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
   in
   let expected_3 =
-    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant"}|}
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
 
   List.iter test_to_json

--- a/test/web/test_step_representation.ml
+++ b/test/web/test_step_representation.ml
@@ -49,12 +49,25 @@ let test_simple () =
   let expected_3 =
     {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant","is_experimental":false}|}
   in
+  let step_info_4 =
+    Option.some
+    @@ Client.create_job_info "variant" (Failed "For reasons")
+         ~queued_at:(Some 1666210392.) ~started_at:(Some 1666210434.)
+         ~finished_at:None ~is_experimental:true
+  in
+  let run_time_4 : Run_time.TimeInfo.t option =
+    Some (Finished { queued_for = 42.2; ran_for = Some 5.4 })
+  in
+  let expected_4 =
+    {|{"version":"1.0","status":"failed: For reasons","created_at":"Oct 19 20:13 +00:00","finished_at":"-","queued_for":"42s","ran_for":"5s","can_rebuild":true,"can_cancel":false,"variant":"variant","is_experimental":true}|}
+  in
 
   List.iter test_to_json
     [
       (step_info_1, run_time_1, can_rebuild, can_cancel, expected_1);
       (step_info_2, run_time_2, can_rebuild, can_cancel, expected_2);
       (step_info_3, run_time_3, can_rebuild, can_cancel, expected_3);
+      (step_info_4, run_time_4, can_rebuild, can_cancel, expected_4);
     ]
 
 let tests = [ Alcotest_lwt.test_case_sync "simple" `Quick test_simple ]

--- a/web-ui/representation/step.ml
+++ b/web-ui/representation/step.ml
@@ -13,35 +13,51 @@ type t = {
   can_rebuild : bool;
   can_cancel : bool;
   variant : string;
+  is_experimental : bool;
 }
 [@@deriving yojson]
 
 let from_status_info_run_time ~step_info ~run_time ~can_rebuild ~can_cancel =
+  let status =
+    Option.fold ~none:""
+      ~some:(fun i -> Fmt.str "%a" Client.State.pp i.Client.outcome)
+      step_info
+  in
+  let created_at =
+    Option.fold ~none:""
+      ~some:(fun i -> Run_time.Duration.pp_readable_opt i.Client.queued_at)
+      step_info
+  in
+  let finished_at =
+    Option.fold ~none:""
+      ~some:(fun i -> Run_time.Duration.pp_readable_opt i.Client.finished_at)
+      step_info
+  in
+  let queued_for =
+    Run_time.Duration.pp_opt (Option.map Run_time.TimeInfo.queued_for run_time)
+  in
+  let ran_for =
+    Run_time.Duration.pp_opt (Option.map Run_time.TimeInfo.ran_for run_time)
+  in
+  let variant =
+    Option.fold ~none:""
+      ~some:(fun i -> Fmt.str "%s" i.Client.variant)
+      step_info
+  in
+  let is_experimental =
+    Option.fold ~none:false ~some:(fun i -> i.Client.is_experimental) step_info
+  in
   {
     version;
-    status =
-      Option.fold ~none:""
-        ~some:(fun i -> Fmt.str "%a" Client.State.pp i.Client.outcome)
-        step_info;
-    created_at =
-      Option.fold ~none:""
-        ~some:(fun i -> Run_time.Duration.pp_readable_opt i.Client.queued_at)
-        step_info;
-    finished_at =
-      Option.fold ~none:""
-        ~some:(fun i -> Run_time.Duration.pp_readable_opt i.Client.finished_at)
-        step_info;
-    queued_for =
-      Run_time.Duration.pp_opt
-        (Option.map Run_time.TimeInfo.queued_for run_time);
-    ran_for =
-      Run_time.Duration.pp_opt (Option.map Run_time.TimeInfo.ran_for run_time);
+    status;
+    created_at;
+    finished_at;
+    queued_for;
+    ran_for;
     can_rebuild;
     can_cancel;
-    variant =
-      Option.fold ~none:""
-        ~some:(fun i -> Fmt.str "%s" i.Client.variant)
-        step_info;
+    variant;
+    is_experimental;
   }
 
 let from_status_info ~step_info ~build_created_at =

--- a/web-ui/static/js/build-page-poll.js
+++ b/web-ui/static/js/build-page-poll.js
@@ -72,7 +72,7 @@ function poll(api_path, timeout, interval) {
           const hyphen = document.createElement("div");
           const step_queued_for = document.createElement("div");
           const right_matter = document.createElement("div"); // ran_for, right_arrow
-          const is_experimental = document.createElement("div"); // TODO
+          const is_experimental = document.createElement("div"); // is_experimental
           const step_ran_for = document.createElement("div"); // ran_for
           const right_arrow_elt = document.createElement("div");
 

--- a/web-ui/static/js/build-page-poll.js
+++ b/web-ui/static/js/build-page-poll.js
@@ -102,11 +102,12 @@ function poll(api_path, timeout, interval) {
           main.appendChild(step_info);
           main.setAttribute("class", "flex items-center space-x-3");
 
-          is_experimental.textContent = "(EXPERIMENTAL)";
           step_ran_for.textContent = "Ran for " + step["ran_for"];
-
           right_arrow_elt.innerHTML = right_arrow;
-          right_matter.appendChild(is_experimental);
+          if (step["is_experimental"]) {
+            is_experimental.textContent = "(experimental)";
+            right_matter.appendChild(is_experimental);
+          }
           right_matter.appendChild(step_ran_for);
           right_matter.appendChild(right_arrow_elt);
           right_matter.setAttribute(

--- a/web-ui/static/js/build-page-poll.js
+++ b/web-ui/static/js/build-page-poll.js
@@ -72,6 +72,7 @@ function poll(api_path, timeout, interval) {
           const hyphen = document.createElement("div");
           const step_queued_for = document.createElement("div");
           const right_matter = document.createElement("div"); // ran_for, right_arrow
+          const is_experimental = document.createElement("div"); // TODO
           const step_ran_for = document.createElement("div"); // ran_for
           const right_arrow_elt = document.createElement("div");
 
@@ -101,9 +102,11 @@ function poll(api_path, timeout, interval) {
           main.appendChild(step_info);
           main.setAttribute("class", "flex items-center space-x-3");
 
+          is_experimental.textContent = "(EXPERIMENTAL)";
           step_ran_for.textContent = "Ran for " + step["ran_for"];
 
           right_arrow_elt.innerHTML = right_arrow;
+          right_matter.appendChild(is_experimental);
           right_matter.appendChild(step_ran_for);
           right_matter.appendChild(right_arrow_elt);
           right_matter.setAttribute(

--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -103,7 +103,8 @@ let title_card ~status ~card_title ~hash_link ~ref_links ~first_created_at
           ];
       ])
 
-let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
+let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri
+    ~is_experimental =
   let cached = queued_for = "0s" && ran_for = "0s" in
   let queued_for_txt =
     if cached then "cached" else Fmt.str "%s in queue" queued_for
@@ -154,8 +155,8 @@ let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
                 ];
             ]
           (let content = [ div [ txt ran_for_txt ]; Common.right_arrow_head ] in
-
-           if true then div [ txt "(EXPERIMENTAL)" ] :: content else content);
+           if is_experimental then div [ txt "(experimental)" ] :: content
+           else content);
       ])
 
 let tabulate_steps step_rows =
@@ -169,7 +170,7 @@ let tabulate_steps step_rows =
         div
           [
             txt "*Variants labelled ";
-            code [ txt "(EXPERIMENTAL)" ];
+            code [ txt "(experimental)" ];
             txt
               " are still undergoing testing; if they have failed it may be a \
                bug in OCaml-CI.";

--- a/web-ui/view/build.ml
+++ b/web-ui/view/build.ml
@@ -153,7 +153,9 @@ let step_row ~step_title ~created_at ~queued_for ~ran_for ~status ~step_uri =
                    items-center";
                 ];
             ]
-          [ div [ txt ran_for_txt ]; Common.right_arrow_head ];
+          (let content = [ div [ txt ran_for_txt ]; Common.right_arrow_head ] in
+
+           if true then div [ txt "(EXPERIMENTAL)" ] :: content else content);
       ])
 
 let tabulate_steps step_rows =
@@ -164,4 +166,12 @@ let tabulate_steps step_rows =
         div
           ~a:[ a_id "table-container"; a_class [ "table-container" ] ]
           step_rows;
+        div
+          [
+            txt "*Variants labelled ";
+            code [ txt "(EXPERIMENTAL)" ];
+            txt
+              " are still undergoing testing; if they have failed it may be a \
+               bug in OCaml-CI.";
+          ];
       ])

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -175,7 +175,8 @@ module Make (M : Git_forge_intf.Forge) = struct
           List.append l
             [
               Build.step_row ~step_title:j.variant ~created_at ~queued_for
-                ~ran_for ~status:j.outcome ~step_uri;
+                ~ran_for ~status:j.outcome ~step_uri
+                ~is_experimental:j.is_experimental;
             ])
         [] jobs
     in


### PR DESCRIPTION
Failures of experimental variants can sometimes be due to bugs in OCaml-CI. This should be signposted to users who would otherwise think that there is a definite issue with their project.

I'm open to rewording of the explanatory text at the bottom of the page, which is currently:
> *Variants labelled `(experimental)` are still undergoing testing; if they have failed it may be a bug in OCaml-CI.

---

<img width="658" alt="Screenshot 2023-05-24 at 11 24 36" src="https://github.com/ocurrent/ocaml-ci/assets/13054139/a6321f20-4d6a-46ff-9796-b5c01fb5c569">