### PR TITLE
Constrain platform for `(opam-dune-lint)`

### DIFF
--- a/lib/spec.mli
+++ b/lib/spec.mli
@@ -15,6 +15,7 @@ val opam :
   [ `Build | `Lint of [ `Doc | `Fmt | `Opam ] ] ->
   t
 
+val lint_specs : analysis:Analyse.Analysis.t -> Selection.t list -> t list
 val opam_monorepo : Opam_monorepo.config list -> t list
 val pp : t Fmt.t
 val compare : t -> t -> int


### PR DESCRIPTION
`(opam-dune-lint)` has been failing due to a change that preferred the lowest available version of OCaml for linting steps, and it was not noticed that `(opam-dune-lint)` has a constraint of `ocaml >= 4.14.0`.

This PR corrects this, and refactors the logic for choosing platforms for linting.