### PR TITLE
Update opam lint

### DIFF
--- a/lib/analyse.mli
+++ b/lib/analyse.mli
@@ -5,6 +5,7 @@ module Analysis : sig
 
   val opam_files : t -> string list
   val ocamlformat_selection : t -> Selection.t option
+  val opam_dune_lint_selections : t -> Selection.t list
   val ocamlformat_source : t -> Analyse_ocamlformat.source option
 
   val selections :

--- a/lib/build.ml
+++ b/lib/build.ml
@@ -37,8 +37,8 @@ let make_build_spec ~base ~repo ~variant ~ty =
       Opam_build.spec ~base ~opam_files ~selection ~opam_version
   | `Opam (`Lint `Doc, selection, opam_files) ->
       Lint.doc_spec ~base ~opam_files ~selection
-  | `Opam (`Lint `Opam, selection, _) ->
-      Lint.opam_dune_lint_spec ~base ~selection
+  | `Opam (`Lint `Opam, selection, opam_files) ->
+      Lint.opam_dune_lint_spec ~base ~opam_files ~selection
   | `Opam_fmt (selection, ocamlformat_source) ->
       Lint.fmt_spec ~base ~ocamlformat_source ~selection
   | `Opam_monorepo config -> Opam_monorepo.spec ~base ~repo ~config ~variant

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -105,25 +105,12 @@ let doc_spec ~base ~opam_files ~selection =
         only_packages;
     ]
 
-let opam_dune_lint_spec ~base ~selection =
-  let cache =
-    [
-      Obuilder_spec.Cache.v Opam_build.download_cache
-        ~target:"/home/opam/.opam/download-cache";
-    ]
-  in
-  let network = [ "host" ] in
+let opam_dune_lint_spec ~base ~opam_files ~selection =
   let open Obuilder_spec in
   stage ~from:base
   @@ comment "%s" (Fmt.str "%a" Variant.pp selection.Selection.variant)
      :: user_unix ~uid:1000 ~gid:1000
-     :: [
-          run ~cache ~network
-            "git -C ~/opam-repository pull origin master && opam update && \
-             opam pin add -yn opam-dune-lint.dev \
-             https://github.com/ocurrent/opam-dune-lint.git#2c33c7bd4e5d57be7ac7b0230b33cae542b4cbec";
-          run ~cache ~network "opam depext -i opam-dune-lint";
-        ]
+     :: Opam_build.install_project_deps ~opam_version ~opam_files ~selection
   @ [
       env "CI" "true";
       env "OCAMLCI" "true";

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -19,6 +19,9 @@ val opam_lint_spec : base:string -> opam_files:string list -> Obuilder_spec.t
 (** A build spec that lints the dune and opam files for common errors. *)
 
 val opam_dune_lint_spec :
-  base:string -> selection:Selection.t -> Obuilder_spec.t
+  base:string ->
+  opam_files:string list ->
+  selection:Selection.t ->
+  Obuilder_spec.t
 (** A build spec that does extra linting of the dune and opam files for common
     errors. *)

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -97,7 +97,12 @@ let install_project_deps ~opam_version ~opam_files ~selection =
   let groups = group_opam_files opam_files in
   let root_pkgs = get_root_opam_packages groups in
   let non_root_pkgs =
-    packages |> List.filter (fun pkg -> not (List.mem pkg root_pkgs))
+    packages
+    |> List.filter (fun pkg ->
+           (not (List.mem pkg root_pkgs))
+           && not
+                (Astring.String.take ~rev:true ~sat:(( <> ) '.') pkg
+                |> String.equal "opam"))
   in
   let compatible_root_pkgs =
     if only_packages = [] then root_pkgs else only_packages

--- a/lib/spec.ml
+++ b/lib/spec.ml
@@ -67,7 +67,7 @@ let lint_specs ~analysis selections =
         Ocaml_version.(
           compare (Variant.ocaml_version x.Selection.variant) Releases.v4_14_0)
         >= 0)
-      sorted_linux_x86_64_selections
+      (Analyse.Analysis.opam_dune_lint_selections analysis)
   in
   let optional_spec ~label ~selection ~lint_ty =
     Option.map


### PR DESCRIPTION
Instead of using a specific commit of opam-dune-lint, now we're using the released version. And that was the goal since the opam lint job is added.