### PR TITLE
Auto-collapse refs in admin UI

### DIFF
--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -151,7 +151,8 @@ let v ?ocluster ~app ~solver ~migrations () =
           set_active_refs ~repo refs default
         in
         refs
-        |> Current.list_iter (module Github.Api.Commit) @@ fun head ->
+        |> Current.list_iter ~collapse_key:"ref" (module Github.Api.Commit)
+           @@ fun head ->
            let src = Git.fetch (Current.map Github.Api.Commit.id head) in
            let analysis =
              Analyse.examine ~solver ~platforms ~opam_repository_commit src


### PR DESCRIPTION
Currently, when a repo is expanded in the admin UI, every ref is also expanded, showing every single build for every ref. This takes up too much space and makes it difficult to find a wanted ref.

This PR collapses these by default, as is done in https://github.com/ocurrent/multicoretests-ci/pull/6.

New behaviour:

<img width="652" alt="Screenshot 2023-07-07 at 15 21 01" src="https://github.com/ocurrent/ocaml-ci/assets/13054139/ab08bce9-582a-4ad3-b900-94696bc4e737">
