### PR TITLE
Correct README for recursive submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ opam install --deps-only ./ocaml-dockerfile ./ocluster ./ocurrent ./solver-servi
 
 Note: you need to clone with `--recursive` because this project uses submodules
 (it depends on some packages that aren't released yet).
-If you forget, `git submodule update --init` will fetch them.
+If you forget, `git submodule update --init --recursive` will fetch them.
 
 To test the CI on a local Git clone, you need to first install the
 dependencies and then use `dune exec` as shown below:


### PR DESCRIPTION
When pulling submodules after cloning the repo, the `--recursive` flag must be present in:

```
git submodule update --init --recursive
```

This was highlighted when testing https://github.com/ocurrent/ocaml-ci/pull/855, as it introduces the recursive submodule `ocaml-gitlab` inside `ocurrent`.