### PR TITLE
Add `PLATFORMS` environment variable to support local Docker stack

### DIFF
--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -47,9 +47,12 @@ let setup_log default_level =
   Prometheus_unix.Logging.init ?default_level ();
   Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna);
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
-  match Conf.ci_profile with
-  | `Production -> Logs.info (fun f -> f "Using production configuration")
-  | `Dev -> Logs.info (fun f -> f "Using dev configuration")
+  (match Conf.capnp_profile with
+  | `Production -> Logs.info (fun f -> f "Using production capnp configuration")
+  | `Dev -> Logs.info (fun f -> f "Using dev capnp configuration"));
+  match Conf.platforms_profile with
+  | `All -> Logs.info (fun f -> f "Testing all platforms")
+  | `Minimal -> Logs.info (fun f -> f "Testing minimal platforms")
 
 let or_die = function Ok x -> x | Error (`Msg m) -> failwith m
 

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -2,11 +2,11 @@
 
 let website_scheme_and_domain = "https://ocaml.ci.dev"
 
-let ci_profile =
-  match Sys.getenv_opt "CI_PROFILE" with
+let capnp_profile =
+  match Sys.getenv_opt "CAPNP_PROFILE" with
   | Some "production" -> `Production
   | Some "dev" | None -> `Dev
-  | Some x -> Fmt.failwith "Unknown $CI_PROFILE setting %S." x
+  | Some x -> Fmt.failwith "Unknown $CAPNP_PROFILE setting %S." x
 
 let platforms_profile =
   match Sys.getenv_opt "PLATFORMS" with
@@ -15,7 +15,7 @@ let platforms_profile =
   | Some x -> Fmt.failwith "Unknown $PLATFORMS setting %S." x
 
 let cmdliner_envs =
-  let ci_profile_doc =
+  let capnp_doc =
     let values = [ "production"; "dev" ] in
     Printf.sprintf "CI profile settings, must be %s."
       (Cmdliner.Arg.doc_alts values)
@@ -26,7 +26,7 @@ let cmdliner_envs =
       (Cmdliner.Arg.doc_alts values)
   in
   [
-    Cmdliner.Cmd.Env.info "CI_PROFILE" ~doc:ci_profile_doc;
+    Cmdliner.Cmd.Env.info "CAPNP_PROFILE" ~doc:capnp_doc;
     Cmdliner.Cmd.Env.info "PLATFORMS" ~doc:platforms_doc;
   ]
 
@@ -39,7 +39,7 @@ module Capnp = struct
      (because they're just internal to the Docker container). *)
 
   let cap_secrets =
-    match ci_profile with
+    match capnp_profile with
     | `Production -> "/capnp-secrets"
     | `Dev -> "./capnp-secrets"
 

--- a/service/main.ml
+++ b/service/main.ml
@@ -46,9 +46,12 @@ let setup_log default_level =
   Prometheus_unix.Logging.init ?default_level ();
   Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna);
   Prometheus.CollectorRegistry.(register_pre_collect default) Metrics.update;
-  match Conf.ci_profile with
-  | `Production -> Logs.info (fun f -> f "Using production configuration")
-  | `Dev -> Logs.info (fun f -> f "Using dev configuration")
+  (match Conf.capnp_profile with
+  | `Production -> Logs.info (fun f -> f "Using production capnp configuration")
+  | `Dev -> Logs.info (fun f -> f "Using dev capnp configuration"));
+  match Conf.platforms_profile with
+  | `All -> Logs.info (fun f -> f "Testing all platforms")
+  | `Minimal -> Logs.info (fun f -> f "Testing minimal platforms")
 
 let or_die = function Ok x -> x | Error (`Msg m) -> failwith m
 

--- a/stack.yml
+++ b/stack.yml
@@ -42,7 +42,7 @@ services:
       --verbosity info
       --github-account-allowlist 'talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,robur-coop,misterda,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV,ocaml-community,verbosemode,tomjridge,thizanne,n-osborne,TheLortex,patricoferris,routineco,moby,djs55,hyunha,hyper-systems,coco33920,sanette,maiste,yomimono,c-cube,novemberkilo,joaosreis,mtelvers,ygrek,geocaml,panglesd,SimonJF,haesbaert,benmandrew,andrenth,backtracking,jmid,shindere,gildor478,mefyl,ElectreAAS,well-typed-lightbulbs,johnyob,lasamlai,zshipko,andreas,bobot,dialohq,reynir,nilsbecker,ngernest,progman1,moyodiallo,edwintorok'
     environment:
-      - "CI_PROFILE=production"
+      - "CAPNP_PROFILE=production"
       - "PLATFORMS=all"
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"
@@ -76,7 +76,7 @@ services:
       --migration-path /migrations
       --verbosity info
     environment:
-      - "CI_PROFILE=production"
+      - "CAPNP_PROFILE=production"
       - "PLATFORMS=all"
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"

--- a/stack.yml
+++ b/stack.yml
@@ -43,6 +43,7 @@ services:
       --github-account-allowlist 'talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,julow,ocaml-gospel,vbmithr,gs0510,magnuss,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,robur-coop,misterda,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV,ocaml-community,verbosemode,tomjridge,thizanne,n-osborne,TheLortex,patricoferris,routineco,moby,djs55,hyunha,hyper-systems,coco33920,sanette,maiste,yomimono,c-cube,novemberkilo,joaosreis,mtelvers,ygrek,geocaml,panglesd,SimonJF,haesbaert,benmandrew,andrenth,backtracking,jmid,shindere,gildor478,mefyl,ElectreAAS,well-typed-lightbulbs,johnyob,lasamlai,zshipko,andreas,bobot,dialohq,reynir,nilsbecker,ngernest,progman1,moyodiallo,edwintorok'
     environment:
       - "CI_PROFILE=production"
+      - "PLATFORMS=all"
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"
     ports:
@@ -76,6 +77,7 @@ services:
       --verbosity info
     environment:
       - "CI_PROFILE=production"
+      - "PLATFORMS=all"
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"
     ports:

--- a/test/service/test_conf.ml
+++ b/test/service/test_conf.ml
@@ -21,7 +21,7 @@ let to_tag d = DD.((resolve_alias d :> t) |> tag_of_distro)
 
 let test_platforms () =
   let platforms =
-    Service.Conf.platforms ~ci_profile:`Production ~include_macos:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true `V2_1
     |> List.map extract
   in
   let exists =
@@ -57,7 +57,7 @@ let test_platforms () =
 
 let test_macos_platforms () =
   let platforms =
-    Service.Conf.platforms ~ci_profile:`Production ~include_macos:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true `V2_1
     |> List.map extract
   in
   let exists =
@@ -93,7 +93,7 @@ let test_macos_platforms () =
 
 let test_distro_arches () =
   let platforms =
-    Service.Conf.platforms ~ci_profile:`Production ~include_macos:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true `V2_1
     |> List.map extract
   in
   (* Test that these distros don't occur with these arches under any OCaml version *)


### PR DESCRIPTION
Currently the `CI_PROFILE` env controls both where capnp secrets are located (relative path for local testing or absolute path for Docker volume), and what platforms are chosen to test on (a minimal subset, or all of them).

I am working on a `docker-compose.yml` for testing an entire OCaml-CI stack locally, where `CI_PROFILE=production` is needed. However, for this sort of local testing a minimal subset of platforms is preferred. This PR separates the platforms behaviour of `CI_PROFILE` into `PLATFORMS` so that they can be set independently.