### PR TITLE
Fix x32_86bit job caused by capnproto

### DIFF
--- a/service/conf.ml
+++ b/service/conf.ml
@@ -206,6 +206,7 @@ let platforms ~profile ~include_macos ~include_freebsd opam_version =
         List.rev OV.Releases.recent
       in
       List.map make_release [ latest; previous ]
+      @ [ make_release ~arch:`I386 OV.Releases.v4_14_1 ]
 
 (** When we have the same platform differing only in [lower_bound], for the
     purposes of Docker pulls, take only the platform with [lower_bound = true].


### PR DESCRIPTION
This is a temporary fix, it may take time to have new release of Debian following bookworm, that fixes capnproto.

Issue related to https://github.com/mirage/capnp-rpc/issues/273.
And a PR is addressed to capnproto https://github.com/capnproto/capnproto/pull/1824