### PR TITLE
Docker compose setup for locally testing the whole OCaml-CI stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ var
 .vscode
 /capnp-secrets/
 .DS_Store
+
+.env

--- a/Dockerfile.rsync-worker
+++ b/Dockerfile.rsync-worker
@@ -1,0 +1,2 @@
+FROM ocurrent/ocluster-worker:live
+RUN apt-get -qq update && apt-get -qq --yes install rsync

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -26,17 +26,14 @@ Push
 
 ## Running the GitHub pipeline locally
 
-In `docker-compose.yml` change the following:
+You will need the following:
 
-1. Under `services`, then `service`, change the argument to `--github-app-id` to the GitHub App ID of the app you created
-2. Under the same `service` tag, change the argument to `--github-account-allowlist` to a comma-separated list of GitHub accounts to allow—this could start out as just your GitHub account
-3. Under `secrets`, set `ocaml-ci-github-key` to the `pem` file containing the private key associated to the app, and `ocaml-ci-webhook-secret` to a file containing the webhook secret that is used to authenticate to the app
+1. The GitHub App ID of the app you created
+2. A comma-separated list of GitHub accounts to allow—this could start out as just your GitHub account
+3. A file `private-key.pem` containing the private key associated with the app
+4. A file `webhook-secret` containing the webhook secret that is used to authenticate with the app
 
-Build the docker containers for `service` and `web`:
-```
-docker build -t ocaml-ci-service -f Dockerfile .
-docker build -t ocaml-ci-web -f Dockerfile.web .
-```
+`private-key.pem` and `webhook-secret` must be stored in the same directory on the host. The directory path will be needed.
 
 Create a file `/etc/caddy/Caddyfile` containing:
 ```
@@ -57,15 +54,29 @@ http://localhost {
 
 You can then start the services with:
 ```
-docker compose up
+APP_ID=... ALLOW_LIST=... SECRETS_DIR=... docker compose up
 ```
 
 You should see the admin site on [`http://localhost:8100`](http://localhost:8100) and the user site on [`http://localhost`](http://localhost).
 
-If you want webhooks to be redirected to your application, start `smee` in another terminal, replacing the argument to `--url` with the URL you generated before on [smee.io](https://smee.io):
+Alternatively, you can store the environment variables in a `.env` file at the root of the project. For example:
+```
+APP_ID=359343
+ALLOW_LIST="myusername,ocurrent"
+SECRETS_DIR=$HOME/ci_secrets/
+```
+
+You can then run the compose as simply:
+```
+docker compose up
+```
+
+If you want webhooks to be directed to your application, start `smee` in another terminal, replacing the argument to `--url` with the URL you generated before on [smee.io](https://smee.io):
 ```
 smee --url https://smee.io/xxxxxxxxxxxxxxxx --path /webhooks/github --port 8100
 ```
+
+Make sure that the GitHub App is sending webhooks to the URL, specified in its settings.
 
 ## Migrations
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -32,6 +32,12 @@ In `docker-compose.yml` change the following:
 2. Under the same `service` tag, change the argument to `--github-account-allowlist` to a comma-separated list of GitHub accounts to allow—this could start out as just your GitHub account
 3. Under `secrets`, set `ocaml-ci-github-key` to the `pem` file containing the private key associated to the app, and `ocaml-ci-webhook-secret` to a file containing the webhook secret that is used to authenticate to the app
 
+Build the docker containers for `service` and `web`:
+```
+docker build -t ocaml-ci-service -f Dockerfile .
+docker build -t ocaml-ci-web -f Dockerfile.web .
+```
+
 Create a file `/etc/caddy/Caddyfile` containing:
 ```
 {
@@ -50,7 +56,6 @@ http://localhost {
 ```
 
 You can then start the services with:
-
 ```
 docker compose up
 ```
@@ -58,7 +63,6 @@ docker compose up
 You should see the admin site on [`http://localhost:8100`](http://localhost:8100) and the user site on [`http://localhost`](http://localhost).
 
 If you want webhooks to be redirected to your application, start `smee` in another terminal, replacing the argument to `--url` with the URL you generated before on [smee.io](https://smee.io):
-
 ```
 smee --url https://smee.io/xxxxxxxxxxxxxxxx --path /webhooks/github --port 8100
 ```

--- a/doc/gitlab-dev.md
+++ b/doc/gitlab-dev.md
@@ -1,0 +1,18 @@
+## Running the GitLab pipeline locally
+
+You will need the following:
+
+1. The GitLab API token with permissions to the repositories to build
+2. GitLab secret associated with webhooks
+3. A capability file for submitting jobs to a cluster, in this case the main ocaml-ci cluster as documented in https://github.com/ocurrent/ocluster#admin
+
+``` shell
+dune exec -- ocaml-ci-gitlab \
+  --gitlab-token-file <your-gitlab-token> \
+  --gitlab-webhook-secret-file <your-gitlab-secret> \
+  --submission-service <path-to-the-submission-capability-file> \
+  --capnp-listen-address tcp:127.0.0.1:9800
+  --migration-path "$PWD/migrations"
+```
+
+This will generate a capability file. See the logs for `Wrote capability reference to "./capnp-secrets/ocaml-ci-gitlab-admin.cap"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,13 +9,9 @@ volumes:
 
 secrets:
   ocaml-ci-github-key:
-    file: $HOME/ci_secrets/benmandrew-ci.2022-10-05.private-key.pem
-  ocaml-ci-submission.cap:
-    file: $HOME/ci_secrets/ben.cap
+    file: $HOME/ci_secrets/new-test-ci.2022-11-08.private-key.pem
   ocaml-ci-webhook-secret:
     file: $HOME/ci_secrets/benmandrew-ci-webhook-secret
-  ocaml-ci-solver.cap:
-    file: $HOME/ci_secrets/solver.cap
 
 services:
   caddy:
@@ -30,7 +26,6 @@ services:
       - caddy_config:/config
 
   service:
-    # image: ocurrent/ocaml-ci-service:live
     image: ocaml-ci-service
     # For local deploys using docker build -t ocaml-ci-service -f Dockerfile .
     command: >
@@ -41,76 +36,83 @@ services:
       --confirm-auto-release 120
       --capnp-public-address=tcp:service:8102
       --capnp-listen-address=tcp:0.0.0.0:9000
-      --submission-service /run/secrets/ocaml-ci-submission.cap
-      --submission-solver-service /run/secrets/ocaml-ci-solver.cap 
+      --submission-service /capnp-secrets/user.cap
+      --submission-solver-service /capnp-secrets/user.cap
       --migration-path /migrations
-      --verbosity info
       --github-account-allowlist 'benmandrew'
-    # Wait for the default network to be created
     restart: on-failure
     environment:
       - "CAPNP_PROFILE=production"
       - "PLATFORMS=minimal"
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"
+    ports:
+      - '8102:9000'
     volumes:
       - 'data:/var/lib/ocurrent'
       - '/var/run/docker.sock:/var/run/docker.sock'
       - 'capnp-secrets:/capnp-secrets'
     secrets:
       - 'ocaml-ci-github-key'
-      - 'ocaml-ci-submission.cap'
-      - 'ocaml-ci-solver.cap'
       - 'ocaml-ci-webhook-secret'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
 
-  web:
-    # image: ocurrent/ocaml-ci-web:live
-    image: ocaml-ci-web
-    # For local deploys using docker build -t ocaml-ci-web -f Dockerfile.web .
-    command: >
-      --backend /capnp-secrets/ocaml-ci-admin.cap
-      --listen-prometheus=9090
-    # Wait for the default network to be created
-    restart: on-failure
-    volumes:
-      - 'capnp-secrets:/capnp-secrets:ro'
-    sysctls:
-      - 'net.ipv4.tcp_keepalive_time=60'
+  # web:
+  #   image: ocaml-ci-web
+  #   # For local deploys using docker build -t ocaml-ci-web -f Dockerfile.web .
+  #   command: >
+  #     --backend /capnp-secrets/ocaml-ci-admin.cap
+  #     --listen-prometheus=9090
+  #   # Wait for the default network to be created
+  #   restart: on-failure
+  #   volumes:
+  #     - 'capnp-secrets:/capnp-secrets:ro'
+  #   sysctls:
+  #     - 'net.ipv4.tcp_keepalive_time=60'
 
   scheduler:
     image: ocurrent/ocluster-scheduler:live
-    command:
-      - --secrets-dir=/capnp-secrets
-      - --capnp-secret-key-file=/capnp-secrets/key.pem
-      - --capnp-listen-address=tcp:0.0.0.0:9000
-      - --capnp-public-address=tcp:scheduler:9000
-      - --pools=macos-arm64
-      - --state-dir=/var/lib/ocluster-scheduler
-    # Wait for the default network to be created
+    command: >
+      --secrets-dir=/capnp-secrets
+      --capnp-secret-key-file=/capnp-secrets/key.pem
+      --capnp-listen-address=tcp:0.0.0.0:9000
+      --capnp-public-address=tcp:scheduler:9000
+      --pools=solver,linux-x86_64
+      --state-dir=/var/lib/ocluster-scheduler
     restart: on-failure
     volumes:
       - 'scheduler-data:/var/lib/ocluster-scheduler'
       - 'capnp-secrets:/capnp-secrets'
 
+  # Generate the capability file to allow the
+  # service to connect to the scheduler
+  scheduler-cap:
+    image: ocurrent/ocluster-scheduler:live
+    entrypoint: /bin/sh
+    command: -c "ocluster-admin -c /capnp-secrets/admin.cap add-client user >> /capnp-secrets/user.cap"
+    depends_on:
+      - scheduler
+    volumes:
+      - 'capnp-secrets:/capnp-secrets'
+
   worker:
-    image: ocurrent/ocluster-worker:live
+    # image: ocurrent/ocluster-worker:live
     build:
-      dockerfile: docker/worker/Dockerfile
       context: .
-    command:
-      - --connect=/capnp-secrets/pool-macos-arm64.cap
-      - --name=ocluster-worker
-      # - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
-      - --capacity=1
-      - --state-dir=/var/lib/ocluster
-      - --obuilder-store=docker:/var/cache/obuilder
-      - --obuilder-healthcheck=0
-      - --verbose
+      dockerfile: Dockerfile.rsync-worker
+    command: >
+      --connect=/capnp-secrets/pool-linux-x86_64.cap
+      --name=ocluster-worker
+      --capacity=1
+      --state-dir=/var/lib/ocluster
+      --obuilder-store=rsync:/rsync
+      --rsync-mode=copy
+      --obuilder-healthcheck=0
+      --verbose
     # Required for the Docker in Docker container to work
     privileged: true
-    # Wait for the scheduler to write the pool cap
+    # Wait for the scheduler to write pool-linux-x86_64.cap
     restart: on-failure
     volumes:
       - 'worker-data:/var/lib/ocluster'
@@ -119,3 +121,20 @@ services:
     environment:
       - DOCKER_BUILDKIT=1
       - DOCKER_CLI_EXPERIMENTAL=enabled
+
+  solver-worker:
+      image: ocurrent/solver-service:live
+      command: >
+        --connect=/capnp-secrets/pool-solver.cap
+        --name=solver-worker
+        --capacity=1
+        --internal-workers=1
+        --state-dir=/var/lib/ocluster
+        --verbose
+      # Wait for the scheduler to write pool-solver.cap
+      restart: on-failure
+      volumes:
+        - 'worker-data:/var/lib/ocluster'
+        - 'capnp-secrets:/capnp-secrets:ro'
+      environment:
+        - DOCKER_BUILDKIT=1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,12 +34,14 @@ services:
       --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret
       --confirm above-average
       --confirm-auto-release 120
-      --capnp-public-address=tcp:service:8102
+      --capnp-public-address=tcp:service:9000
       --capnp-listen-address=tcp:0.0.0.0:9000
       --submission-service /capnp-secrets/user.cap
       --submission-solver-service /capnp-secrets/user.cap
       --migration-path /migrations
       --github-account-allowlist 'benmandrew'
+    depends_on:
+      - scheduler
     restart: on-failure
     environment:
       - "CAPNP_PROFILE=production"
@@ -47,7 +49,7 @@ services:
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"
     ports:
-      - '8102:9000'
+      - ':9000'
     volumes:
       - 'data:/var/lib/ocurrent'
       - '/var/run/docker.sock:/var/run/docker.sock'
@@ -58,18 +60,20 @@ services:
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
 
-  # web:
-  #   image: ocaml-ci-web
-  #   # For local deploys using docker build -t ocaml-ci-web -f Dockerfile.web .
-  #   command: >
-  #     --backend /capnp-secrets/ocaml-ci-admin.cap
-  #     --listen-prometheus=9090
-  #   # Wait for the default network to be created
-  #   restart: on-failure
-  #   volumes:
-  #     - 'capnp-secrets:/capnp-secrets:ro'
-  #   sysctls:
-  #     - 'net.ipv4.tcp_keepalive_time=60'
+  web:
+    image: ocaml-ci-web
+    # For local deploys using docker build -t ocaml-ci-web -f Dockerfile.web .
+    command: >
+      --backend /capnp-secrets/ocaml-ci-admin.cap
+      --listen-prometheus=9090
+    depends_on:
+      - service
+    # Wait for the default network to be created
+    restart: on-failure
+    volumes:
+      - 'capnp-secrets:/capnp-secrets:ro'
+    sysctls:
+      - 'net.ipv4.tcp_keepalive_time=60'
 
   scheduler:
     image: ocurrent/ocluster-scheduler:live
@@ -109,7 +113,6 @@ services:
       --obuilder-store=rsync:/rsync
       --rsync-mode=copy
       --obuilder-healthcheck=0
-      --verbose
     # Required for the Docker in Docker container to work
     privileged: true
     # Wait for the scheduler to write pool-linux-x86_64.cap
@@ -130,7 +133,6 @@ services:
         --capacity=1
         --internal-workers=1
         --state-dir=/var/lib/ocluster
-        --verbose
       # Wait for the scheduler to write pool-solver.cap
       restart: on-failure
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,27 +9,29 @@ volumes:
 
 secrets:
   ocaml-ci-github-key:
-    file: $HOME/ci_secrets/new-test-ci.2022-11-08.private-key.pem
+    file: ${SECRETS_DIR}/private-key.pem
   ocaml-ci-webhook-secret:
-    file: $HOME/ci_secrets/benmandrew-ci-webhook-secret
+    file: ${SECRETS_DIR}/webhook-secret
 
 services:
   caddy:
     image: caddy
     ports:
-      - 80:80
-      - 443:443
-      - 8100:8100
+      - '80:80'
+      - '443:443'
+      - '8100:8100'
     volumes:
       - /etc/caddy:/etc/caddy:ro
       - caddy_data:/data
       - caddy_config:/config
 
   service:
-    image: ocaml-ci-service
+    build:
+      context: .
+      dockerfile: Dockerfile
     # For local deploys using docker build -t ocaml-ci-service -f Dockerfile .
     command: >
-      --github-app-id 244548
+      --github-app-id ${APP_ID}
       --github-private-key-file /run/secrets/ocaml-ci-github-key
       --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret
       --confirm above-average
@@ -39,7 +41,7 @@ services:
       --submission-service /capnp-secrets/user.cap
       --submission-solver-service /capnp-secrets/user.cap
       --migration-path /migrations
-      --github-account-allowlist 'benmandrew'
+      --github-account-allowlist '${ALLOW_LIST}'
     depends_on:
       - scheduler
     restart: on-failure
@@ -48,8 +50,6 @@ services:
       - "PLATFORMS=minimal"
       - "DOCKER_BUILDKIT=1"
       - "PROGRESS_NO_TRUNC=1"
-    ports:
-      - ':9000'
     volumes:
       - 'data:/var/lib/ocurrent'
       - '/var/run/docker.sock:/var/run/docker.sock'
@@ -61,7 +61,9 @@ services:
       - 'net.ipv4.tcp_keepalive_time=60'
 
   web:
-    image: ocaml-ci-web
+    build:
+      context: .
+      dockerfile: Dockerfile.web
     # For local deploys using docker build -t ocaml-ci-web -f Dockerfile.web .
     command: >
       --backend /capnp-secrets/ocaml-ci-admin.cap

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,121 @@
+version: '3.1'
+volumes:
+  data:
+  capnp-secrets:
+  worker-data:
+  scheduler-data:
+  caddy_data:
+  caddy_config:
+
+secrets:
+  ocaml-ci-github-key:
+    file: $HOME/ci_secrets/benmandrew-ci.2022-10-05.private-key.pem
+  ocaml-ci-submission.cap:
+    file: $HOME/ci_secrets/ben.cap
+  ocaml-ci-webhook-secret:
+    file: $HOME/ci_secrets/benmandrew-ci-webhook-secret
+  ocaml-ci-solver.cap:
+    file: $HOME/ci_secrets/solver.cap
+
+services:
+  caddy:
+    image: caddy
+    ports:
+      - 80:80
+      - 443:443
+      - 8100:8100
+    volumes:
+      - /etc/caddy:/etc/caddy:ro
+      - caddy_data:/data
+      - caddy_config:/config
+
+  service:
+    # image: ocurrent/ocaml-ci-service:live
+    image: ocaml-ci-service
+    # For local deploys using docker build -t ocaml-ci-service -f Dockerfile .
+    command: >
+      --github-app-id 244548
+      --github-private-key-file /run/secrets/ocaml-ci-github-key
+      --github-webhook-secret-file /run/secrets/ocaml-ci-webhook-secret
+      --confirm above-average
+      --confirm-auto-release 120
+      --capnp-public-address=tcp:service:8102
+      --capnp-listen-address=tcp:0.0.0.0:9000
+      --submission-service /run/secrets/ocaml-ci-submission.cap
+      --submission-solver-service /run/secrets/ocaml-ci-solver.cap 
+      --migration-path /migrations
+      --verbosity info
+      --github-account-allowlist 'benmandrew'
+    # Wait for the default network to be created
+    restart: on-failure
+    environment:
+      - "CAPNP_PROFILE=production"
+      - "PLATFORMS=minimal"
+      - "DOCKER_BUILDKIT=1"
+      - "PROGRESS_NO_TRUNC=1"
+    volumes:
+      - 'data:/var/lib/ocurrent'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - 'capnp-secrets:/capnp-secrets'
+    secrets:
+      - 'ocaml-ci-github-key'
+      - 'ocaml-ci-submission.cap'
+      - 'ocaml-ci-solver.cap'
+      - 'ocaml-ci-webhook-secret'
+    sysctls:
+      - 'net.ipv4.tcp_keepalive_time=60'
+
+  web:
+    # image: ocurrent/ocaml-ci-web:live
+    image: ocaml-ci-web
+    # For local deploys using docker build -t ocaml-ci-web -f Dockerfile.web .
+    command: >
+      --backend /capnp-secrets/ocaml-ci-admin.cap
+      --listen-prometheus=9090
+    # Wait for the default network to be created
+    restart: on-failure
+    volumes:
+      - 'capnp-secrets:/capnp-secrets:ro'
+    sysctls:
+      - 'net.ipv4.tcp_keepalive_time=60'
+
+  scheduler:
+    image: ocurrent/ocluster-scheduler:live
+    command:
+      - --secrets-dir=/capnp-secrets
+      - --capnp-secret-key-file=/capnp-secrets/key.pem
+      - --capnp-listen-address=tcp:0.0.0.0:9000
+      - --capnp-public-address=tcp:scheduler:9000
+      - --pools=macos-arm64
+      - --state-dir=/var/lib/ocluster-scheduler
+    # Wait for the default network to be created
+    restart: on-failure
+    volumes:
+      - 'scheduler-data:/var/lib/ocluster-scheduler'
+      - 'capnp-secrets:/capnp-secrets'
+
+  worker:
+    image: ocurrent/ocluster-worker:live
+    build:
+      dockerfile: docker/worker/Dockerfile
+      context: .
+    command:
+      - --connect=/capnp-secrets/pool-macos-arm64.cap
+      - --name=ocluster-worker
+      # - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
+      - --capacity=1
+      - --state-dir=/var/lib/ocluster
+      - --obuilder-store=docker:/var/cache/obuilder
+      - --obuilder-healthcheck=0
+      - --verbose
+    # Required for the Docker in Docker container to work
+    privileged: true
+    # Wait for the scheduler to write the pool cap
+    restart: on-failure
+    volumes:
+      - 'worker-data:/var/lib/ocluster'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - 'capnp-secrets:/capnp-secrets:ro'
+    environment:
+      - DOCKER_BUILDKIT=1
+      - DOCKER_CLI_EXPERIMENTAL=enabled

--- a/stack.yml
+++ b/stack.yml
@@ -24,7 +24,7 @@ secrets:
     external: true
 
 services:
-  ci:
+  service-github:
     image: ocurrent/ocaml-ci-service:live
     # image: ocaml-ci-service
     # For local deploys using docker -c ocaml.ci.dev build -t ocaml-ci-service -f Dockerfile .
@@ -61,7 +61,7 @@ services:
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
 
-  gitlab:
+  service-gitlab:
     image: ocurrent/ocaml-ci-gitlab-service:live
     # image: ocaml-ci-gitlab-service
     # For local deploys using docker -c ocaml.ci.dev build -t ocaml-ci-gitlab-service -f Dockerfile.gitlab .


### PR DESCRIPTION
The tested stack currently involves:
- `service`, the OCaml-CI service for GitHub.
- `web`, the front-end web interface.
- `scheduler`, for scheduling jobs.
- `worker`, a single Docker-based worker. I'm on Mac, and the default rsync didn't work first time so I just set it to Docker.
- `caddy`, for reverse proxy stuff (unsure if necessary).

Rebased on top of the contents of #883.

## To run

1. In `docker-compose.yml`, change the file paths under the `secrets` label to point to your own relevant local files.

2. `scheduler`, `worker` and `caddy` pull pre-built images from Docker Hub; `service` and `web` must be built as local images by running:
```
docker build -t ocaml-ci-service -f Dockerfile .
docker build -t ocaml-ci-web -f Dockerfile.web .
```

3. Create a file at `/etc/caddy/Caddyfile` containing:
```
https://localhost:8100 {
	reverse_proxy service:8080
}

https://localhost {
	reverse_proxy web:8090
}
```

4. Run `docker compose up`.
