### PR TITLE
Exclude debian-12 x86_32 from builds with capnproto

### DIFF
--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -77,7 +77,7 @@ let get_job_id x =
    platforms unsupported by some required package. *)
 let excluded_selection =
   let is_debian_12_x86_32 (v : Variant.t) =
-    match Variant.distro v, Variant.arch v with
+    match (Variant.distro v, Variant.arch v) with
     | "debian-12", `X86_64 -> true
     | _ -> false
   in


### PR DESCRIPTION
Debian 12, "bookwork" is currently on a stable package repo, and package versions are frozen. The frozen version of capnproto is 0.9.2. This version does not support large files on 32 bit arch, and this can result in specious test and build failures.

These false positives have been giving us noisy red trunks for a long while, but this fix should clean up our builds until we either drop support for this target or the fix needed is backported to 0.9.2.

Mitigates #931, however that should  remain open until we have a fix, rather than a workaround.