### PR TITLE
Exclude macos and freebsd builds when running ocaml-ci-local.

### DIFF
--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -18,7 +18,9 @@ module Metrics = struct
       "repositories_total"
 end
 
-let platforms = Conf.fetch_platforms ~include_macos:true ~include_freebsd:true ()
+let platforms =
+  Conf.fetch_platforms ~include_macos:true ~include_freebsd:true ()
+
 let program_name = "ocaml-ci"
 
 (* Link for GitLab statuses. *)
@@ -181,7 +183,9 @@ let gitlab_status_of_state head result =
       Gitlab.Api.Status.v ~url `Failure ~description:m ~name:program_name
 
 let local_test ~solver repo () =
-  let platforms = Conf.fetch_platforms ~include_macos:false ~include_freebsd:false () in
+  let platforms =
+    Conf.fetch_platforms ~include_macos:false ~include_freebsd:false ()
+  in
   let src = Git.Local.head_commit repo in
   let repo = Current.return { Repo_id.owner = "local"; name = "test" }
   and analysis =

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -18,7 +18,7 @@ module Metrics = struct
       "repositories_total"
 end
 
-let platforms = Conf.fetch_platforms ~include_macos:true ()
+let platforms = Conf.fetch_platforms ~include_macos:true ~include_freebsd:true ()
 let program_name = "ocaml-ci"
 
 (* Link for GitLab statuses. *)
@@ -181,7 +181,7 @@ let gitlab_status_of_state head result =
       Gitlab.Api.Status.v ~url `Failure ~description:m ~name:program_name
 
 let local_test ~solver repo () =
-  let platforms = Conf.fetch_platforms ~include_macos:false () in
+  let platforms = Conf.fetch_platforms ~include_macos:false ~include_freebsd:false () in
   let src = Git.Local.head_commit repo in
   let repo = Current.return { Repo_id.owner = "local"; name = "test" }
   and analysis =

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -288,7 +288,7 @@ let get ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base
 
 let get_macos ~arch ~label ~builder ~pool ~distro ~ocaml_version ~opam_version
     ~lower_bound base =
-  (* Hardcoding opam-vars for macos 12.6 Monterey. *)
+  (* Hardcoding opam-vars for macos 13.6 Ventura. *)
   match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
@@ -298,9 +298,9 @@ let get_macos ~arch ~label ~builder ~pool ~distro ~ocaml_version ~opam_version
            {
              Worker.Vars.arch = Ocaml_version.to_opam_arch arch;
              os = "macos";
-             os_family = "macos";
-             os_distribution = "macos";
-             os_version = "12.6";
+             os_family = "homebrew";
+             os_distribution = "homebrew";
+             os_version = "13.4";
              ocaml_package = "ocaml-base-compiler";
              ocaml_version = Fmt.str "%a" Ocaml_version.pp ocaml_version;
              opam_version = Opam_version.to_string_with_patch opam_version;
@@ -322,9 +322,9 @@ let get_freebsd ~arch ~label ~builder ~pool ~distro ~ocaml_version ~opam_version
            {
              Worker.Vars.arch = Ocaml_version.to_opam_arch arch;
              os = "freebsd";
-             os_family = "freebsd";
+             os_family = "bsd";
              os_distribution = "freebsd";
-             os_version = "13.2";
+             os_version = "1302001";
              ocaml_package = "ocaml-base-compiler";
              ocaml_version = Fmt.str "%a" Ocaml_version.pp ocaml_version;
              opam_version = Opam_version.to_string_with_patch opam_version;

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -68,7 +68,8 @@ end
 module OV = Ocaml_version
 module DD = Dockerfile_opam.Distro
 
-(** Default supported compilers. Defined as 4.14 Long Term Support and latest 5.* release. *)
+(** Default supported compilers. Defined as 4.14 Long Term Support and latest
+    5.* release. *)
 let default_compilers =
   OV.(List.map with_just_major_and_minor Releases.[ v4_14; latest ])
 
@@ -76,7 +77,7 @@ let trunk_compiler = OV.(Sources.trunk |> without_patch)
 
 (* Local type representing a Platform to run a build on.
    Where platform is operating system, architecture, OCaml version and opam version.
- *)
+*)
 type platform = {
   label : string;
   builder : Ocaml_ci.Builder.t;
@@ -90,7 +91,8 @@ type platform = {
 
 (* Support OCaml default compilers on FreeBSD platform. *)
 let freebsd_distros =
-  List.map (fun ocaml_version ->
+  List.map
+    (fun ocaml_version ->
       {
         label = "freebsd";
         builder = Builders.local;
@@ -100,11 +102,13 @@ let freebsd_distros =
         arch = `X86_64;
         opam_version = `V2_1;
         lower_bound = false;
-    }) default_compilers
+      })
+    default_compilers
 
 (* Support OCaml default compilers on MacOS platform. *)
 let macos_distros =
-  List.map (fun ocaml_version ->
+  List.map
+    (fun ocaml_version ->
       {
         label = "macos-homebrew";
         builder = Builders.local;
@@ -114,18 +118,21 @@ let macos_distros =
         arch = `X86_64;
         opam_version = `V2_1;
         lower_bound = false;
-    }) default_compilers @
-  List.map (fun ocaml_version ->
-      {
-        label = "macos-homebrew";
-        builder = Builders.local;
-        pool = `Macos_ARM64;
-        distro = "macos-homebrew";
-        ocaml_version;
-        arch = `Aarch64;
-        opam_version = `V2_1;
-        lower_bound = false;
-    } ) default_compilers
+      })
+    default_compilers
+  @ List.map
+      (fun ocaml_version ->
+        {
+          label = "macos-homebrew";
+          builder = Builders.local;
+          pool = `Macos_ARM64;
+          distro = "macos-homebrew";
+          ocaml_version;
+          arch = `Aarch64;
+          opam_version = `V2_1;
+          lower_bound = false;
+        })
+      default_compilers
 
 let pool_of_arch = function
   | `X86_64 | `I386 -> `Linux_x86_64
@@ -202,8 +209,7 @@ let platforms ~profile ~include_macos ~include_freebsd opam_version =
 
 (** When we have the same platform differing only in [lower_bound], for the
     purposes of Docker pulls, take only the platform with [lower_bound = true].
-    The non-lower-bound platform will be regenerated in the "opam-vars" step 
-*)
+    The non-lower-bound platform will be regenerated in the "opam-vars" step *)
 let merge_lower_bound_platforms platforms =
   let eq_without_lower_bound
       {
@@ -299,6 +305,7 @@ let fetch_platforms ~include_macos ~include_freebsd () =
           ~host_base ~opam_version ~lower_bound base
   in
   let v2_1 =
-    platforms ~profile:platforms_profile `V2_1 ~include_macos ~include_freebsd |> merge_lower_bound_platforms
+    platforms ~profile:platforms_profile `V2_1 ~include_macos ~include_freebsd
+    |> merge_lower_bound_platforms
   in
   Current.list_seq (List.map v v2_1) |> Current.map List.flatten

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -68,11 +68,15 @@ end
 module OV = Ocaml_version
 module DD = Dockerfile_opam.Distro
 
+(** Default supported compilers. Defined as 4.14 Long Term Support and latest 5.* release. *)
 let default_compilers =
   OV.(List.map with_just_major_and_minor Releases.[ v4_14; latest ])
 
 let trunk_compiler = OV.(Sources.trunk |> without_patch)
 
+(* Local type representing a Platform to run a build on.
+   Where platform is operating system, architecture, OCaml version and opam version.
+ *)
 type platform = {
   label : string;
   builder : Ocaml_ci.Builder.t;
@@ -84,80 +88,44 @@ type platform = {
   lower_bound : bool;
 }
 
-(* TODO Hardcoding the versions for now, this should expand to OV.Releases.recent.
-   Currently we only have base images for these 2 compiler variants. See ocurrent/freebsd-infra playbook.yml.
-*)
+(* Support OCaml default compilers on FreeBSD platform. *)
 let freebsd_distros =
-  [
-    {
-      label = "freebsd";
-      builder = Builders.local;
-      pool = `FreeBSD_x86_64;
-      distro = "freebsd";
-      ocaml_version = OV.Releases.v4_14;
-      arch = `X86_64;
-      opam_version = `V2_1;
-      lower_bound = false;
-    };
-    {
-      label = "freebsd";
-      builder = Builders.local;
-      pool = `FreeBSD_x86_64;
-      distro = "freebsd";
-      ocaml_version = OV.Releases.v5_1;
-      arch = `X86_64;
-      opam_version = `V2_1;
-      lower_bound = false;
-    };
-  ]
+  List.map (fun ocaml_version ->
+      {
+        label = "freebsd";
+        builder = Builders.local;
+        pool = `FreeBSD_x86_64;
+        distro = "freebsd";
+        ocaml_version;
+        arch = `X86_64;
+        opam_version = `V2_1;
+        lower_bound = false;
+    }) default_compilers
 
-(* TODO Hardcoding the versions for now, this should expand to OV.Releases.recent.
-   Currently we only have base images for these 2 compiler variants. See ocurrent/macos-infra playbook.yml.
-*)
+(* Support OCaml default compilers on MacOS platform. *)
 let macos_distros =
-  [
-    {
-      label = "macos-homebrew";
-      builder = Builders.local;
-      pool = `Macos_x86_64;
-      distro = "macos-homebrew";
-      ocaml_version = OV.Releases.v4_14;
-      arch = `X86_64;
-      opam_version = `V2_1;
-      lower_bound = false;
-    };
-    {
-      label = "macos-homebrew";
-      builder = Builders.local;
-      pool = `Macos_x86_64;
-      distro = "macos-homebrew";
-      ocaml_version = OV.Releases.v5_1;
-      arch = `X86_64;
-      opam_version = `V2_1;
-      lower_bound = false;
-    };
-    (* Apple Silicon *)
-    {
-      label = "macos-homebrew";
-      builder = Builders.local;
-      pool = `Macos_ARM64;
-      distro = "macos-homebrew";
-      ocaml_version = OV.Releases.v4_14;
-      arch = `Aarch64;
-      opam_version = `V2_1;
-      lower_bound = false;
-    };
-    {
-      label = "macos-homebrew";
-      builder = Builders.local;
-      pool = `Macos_ARM64;
-      distro = "macos-homebrew";
-      ocaml_version = OV.Releases.v5_1;
-      arch = `Aarch64;
-      opam_version = `V2_1;
-      lower_bound = false;
-    };
-  ]
+  List.map (fun ocaml_version ->
+      {
+        label = "macos-homebrew";
+        builder = Builders.local;
+        pool = `Macos_x86_64;
+        distro = "macos-homebrew";
+        ocaml_version;
+        arch = `X86_64;
+        opam_version = `V2_1;
+        lower_bound = false;
+    }) default_compilers @
+  List.map (fun ocaml_version ->
+      {
+        label = "macos-homebrew";
+        builder = Builders.local;
+        pool = `Macos_ARM64;
+        distro = "macos-homebrew";
+        ocaml_version;
+        arch = `Aarch64;
+        opam_version = `V2_1;
+        lower_bound = false;
+    } ) default_compilers
 
 let pool_of_arch = function
   | `X86_64 | `I386 -> `Linux_x86_64
@@ -166,7 +134,7 @@ let pool_of_arch = function
   | `Ppc64le -> `Linux_ppc64
   | `Riscv64 -> `Linux_riscv64
 
-let platforms ~profile ~include_macos opam_version =
+let platforms ~profile ~include_macos ~include_freebsd opam_version =
   let v ?(arch = `X86_64) ?(lower_bound = false) label distro ocaml_version =
     {
       arch;
@@ -210,8 +178,9 @@ let platforms ~profile ~include_macos opam_version =
         |> List.concat_map make_platform
       in
       let distros =
-        if include_macos then macos_distros @ distros @ freebsd_distros
-        else distros @ freebsd_distros
+        distros
+        |> List.append (if include_macos then macos_distros else [])
+        |> List.append (if include_freebsd then freebsd_distros else [])
       in
       (* The first one in this list is used for lint actions *)
       let ovs = List.rev OV.Releases.recent @ OV.Releases.unreleased_betas in
@@ -229,14 +198,12 @@ let platforms ~profile ~include_macos opam_version =
       let[@warning "-8"] (latest :: previous :: _) =
         List.rev OV.Releases.recent
       in
-      let macos_distros = if include_macos then macos_distros else [] in
-      let ovs = [ latest; previous ] in
-      let releases = List.map make_release ovs in
-      releases @ macos_distros @ freebsd_distros
+      List.map make_release [ latest; previous ]
 
 (** When we have the same platform differing only in [lower_bound], for the
     purposes of Docker pulls, take only the platform with [lower_bound = true].
-    The non-lower-bound platform will be regenerated in the "opam-vars" step *)
+    The non-lower-bound platform will be regenerated in the "opam-vars" step 
+*)
 let merge_lower_bound_platforms platforms =
   let eq_without_lower_bound
       {
@@ -276,7 +243,7 @@ let merge_lower_bound_platforms platforms =
   in
   upper_bound @ lower_bound
 
-let fetch_platforms ~include_macos () =
+let fetch_platforms ~include_macos ~include_freebsd () =
   let open Ocaml_ci in
   let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
   let v
@@ -332,7 +299,6 @@ let fetch_platforms ~include_macos () =
           ~host_base ~opam_version ~lower_bound base
   in
   let v2_1 =
-    platforms ~profile:platforms_profile `V2_1 ~include_macos
-    |> merge_lower_bound_platforms
+    platforms ~profile:platforms_profile `V2_1 ~include_macos ~include_freebsd |> merge_lower_bound_platforms
   in
   Current.list_seq (List.map v v2_1) |> Current.map List.flatten

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -5,7 +5,7 @@ module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
 
-let platforms = Conf.fetch_platforms ~include_macos:true ()
+let platforms = Conf.fetch_platforms ~include_macos:true  ~include_freebsd:true ()
 
 (* Link for GitHub statuses. *)
 let url ~owner ~name ~hash ~gref =
@@ -112,7 +112,7 @@ let set_active_refs ~repo refs default_ref =
   xs
 
 let local_test ~solver repo () =
-  let platforms = Conf.fetch_platforms ~include_macos:false () in
+  let platforms = Conf.fetch_platforms ~include_macos:false ~include_freebsd:false () in
   let src = Git.Local.head_commit repo in
   let repo = Current.return { Repo_id.owner = "local"; name = "test" }
   and analysis =

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -5,7 +5,8 @@ module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
 
-let platforms = Conf.fetch_platforms ~include_macos:true  ~include_freebsd:true ()
+let platforms =
+  Conf.fetch_platforms ~include_macos:true ~include_freebsd:true ()
 
 (* Link for GitHub statuses. *)
 let url ~owner ~name ~hash ~gref =
@@ -112,7 +113,9 @@ let set_active_refs ~repo refs default_ref =
   xs
 
 let local_test ~solver repo () =
-  let platforms = Conf.fetch_platforms ~include_macos:false ~include_freebsd:false () in
+  let platforms =
+    Conf.fetch_platforms ~include_macos:false ~include_freebsd:false ()
+  in
   let src = Git.Local.head_commit repo in
   let repo = Current.return { Repo_id.owner = "local"; name = "test" }
   and analysis =

--- a/test/service/test_conf.ml
+++ b/test/service/test_conf.ml
@@ -21,7 +21,7 @@ let to_tag d = DD.((resolve_alias d :> t) |> tag_of_distro)
 
 let test_platforms () =
   let platforms =
-    Service.Conf.platforms ~profile:`All ~include_macos:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true ~include_freebsd:true `V2_1
     |> List.map extract
   in
   let exists =
@@ -57,7 +57,7 @@ let test_platforms () =
 
 let test_macos_platforms () =
   let platforms =
-    Service.Conf.platforms ~profile:`All ~include_macos:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true ~include_freebsd:true `V2_1
     |> List.map extract
   in
   let exists =
@@ -93,7 +93,7 @@ let test_macos_platforms () =
 
 let test_distro_arches () =
   let platforms =
-    Service.Conf.platforms ~profile:`All ~include_macos:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true ~include_freebsd:true `V2_1
     |> List.map extract
   in
   (* Test that these distros don't occur with these arches under any OCaml version *)

--- a/test/service/test_conf.ml
+++ b/test/service/test_conf.ml
@@ -21,7 +21,8 @@ let to_tag d = DD.((resolve_alias d :> t) |> tag_of_distro)
 
 let test_platforms () =
   let platforms =
-    Service.Conf.platforms ~profile:`All ~include_macos:true ~include_freebsd:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true
+      ~include_freebsd:true `V2_1
     |> List.map extract
   in
   let exists =
@@ -57,7 +58,8 @@ let test_platforms () =
 
 let test_macos_platforms () =
   let platforms =
-    Service.Conf.platforms ~profile:`All ~include_macos:true ~include_freebsd:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true
+      ~include_freebsd:true `V2_1
     |> List.map extract
   in
   let exists =
@@ -93,7 +95,8 @@ let test_macos_platforms () =
 
 let test_distro_arches () =
   let platforms =
-    Service.Conf.platforms ~profile:`All ~include_macos:true ~include_freebsd:true `V2_1
+    Service.Conf.platforms ~profile:`All ~include_macos:true
+      ~include_freebsd:true `V2_1
     |> List.map extract
   in
   (* Test that these distros don't occur with these arches under any OCaml version *)


### PR DESCRIPTION
ocaml-ci-local pipelines assume you are building using docker which only support Linux.