### PR TITLE
Select a Debian-12 linux distro to run the opam-monorepo build on.

### DIFF
--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -151,11 +151,25 @@ let selection ~info:(lock_file_path, lock_file) ~platforms ~solve =
           ] );
     ]
   in
-  solve ~root_pkgs ~pinned_pkgs:[] ~platforms >|= fun workers ->
-  let selection =
-    List.hd workers |> Selection.remove_package ~package:deps_package
+  solve ~root_pkgs ~pinned_pkgs:[] ~platforms >>= fun workers ->
+  (* Choose a linux distro (Debian-12 is the default) to run the build on. *)
+  let debian_selection =
+    List.find_opt
+      (fun worker ->
+        String.equal (Variant.distro worker.Selection.variant) "debian-12"
+        && Variant.arch worker.Selection.variant == `X86_64)
+      workers
   in
-  { lock_file_path; selection; lock_file_version; switch_type }
+  match debian_selection with
+  | Some selection ->
+      let selection =
+        Selection.remove_package ~package:deps_package selection
+      in
+      Lwt_result.return
+        { lock_file_path; selection; lock_file_version; switch_type }
+  | None ->
+      Lwt.return_error
+        (`Msg "No debian-12 solution found for this monorepo build.")
 
 let initialize_switch ~network = function
   | Base -> []


### PR DESCRIPTION
The ordering on the solve result is not stable so we need to be more specific about the selection.

The list of workers is a Selection.t list of potential builds you could perform for that project. It seems to mostly be the same except for the platform (linux-x86, macos-x86 etc) to build on. The old code was taking the head of that list and assuming it was a good platform to build on, it was often building on macos which isn’t a good choice (less build resources and probably not the main platform for Mirage related things).

My change is to explicitly look for the default platform (debian-12 linux x86) and use that to perform the monorepo build on.