### PR TITLE
Print OCaml and OPAM version in spec file

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -206,6 +206,7 @@ let spec ~base ~opam_version ~opam_files ~selection =
   in
   stage ~from:base
     (comment "%s" (Fmt.str "%a" Variant.pp selection.Selection.variant)
+     :: run "eval $(opam env) && ocaml --version && opam --version"
      :: user_unix ~uid:1000 ~gid:1000
      :: install_project_deps ~opam_version ~opam_files ~selection
     @ [ copy [ "." ] ~dst:home_dir; run_build ])

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -206,7 +206,7 @@ let spec ~base ~opam_version ~opam_files ~selection =
   in
   stage ~from:base
     (comment "%s" (Fmt.str "%a" Variant.pp selection.Selection.variant)
-     :: run "eval $(opam env) && ocaml --version && opam --version"
+     :: run "opam exec -- ocaml --version && opam --version"
      :: user_unix ~uid:1000 ~gid:1000
      :: install_project_deps ~opam_version ~opam_files ~selection
     @ [ copy [ "." ] ~dst:home_dir; run_build ])

--- a/test/service/test_spec.ml
+++ b/test/service/test_spec.ml
@@ -3,6 +3,7 @@ let expected_macos_spec =
   {|
 ((from macos-homebrew-ocaml-4.14)
  (comment macos-homebrew-4.14.0_opam-2.1)
+ (run (shell "opam exec -- ocaml --version && opam --version"))
  (user (uid 1000) (gid 1000)) (env CLICOLOR_FORCE 1)
  (env OPAMCOLOR always)
  (run (shell "ln -f ~/local/bin/opam-2.1 ~/local/bin/opam"))
@@ -35,6 +36,7 @@ let expected_linux_spec =
   {|
 ((from ocaml/opam@sha256:03668731d460043acc763d35e1d5dfc6e6fe68a02f987849ac74f855e3e42c10)
  (comment debian-11-4.14.0_opam-2.1)
+ (run (shell "opam exec -- ocaml --version && opam --version"))
  (user (uid 1000) (gid 1000)) (env CLICOLOR_FORCE 1)
  (env OPAMCOLOR always)
  (workdir /src)


### PR DESCRIPTION
This is often useful information for debugging errors that are localised to specific versions. It can also expose configuration inconsistencies in our infrastructure.

As an example, the output may look like:
```
/: (run (shell "opam exec -- ocaml --version && opam --version"))
The OCaml toplevel, version 5.2.0+dev0-2023-04-11
2.0.10
```