### PR TITLE
Have GitHub organisations list in one place

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,5 +9,10 @@ deploy-backend:
 deploy-web:
 	env DOCKER_BUILDKIT=1 docker --context $(CONTEXT) build -f Dockerfile.web -t ocaml-ci-web .
 
-deploy-stack:
+orgs := $(shell cat deploy-data/github-organisations.txt | tr '\n' ',')
+
+stack.yml: stack.yml.in deploy-data/github-organisations.txt
+	sed 's/GITHUB_ORGANISATIONS/${orgs:,=}/' stack.yml.in > stack.yml
+
+deploy-stack: stack.yml
 	docker --context $(CONTEXT) stack deploy --prune -c stack.yml ocaml-ci

--- a/deploy-data/github-organisations.txt
+++ b/deploy-data/github-organisations.txt
@@ -92,3 +92,4 @@ ngernest
 progman1
 moyodiallo
 edwintorok
+smuenzel

--- a/stack.yml.in
+++ b/stack.yml.in
@@ -40,7 +40,7 @@ services:
       --submission-solver-service /run/secrets/ocaml-ci-solver.cap 
       --migration-path /migrations
       --verbosity info
-      --github-account-allowlist talex5,ocurrent,ocaml,mirage,avsm,samoht,kit-ty-kate,tarides,aantron,ocamllabs,realworldocaml,NathanReb,0install,gpetiot,ocaml-ppx,CraigFe,pascutto,Julow,ocaml-gospel,vbmithr,gs0510,MagnusS,dune-universe,janestreet,emillon,capnproto,ocaml-opam,ocaml-dune,favonia,joelburget,jeffa5,bikallem,jonludlam,g2p,stedolan,ocsigen,dinosaure,hannesm,mirleft,robur-coop,MisterDA,ocaml-multicore,cdaringe,inhabitedtype,tmcgilchrist,ocaml-doc,grievejia,Leonidas-from-XIV,ocaml-community,verbosemode,tomjridge,thizanne,n-osborne,TheLortex,patricoferris,routineco,moby,djs55,hyunha,hyper-systems,coco33920,sanette,maiste,yomimono,c-cube,novemberkilo,joaosreis,mtelvers,ygrek,geocaml,panglesd,SimonJF,haesbaert,benmandrew,andrenth,backtracking,jmid,shindere,gildor478,mefyl,ElectreAAS,well-typed-lightbulbs,johnyob,lasamlai,zshipko,andreas,bobot,dialohq,reynir,nilsbecker,ngernest,progman1,moyodiallo,edwintorok,smuenzel
+      --github-account-allowlist GITHUB_ORGANISATIONS
     environment:
       - "CAPNP_PROFILE=production"
       - "PLATFORMS=all"


### PR DESCRIPTION
It is becoming unwieldy to have the GitHub orgs stored in two different places (`stack.yml` and `deploy-data/github-organisations.txt`) as well as making it more of a pain for new users to onboard. More often than not, they only put their username in one place.

This PR makes it so `stack.yml` is generated from `stack.yml.in`, with the orgs substituted in from `github-organisations.txt`. This is done when `make deploy-stack` is run.

`github-organisations.txt` is now the unique source of GitHub orgs, and is where new users should add their usernames. I will update the documentation to reflect this.

Currently, the new script substitutes the org list into `stack.yml.in` with a `sed` call, replacing the placeholder string `GITHUB_ORGANISATIONS`. I'm open to suggestion for more robust or idiomatic ways of getting the org list into `stack.yml`.