### PR TITLE
Add Cumulus as an organization allowed to use ocaml-ci

### DIFF
--- a/deploy-data/github-organisations.txt
+++ b/deploy-data/github-organisations.txt
@@ -94,3 +94,4 @@ moyodiallo
 edwintorok
 smuenzel
 9glenda
+Cumulus


### PR DESCRIPTION
Cumulus is currently the owner of `Syndic` which is a library used by `ocaml.org`. It will be nice to have an access to `ocaml-ci` and check if Syndic is in a good shape.