### PR TITLE
Show raw logs.

### DIFF
--- a/web-ui/router.ml
+++ b/web-ui/router.ml
@@ -41,12 +41,17 @@ struct
       Printf.sprintf "/%s/:org/:repo/commit/:hash/variant/:variant" F.prefix
     in
     Dream.get url (fun request ->
+        let show_raw_logs =
+          match Dream.query request "show_raw" with
+          | None -> false
+          | Some message -> message = "true"
+        in
         F.Controller.show_step
           ~org:(Dream.param request "org")
           ~repo:(Dream.param request "repo")
           ~hash:(Dream.param request "hash")
           ~variant:(Dream.param request "variant")
-          request F.backend)
+          ~show_raw_logs request F.backend)
 
   let branch_history =
     let url = Printf.sprintf "/%s/:org/:repo/history/branch/**" F.prefix in

--- a/web-ui/view/common.ml
+++ b/web-ui/view/common.ml
@@ -640,3 +640,19 @@ let logo_unsafe =
 </linearGradient>
 </defs>
 </svg>|})
+
+let show_logs_button show_raw =
+  let href, text =
+    match show_raw with
+    | true -> ("?show_raw=true", "Show raw logs")
+    | false -> ("?show_raw=false", "Show full logs")
+  in
+  Tyxml.Html.(
+    a
+      ~a:
+        [
+          a_class [ "btn btn-secondary btn-xs rounded-full" ];
+          a_rel [ `Alternate ];
+          a_href href;
+        ]
+      [ txt text ])

--- a/web-ui/view/git_forge.ml
+++ b/web-ui/view/git_forge.ml
@@ -13,6 +13,7 @@ module Make (F : Forge) : View = struct
   let list_refs = Ref.list
   let list_steps = Step.list
   let show_step = Step.show
+  let show_step_raw = Step.show_raw
 
   include Message
 end

--- a/web-ui/view/git_forge_intf.ml
+++ b/web-ui/view/git_forge_intf.ml
@@ -98,6 +98,25 @@ module type View = sig
     ?flash_messages:(string * string) list ->
     string * int64 ->
     Dream.response Lwt.t
+
+  val show_step_raw :
+    org:string ->
+    repo:string ->
+    refs:string list ->
+    hash:string ->
+    variant:Client.variant ->
+    job:Current_rpc.Job.t ->
+    status:Client.State.t ->
+    csrf_token:string ->
+    timestamps:Run_time.Timestamp.t option ->
+    build_created_at:float option ->
+    step_created_at:float option ->
+    step_finished_at:float option ->
+    can_rebuild:bool ->
+    can_cancel:bool ->
+    ?flash_messages:(string * string) list ->
+    string * int64 ->
+    Dream.response Lwt.t
 end
 
 module type S = sig

--- a/web-ui/view/step.mli
+++ b/web-ui/view/step.mli
@@ -33,4 +33,23 @@ module Make : functor (_ : Git_forge_intf.Forge) -> sig
     ?flash_messages:(string * string) list ->
     string * int64 ->
     Dream.response Lwt.t
+
+  val show_raw :
+    org:string ->
+    repo:string ->
+    refs:string list ->
+    hash:string ->
+    variant:string ->
+    job:Current_rpc.Job.t ->
+    status:Git_forge_intf.Client.State.t ->
+    csrf_token:string ->
+    timestamps:Git_forge_intf.Run_time.Timestamp.t option ->
+    build_created_at:float option ->
+    step_created_at:float option ->
+    step_finished_at:float option ->
+    can_rebuild:bool ->
+    can_cancel:bool ->
+    ?flash_messages:(string * string) list ->
+    string * int64 ->
+    Dream.response Lwt.t
 end


### PR DESCRIPTION
Introduces the ability to see logs in their raw form and to move between this view and the current fully decorated logs. 

![Screenshot 2023-09-27 at 8 57 01 am](https://github.com/ocurrent/ocaml-ci/assets/181086/df21272d-fd8d-448b-9193-c87936594f0a)


![Screenshot 2023-09-27 at 8 56 47 am](https://github.com/ocurrent/ocaml-ci/assets/181086/84a34aac-6d3b-4981-b3ad-1050b96567ba)
