### PR TITLE
Linting without installing dependencies of a project

### DIFF
--- a/lib/build.ml
+++ b/lib/build.ml
@@ -37,8 +37,8 @@ let make_build_spec ~base ~repo ~variant ~ty =
       Opam_build.spec ~base ~opam_files ~selection ~opam_version
   | `Opam (`Lint `Doc, selection, opam_files) ->
       Lint.doc_spec ~base ~opam_files ~selection
-  | `Opam (`Lint `Opam, selection, opam_files) ->
-      Lint.opam_dune_lint_spec ~base ~opam_files ~selection
+  | `Opam (`Lint `Opam, selection, _) ->
+      Lint.opam_dune_lint_spec ~base ~selection
   | `Opam_fmt (selection, ocamlformat_source) ->
       Lint.fmt_spec ~base ~ocamlformat_source ~selection
   | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -19,9 +19,6 @@ val opam_lint_spec : base:string -> opam_files:string list -> Obuilder_spec.t
 (** A build spec that lints the dune and opam files for common errors. *)
 
 val opam_dune_lint_spec :
-  base:string ->
-  opam_files:string list ->
-  selection:Selection.t ->
-  Obuilder_spec.t
+  base:string -> selection:Selection.t -> Obuilder_spec.t
 (** A build spec that does extra linting of the dune and opam files for common
     errors. *)


### PR DESCRIPTION
[opam-dune-lint](https://github.com/ocurrent/opam-dune-lint/pull/46) doesn't build a project when linting, so installing the dependencies isn't necessary.

_To note this is on experimentation._