### PR TITLE
Lint on linux (the sequel)

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -224,7 +224,16 @@ module Analysis = struct
           Hashtbl.add solver_cache version (selections, platforms);
           selections
     in
-    let selection = List.hd selections in
+    let selection =
+      List.find_opt
+        (fun x ->
+          Variant.arch x.Selection.variant == `X86_64
+          && Variant.os x.Selection.variant == `linux)
+        selections
+    in
+    let selection =
+      match selection with None -> List.hd selections | Some s -> s
+    in
     (selection.Selection.commit, selection)
 
   let of_dir ~solver ~job ~platforms ~opam_repository_commit root =

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -102,11 +102,12 @@ let build_with_docker ?ocluster ?on_cancel ~(repo : Repo_id.t Current.t)
                       (Variant.ocaml_version y.Selection.variant))
                   selections
               in
-              List.find
+              List.find_opt
                 (fun x ->
                   Variant.arch x.Selection.variant == `X86_64
                   && Variant.os x.Selection.variant == `linux)
                 sorted
+              |> Option.value ~default:(List.hd selections)
             in
             let lint_ocamlformat =
               match Analyse.Analysis.ocamlformat_selection analysis with


### PR DESCRIPTION
Prefer running `(lint-fmt)` on Linux x86 platforms. Completion of #839.