### PR TITLE
Fix Docker compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ocaml/opam:debian-12-ocaml-4.14@sha256:45b04e2a4c933c57549382045dfac12cb7e872cace0456f92f4b022066e48111 AS build
 RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -ni
-RUN sudo apt-get update && sudo apt-get install libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
+RUN sudo apt-get update && sudo apt-get install libcapnp-dev libffi-dev libev-dev capnproto m4 pkg-config libsqlite3-dev libgmp-dev graphviz -y --no-install-recommends
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard cf93548ddc4f36b87b006f4858fac7ae73ccaa0f && opam update
 COPY --chown=opam \
 	ocurrent/current_docker.opam \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,11 +130,12 @@ services:
   solver-worker:
       image: ocurrent/solver-service:live
       command: >
+        run-cluster
         --connect=/capnp-secrets/pool-solver.cap
         --name=solver-worker
         --capacity=1
         --internal-workers=1
-        --state-dir=/var/lib/ocluster
+        --cache-dir=/var/lib/ocluster
       # Wait for the scheduler to write pool-solver.cap
       restart: on-failure
       volumes:


### PR DESCRIPTION
Command-line interface of the solver worker has changed, so needs to be updated in `docker-compose.yml`.

I also needed to install the `libcapnp-dev` and `libffi-dev` system packages in the `Dockerfile` to successfully build it.