### PR TITLE
Revert names

### DIFF
--- a/stack.yml
+++ b/stack.yml
@@ -24,7 +24,7 @@ secrets:
     external: true
 
 services:
-  service-github:
+  ci:
     image: ocurrent/ocaml-ci-service:live
     # image: ocaml-ci-service
     # For local deploys using docker -c ocaml.ci.dev build -t ocaml-ci-service -f Dockerfile .
@@ -61,7 +61,7 @@ services:
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
 
-  service-gitlab:
+  gitlab:
     image: ocurrent/ocaml-ci-gitlab-service:live
     # image: ocaml-ci-gitlab-service
     # For local deploys using docker -c ocaml.ci.dev build -t ocaml-ci-gitlab-service -f Dockerfile.gitlab .


### PR DESCRIPTION
If we deploy current `stack.yml` with the changes implemented in #884, the services are renamed which prevents Caddy from finding them.

Caddy (under Docker) uses the service names, `ci` and `gitlab`, as DNS names.  Docker resolves these internally to the IP address of the container.  If we need to rename these, we need to update the corresponding `Caddyfile`.

This PR reverts the name changes in #884 while we discuss the way forward.