### PR TITLE
Add experimental builds for Opam 2 2

### DIFF
--- a/lib/build_info.ml
+++ b/lib/build_info.ml
@@ -21,15 +21,17 @@ let experimental_variant s =
     match s.variant with
     | None -> false
     | Some v ->
-        Astring.String.equal "freebsd" (Variant.distro v)
-        || Astring.String.equal "macos-homebrew" (Variant.distro v)
-        || Ocaml_version.(equal (v 5 1 ~patch:0)) (Variant.ocaml_version v)
-        || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"alpha1"))
-             (Variant.ocaml_version v)
-        || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"alpha2"))
-             (Variant.ocaml_version v)
-        || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"beta1"))
-             (Variant.ocaml_version v)
+       (* Opam 2.2 is experimental version for now. *)
+       Opam_version.equal (Variant.opam_version v) `V2_2
+       || Astring.String.equal "freebsd" (Variant.distro v)
+       || Astring.String.equal "macos-homebrew" (Variant.distro v)
+       || Ocaml_version.(equal (v 5 1 ~patch:0)) (Variant.ocaml_version v)
+       || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"alpha1"))
+            (Variant.ocaml_version v)
+       || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"alpha2"))
+            (Variant.ocaml_version v)
+       || Ocaml_version.(equal (v 5 1 ~patch:0 ~prerelease:"beta1"))
+            (Variant.ocaml_version v)
 
 (** Like [experimental_variant], but takes strings for when a [build_info]
     record is unavailable.
@@ -38,7 +40,8 @@ let experimental_variant s =
     potentially give false positives. *)
 let experimental_variant_str s =
   Astring.String.(
-    is_prefix ~affix:Variant.lower_bound_label s
+    is_infix ~affix:"opam-2.2" s
+    || is_prefix ~affix:Variant.lower_bound_label s
     || is_prefix ~affix:Variant.opam_label s
     || is_prefix ~affix:"freebsd" s
     || is_prefix ~affix:"macos-homebrew" s

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -158,6 +158,11 @@ let install_project_deps ~opam_version ~opam_files ~selection =
           "opam update --depexts && opam install --cli=2.1 --depext-only -y %s \
            $DEPS"
           compatible_root_pkgs
+    | `V2_2 ->
+        run ~network ~cache
+          "opam update --depexts && opam install --cli=2.2 --depext-only -y %s \
+           $DEPS"
+          compatible_root_pkgs
   in
   (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
      [ shell [ "/usr/bin/linux32"; "/bin/sh"; "-c" ] ]

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -1,11 +1,20 @@
-type t = [ `V2_0 | `V2_1 ] [@@deriving ord, yojson, eq]
+type t = [ `V2_0 | `V2_1 | `V2_2 ] [@@deriving ord, yojson, eq]
 
-let to_string = function `V2_0 -> "2.0" | `V2_1 -> "2.1"
-let to_string_with_patch = function `V2_0 -> "2.0.10" | `V2_1 -> "2.1.2"
+let to_string = function
+  | `V2_0 -> "2.0"
+  | `V2_1 -> "2.1"
+  | `V2_2 -> "2.2" (* TODO Should be 2.2 when an official release is made. *)
+
+let to_string_with_patch = function
+  | `V2_0 -> "2.0.10"
+  | `V2_1 -> "2.1.5"
+  | `V2_2 -> "2.2.0~alpha2"
+
 let pp = Fmt.of_to_string to_string
-let default = `V2_0
+let default = `V2_1
 
 let of_string = function
   | "2.0" -> Ok `V2_0
   | "2.1" -> Ok `V2_1
+  | "2.2" | "2.2.0~alpha2" -> Ok `V2_2
   | s -> Error (`Msg (s ^ ": invalid opam version"))

--- a/lib/opam_version.mli
+++ b/lib/opam_version.mli
@@ -1,6 +1,6 @@
 (** Opam versions supported. *)
 
-type t = [ `V2_0 | `V2_1 ] [@@deriving ord, yojson, eq]
+type t = [ `V2_0 | `V2_1 | `V2_2 ] [@@deriving ord, yojson, eq]
 
 val pp : t Fmt.t
 val to_string : t -> string

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -102,7 +102,9 @@ let docker_specs ~analysis =
             take_lowest_bound_selection lower_bound @ other
           in
           let builds s =
-            Selection.filter_duplicate_opam_versions s
+            (* TODO Remove temporarily while we test opam 2.2. *)
+            (* Selection.filter_duplicate_opam_versions s *)
+            s
             |> List.map (fun selection ->
                    let label =
                      if selection.Selection.lower_bound then

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -189,7 +189,9 @@ let platforms ~ci_profile ~include_macos opam_version =
       lower_bound;
     }
   in
+
   let master_distro = DD.resolve_alias DD.master_distro in
+  (* TODO This DD.master_distro implies Linux. *)
   (* Make platforms for all arches and desired variants using [distro] *)
   let make_platform distro =
     let distro = DD.resolve_alias distro in
@@ -345,4 +347,7 @@ let fetch_platforms ~include_macos () =
   let v2_1 =
     platforms ~ci_profile `V2_1 ~include_macos |> merge_lower_bound_platforms
   in
-  Current.list_seq (List.map v v2_1) |> Current.map List.flatten
+  (* Build on Linux with opam 2.2 for testing. *)
+  let v2_2 : platform list = platforms ~ci_profile `V2_2 ~include_macos:false in
+  Current.list_seq (List.map v (List.append v2_1 v2_2))
+  |> Current.map List.flatten


### PR DESCRIPTION
Adds experimental builds for opam.2.2 using the pre-built opam-dev (master) builds in the docker base images. 
Tagged as a draft because:
1. Some variants like flambda don't work with the opam list command to get opam-vars
2. opam-vars query is hardcoded for macOS and FreeBSD, when it should be run on those cluster builds.