### PR TITLE
Correct copy-paste behaviour in logs

### DIFF
--- a/web-ui/static/css/style.css
+++ b/web-ui/static/css/style.css
@@ -216,7 +216,7 @@ pre.code span.tr {
 }
 
 pre.code span.th { /* used for line numbers */
-  @apply table-cell select-none;
+  @apply table-cell;
   width: 4em;
 }
 

--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -577,6 +577,8 @@ module Make (M : Git_forge_intf.Forge) = struct
           last_line_blank := log_line = "";
           line_number := !line_number + 1;
           let line_number_id = Printf.sprintf "L%d" !line_number in
+          (* Ensure empty lines appear in copy-pastes *)
+          let log_line = if log_line = "" then "\n" else log_line in
           let line =
             Fmt.str "%a" (pp_elt ())
               (span


### PR DESCRIPTION
This PR fixes two issues:

1. Currently when copy-pasting logs on Firefox, an extra newline is added to each line. This is related to the CSS property `user-select: none` (and browser-specific variants) that is attached to the line number `span` to the left of each log line. This PR removes the CSS property which fixes the issue. Fixes #875.

There is a slight regression on Safari in that the line numbers now have the appearance of being partially selected along with the log lines, however the line numbers themselves (which are `::before` pseudo-elements) are not copied and the pasting behaviour is as expected. It appears that when selecting text in Safari, the containing element is highlighted rather than the text itself. As it makes no functional difference, I'll let it be.

2. In Chrome and Firefox, copy-pasted logs do not include a space between paragraphs (i.e. two newlines) when they should. Safari currently does include this. As a fix, this PR replaces empty log lines with newline characters which creates the correct behaviour in Chrome and Firefox. In Safari there are now two spaces between each paragraph, but I would rather have two spaces than no spaces so I include this fix.

Correct paragraph behaviour; Safari pre-fix and Chrome and Firefox post-fix:
```
/: (comment macos-homebrew-4.14.1_arm64_opam-2.1)

/: (user (uid 1000) (gid 1000))
```

Incorrect behaviour; Chrome and Firefox pre-fix:
```
/: (comment macos-homebrew-4.14.1_arm64_opam-2.1)
/: (user (uid 1000) (gid 1000))
```

Incorrect behaviour; Safari post-fix:
```
/: (comment macos-homebrew-4.14.1_arm64_opam-2.1)


/: (user (uid 1000) (gid 1000))
```

Tested on Macos M1, on Chrome (117.0.5938.92), Firefox (117.0.1), and Safari (15.6.1).