### PR TITLE
Collate magic strings and fix lower-bounds experimental check

### DIFF
--- a/lib/build_info.ml
+++ b/lib/build_info.ml
@@ -14,8 +14,8 @@ let of_label label = { label; variant = None }
 let experimental_variant s =
   if
     Astring.String.(
-      is_prefix ~affix:"(lint-lower-bounds)" s.label
-      || is_prefix ~affix:"(lint-opam)" s.label)
+      is_prefix ~affix:Variant.lower_bound_label s.label
+      || is_prefix ~affix:Variant.opam_label s.label)
   then true
   else
     match s.variant with
@@ -35,8 +35,8 @@ let experimental_variant s =
     potentially give false positives. *)
 let experimental_variant_str s =
   Astring.String.(
-    is_prefix ~affix:"(lint-lower-bounds)" s
-    || is_prefix ~affix:"(lint-opam)" s
+    is_prefix ~affix:Variant.lower_bound_label s
+    || is_prefix ~affix:Variant.opam_label s
     || is_prefix ~affix:"macos-homebrew" s
     || is_infix ~affix:"-5.1" s
     || is_infix ~affix:"-5.1~alpha1" s

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -88,8 +88,8 @@ let build_with_docker ?ocluster ?on_cancel ~(repo : Repo_id.t Current.t)
             let lint_selection =
               Opam_monorepo.selection_of_config (List.hd builds)
             in
-            Spec.opam ~label:"(lint-fmt)" ~selection:lint_selection ~analysis
-              (`Lint `Fmt)
+            Spec.opam ~label:Variant.analysis_label ~selection:lint_selection
+              ~analysis (`Lint `Fmt)
             :: Spec.opam_monorepo builds
         | `Opam_build selections ->
             let lint_selection = List.hd selections in
@@ -109,17 +109,18 @@ let build_with_docker ?ocluster ?on_cancel ~(repo : Repo_id.t Current.t)
               Selection.filter_duplicate_opam_versions s
               |> List.map (fun selection ->
                      let label =
-                       if selection.Selection.lower_bound then "(lower-bound)"
+                       if selection.Selection.lower_bound then
+                         Variant.lower_bound_label
                        else Variant.to_string selection.Selection.variant
                      in
                      Spec.opam ~label ~selection ~analysis `Build)
             and lint =
               [
-                Spec.opam ~label:"(lint-fmt)" ~selection:lint_ocamlformat
+                Spec.opam ~label:Variant.fmt_label ~selection:lint_ocamlformat
                   ~analysis (`Lint `Fmt);
-                Spec.opam ~label:"(lint-doc)" ~selection:lint_selection
+                Spec.opam ~label:Variant.doc_label ~selection:lint_selection
                   ~analysis (`Lint `Doc);
-                Spec.opam ~label:"(lint-opam)" ~selection:lint_selection
+                Spec.opam ~label:Variant.opam_label ~selection:lint_selection
                   ~analysis (`Lint `Opam);
               ]
             in
@@ -144,4 +145,7 @@ let build_with_docker ?ocluster ?on_cancel ~(repo : Repo_id.t Current.t)
     Current.state ~hidden:true (Current.map (fun _ -> `Checked) analysis)
   and+ analysis_id = get_job_id analysis in
   builds
-  @ [ (Build_info.of_label "(analysis)", (analysis_result, analysis_id)) ]
+  @ [
+      ( Build_info.of_label Variant.analysis_label,
+        (analysis_result, analysis_id) );
+    ]

--- a/lib/run_time.ml
+++ b/lib/run_time.ml
@@ -206,7 +206,7 @@ module TimeList = struct
   let partition_build_steps build =
     let analysis_steps, rest =
       List.partition
-        (fun (variant, _) -> String.equal variant "(analysis)")
+        (fun (variant, _) -> String.equal variant Variant.analysis_label)
         build
     in
     let analysis_steps = List.map snd analysis_steps in

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -25,6 +25,12 @@ module Ocaml_version = struct
     | _ -> Error "unknown json for ocaml version"
 end
 
+let analysis_label = "(analysis)"
+let lower_bound_label = "(lower-bound)"
+let fmt_label = "(lint-fmt)"
+let doc_label = "(lint-doc)"
+let opam_label = "(lint-opam)"
+
 type t = {
   distro : string;
   ocaml_version : Ocaml_version.t;

--- a/lib/variant.mli
+++ b/lib/variant.mli
@@ -3,6 +3,12 @@
     A build variant covers the OCaml version, opam version, hardware [arch] and
     operating system distribution. *)
 
+val analysis_label : string
+val lower_bound_label : string
+val fmt_label : string
+val doc_label : string
+val opam_label : string
+
 type t [@@deriving eq, ord, yojson]
 
 val v :

--- a/test/service/test_pipeline.ml
+++ b/test/service/test_pipeline.ml
@@ -51,13 +51,15 @@ let test_summarise_running () =
 
 let test_summarise_success_experimental_fail () =
   let result =
-    Ocaml_ci.Build_info.
-      [
-        (of_label "build_1", (Result.Ok `Built, ()));
-        (of_label "build_2", (Result.Ok `Built, ()));
-        (of_label "lint_1", (Result.Ok `Checked, ()));
-        (of_label "(lint-lower-bounds)", (Result.Error (`Msg "failed"), ()));
-      ]
+    Ocaml_ci.(
+      Build_info.
+        [
+          (of_label "build_1", (Result.Ok `Built, ()));
+          (of_label "build_2", (Result.Ok `Built, ()));
+          (of_label "lint_1", (Result.Ok `Checked, ()));
+          ( of_label Variant.lower_bound_label,
+            (Result.Error (`Msg "failed"), ()) );
+        ])
     |> Ocaml_ci.Pipeline.summarise
   in
   let expected = Result.Ok () in
@@ -65,13 +67,14 @@ let test_summarise_success_experimental_fail () =
 
 let test_summarise_success_experimental_running () =
   let result =
-    Ocaml_ci.Build_info.
-      [
-        (of_label "build_1", (Result.Ok `Built, ()));
-        (of_label "build_2", (Result.Ok `Built, ()));
-        (of_label "lint_1", (Result.Ok `Checked, ()));
-        (of_label "(lint-lower-bounds)", (Result.Error (`Active ()), ()));
-      ]
+    Ocaml_ci.(
+      Build_info.
+        [
+          (of_label "build_1", (Result.Ok `Built, ()));
+          (of_label "build_2", (Result.Ok `Built, ()));
+          (of_label "lint_1", (Result.Ok `Checked, ()));
+          (of_label Variant.lower_bound_label, (Result.Error (`Active ()), ()));
+        ])
     |> Ocaml_ci.Pipeline.summarise
   in
   let expected = Result.Ok () in
@@ -87,8 +90,8 @@ let test_experimental () =
     Ocaml_ci.(
       Build_info.
         [
-          (true, of_label "(lint-lower-bounds)");
-          (false, of_label "(lint-doc)");
+          (true, of_label Variant.lower_bound_label);
+          (false, of_label Variant.doc_label);
           ( true,
             {
               label = "";

--- a/test/service/test_run_time.ml
+++ b/test/service/test_run_time.ml
@@ -2,6 +2,7 @@ module Index = Ocaml_ci.Index
 module Run_time = Ocaml_ci.Run_time
 module Job = Current.Job
 module Client = Ocaml_ci_api.Client
+module Variant = Ocaml_ci.Variant
 
 let setup () =
   let open Lwt.Syntax in
@@ -350,11 +351,12 @@ let test_build_created_at_empty =
 
 let test_build_created_at_happy_path =
   let analysis_step =
-    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
-      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
+    Client.create_job_info Variant.analysis_label Passed
+      ~queued_at:(Some 1234567.) ~started_at:(Some 1234570.)
+      ~finished_at:(Some 1234575.)
   in
   let lint_step =
-    Client.create_job_info "(lint-fmt)" Passed ~queued_at:(Some 1234576.)
+    Client.create_job_info Variant.fmt_label Passed ~queued_at:(Some 1234576.)
       ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
   let build_step =
@@ -369,12 +371,14 @@ let test_build_created_at_happy_path =
 
 let test_build_created_at_mangled =
   let analysis_step =
-    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
-      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
+    Client.create_job_info Variant.analysis_label Passed
+      ~queued_at:(Some 1234567.) ~started_at:(Some 1234570.)
+      ~finished_at:(Some 1234575.)
   in
   let analysis_step_2 =
-    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234576.)
-      ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
+    Client.create_job_info Variant.analysis_label Passed
+      ~queued_at:(Some 1234576.) ~started_at:(Some 1234579.)
+      ~finished_at:(Some 1234585.)
   in
   let build_step =
     Client.create_job_info "foo-11-4.14" Active ~queued_at:(Some 1234576.)
@@ -388,11 +392,12 @@ let test_build_created_at_mangled =
 
 let test_total_of_run_times =
   let analysis_step =
-    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
-      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
+    Client.create_job_info Variant.analysis_label Passed
+      ~queued_at:(Some 1234567.) ~started_at:(Some 1234570.)
+      ~finished_at:(Some 1234575.)
   in
   let lint_step =
-    Client.create_job_info "(lint-fmt)" Passed ~queued_at:(Some 1234576.)
+    Client.create_job_info Variant.fmt_label Passed ~queued_at:(Some 1234576.)
       ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
   let build_step =
@@ -407,12 +412,13 @@ let test_total_of_run_times =
 let test_build_run_time =
   (* run-time of analysis step is 3 + 5 = 8 *)
   let analysis_step =
-    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1234567.)
-      ~started_at:(Some 1234570.) ~finished_at:(Some 1234575.)
+    Client.create_job_info Variant.analysis_label Passed
+      ~queued_at:(Some 1234567.) ~started_at:(Some 1234570.)
+      ~finished_at:(Some 1234575.)
   in
   (* run-time of lint step is 3 + 6 = 9 *)
   let lint_step =
-    Client.create_job_info "(lint-fmt)" Passed ~queued_at:(Some 1234576.)
+    Client.create_job_info Variant.fmt_label Passed ~queued_at:(Some 1234576.)
       ~started_at:(Some 1234579.) ~finished_at:(Some 1234585.)
   in
   (* run-time of build_step is 3 + 11 = 14 -- this is the longest running step *)

--- a/test/web/test_build_representation.ml
+++ b/test/web/test_build_representation.ml
@@ -2,6 +2,7 @@ module Build = Representation.Build
 module Step = Representation.Step
 module Client = Ocaml_ci_api.Client
 module Run_time = Ocaml_ci.Run_time
+module Variant = Ocaml_ci.Variant
 
 let test_to_json (jobs, build_status, build_created_at, expected) =
   let result =
@@ -15,8 +16,9 @@ let test_to_json (jobs, build_status, build_created_at, expected) =
    by adding timedesc-tzlocal.utc to the dune file. See the README for timedesc *)
 let test_simple () =
   let step_info_1 =
-    Client.create_job_info "(analysis)" Passed ~queued_at:(Some 1666210392.)
-      ~started_at:(Some 1666210434.) ~finished_at:(Some 1666210490.)
+    Client.create_job_info Variant.analysis_label Passed
+      ~queued_at:(Some 1666210392.) ~started_at:(Some 1666210434.)
+      ~finished_at:(Some 1666210490.)
   in
   let expected_1 =
     {|{"version":"1.0","status":"passed","created_at":"Oct 19 20:13 +00:00","finished_at":"Oct 19 20:14 +00:00","queued_for":"42s","ran_for":"56s","can_rebuild":false,"can_cancel":false,"variant":"(analysis)","is_experimental":false}|}

--- a/web-ui/controller/git_forge.ml
+++ b/web-ui/controller/git_forge.ml
@@ -2,6 +2,7 @@ module type View = View.Git_forge.View
 
 module Client = Ocaml_ci_api.Client
 module Run_time = Ocaml_ci.Run_time
+module Variant = Ocaml_ci.Variant
 
 module type Controller = sig
   val list_repos : org:string -> Backend.t -> Dream.server Dream.message Lwt.t
@@ -281,7 +282,7 @@ module Make (View : View) : Controller = struct
     let rebuild_many commit job_infos =
       let go job_info commit success failed =
         let variant = job_info.Client.variant in
-        if variant = "(analysis)" then
+        if variant = Variant.analysis_label then
           (* Do not rebuild analysis -- this triggers other jobs *)
           Lwt.return (success, failed)
         else


### PR DESCRIPTION
Non-build variants are currently labelled with strings like "(lint-fmt)", which are copied into lots of places in the codebase. There was apparently a change of the label for lower-bounds builds from "(lint-lower-bounds)" to "(lower-bound)", but not everywhere, leading to them no longer being considered experimental builds and failing CI.