### PR TITLE
Remove the fmt job when .ocamlformat analysis fails

### DIFF
--- a/lib/analyse.ml
+++ b/lib/analyse.ml
@@ -292,16 +292,9 @@ module Analysis = struct
       find_opam_repo_commit_for_ocamlformat ~solve
         ~platforms:(filter_linux_x86_64_platforms platforms)
     in
-    let analysed_ocamlformat =
-      Analyse_ocamlformat.get_ocamlformat_source job ~opam_files ~root
-        ~find_opam_repo_commit
-      >>= function
-      | Error (`Msg msg) ->
-          Current.Job.log job "%s@." msg;
-          Lwt_result.return (None, None)
-      | Ok x -> Lwt_result.return x
-    in
-    analysed_ocamlformat >>!= fun (ocamlformat_source, ocamlformat_selection) ->
+    Analyse_ocamlformat.get_ocamlformat_source job ~opam_files ~root
+      ~find_opam_repo_commit
+    >>!= fun (ocamlformat_source, ocamlformat_selection) ->
     if opam_files = [] then Lwt_result.fail (`Msg "No opam files found!")
     else if List.filter Fpath.is_seg opam_files = [] then
       Lwt_result.fail (`Msg "No top-level opam files found!")

--- a/lib/analyse_ocamlformat.mli
+++ b/lib/analyse_ocamlformat.mli
@@ -1,7 +1,7 @@
 (** Detect the required version of OCamlFormat used in a source repository. *)
 
 type source =
-  | Opam of { version : string; opam_repo_commit : string }
+  | Opam of { version : string; opam_repo_commit : string option }
       (** Should install OCamlFormat from opam. *)
   | Vendored of { path : string }
       (** OCamlFormat is vendored. [path] is relative to the project's root. *)

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -27,7 +27,7 @@ let commit_from_ocamlformat_source ocamlformat_source =
   let open Analyse_ocamlformat in
   match ocamlformat_source with
   | None | Some (Vendored _) -> None
-  | Some (Opam { opam_repo_commit; _ }) -> Some opam_repo_commit
+  | Some (Opam { opam_repo_commit; _ }) -> opam_repo_commit
 
 let fmt_spec ~base ~ocamlformat_source ~selection =
   let open Obuilder_spec in


### PR DESCRIPTION
This is the fix of #834, which was partially fixed on #865