### PR TITLE
fix(lint-fmt): do not fail on generated files

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -70,8 +70,8 @@ let fmt_spec ~base ~ocamlformat_source ~selection =
   @ [
       copy [ "." ] ~dst:"/src/";
       run
-        "opam exec -- dune build @fmt || (echo \"dune build @fmt failed\"; \
-         exit 2)";
+        "opam exec -- dune build @fmt --ignore-promoted-rules || (echo \"dune \
+         build @fmt failed\"; exit 2)";
     ]
 
 let doc_spec ~base ~opam_files ~selection =


### PR DESCRIPTION
In [1] `lint-fmt` failed because of missing dependencies:
```
File "bin/dune", line 6, characters 43-49:
6 |  (libraries dune-site.plugins cmdliner fmt gospel registration))
                                               ^^^^^^
Error: Library "gospel" not found.
-> required by _build/default/bin/cli.exe
-> required by _build/install/default/bin/ortac
-> required by _build/default/examples/lwt_dllist_tests.ml
-> required by alias examples/.formatted/fmt
-> required by alias examples/fmt
```

Dune was trying to build the generated file, however that is not really necessary (there is one in the build tree already), so we should instead ask dune to ignore promoted rules when formatting.

I tested the command `dune build @fmt --ignore-promoted-rules` manually (after removing the `gospel` library) in the `ortac` repository and it succeeded.

[1]: https://ocaml.ci.dev/github/ocaml-gospel/ortac/commit/f5c535da2cdc43f24de078ec0540267210b79905/variant/%28lint-fmt%29