### PR TITLE
Remove use of deprecated depext plugin in lint-doc job

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -99,11 +99,9 @@ let doc_spec ~base ~opam_files ~selection =
      :: user_unix ~uid:1000 ~gid:1000
      :: Opam_build.install_project_deps ~opam_version ~opam_files ~selection
   @ [
-      (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
-      (* conf-m4 is a work-around for https://github.com/ocaml-opam/opam-depext/pull/132 *)
-      run ~network ~cache
-        "opam depext -i conf-m4 && opam depext -i dune 'odoc>=1.5.0'";
+      run ~network ~cache "opam install --yes dune 'odoc>=1.5.0'";
       copy [ "." ] ~dst:"/src/";
+      (* Warnings-as-errors was introduced in Odoc.1.5.0 *)
       run
         "ODOC_WARN_ERROR=false opam exec -- dune build%s @doc || (echo \"dune \
          build @doc failed\"; exit 2)"

--- a/ocaml-ci-gitlab.opam
+++ b/ocaml-ci-gitlab.opam
@@ -22,7 +22,7 @@ depends: [
   "alcotest" {>= "1.7.0" & with-test}
   "cmdliner" {>= "1.1.1"}
   "fmt" {>= "0.8.9"}
-  "gitlab-unix" {>= "0.1.7"}
+  "gitlab-unix" {>= "0.1.8"}
   "logs" {>= "0.7.0"}
   "odoc" {with-doc}
   "prometheus-app" {>= "1.2"}


### PR DESCRIPTION
Closes #934

CI failures were occurring during installation using `opam depext`, alongside
deprecation warning against using this plugin with opam 2.1 (which we are using
in this job).

Additionally, it turns out we don't need to install `conf-m4` any more, as it
was a workaround obviated some time ago.

This PR includes an unrelated change to commit the updated opam file resulting
from a recent change to `dune-package`.