### PR TITLE
Update to Tailwind CSS 3.3.6

### DIFF
--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -44,5 +44,5 @@ build: [
 ]
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 pin-depends: [
-  ["tailwindcss.~dev" "https://github.com/tmattio/opam-tailwindcss/archive/f0d65be5f94322f48497b33bc05c057882d57977.tar.gz"]
+  ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
 ]

--- a/ocaml-ci-web.opam.template
+++ b/ocaml-ci-web.opam.template
@@ -1,3 +1,3 @@
 pin-depends: [
-  ["tailwindcss.~dev" "https://github.com/tmattio/opam-tailwindcss/archive/f0d65be5f94322f48497b33bc05c057882d57977.tar.gz"]
+  ["tailwindcss.dev" "https://github.com/tmattio/opam-tailwindcss/archive/3e60fc32bbcf82525999d83ad0f395e16107026b.tar.gz"]
 ]


### PR DESCRIPTION
Both opam and ocaml-ci support pinning tar.gz packages, which are lighter to download than the whole git history.