### PR TITLE
Make lint-fmt a no-op when ocamlformat is not configured for a project

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -26,8 +26,8 @@ let install_ocamlformat =
 let commit_from_ocamlformat_source ocamlformat_source =
   let open Analyse_ocamlformat in
   match ocamlformat_source with
-  | None | Some (Vendored _) -> None
-  | Some (Opam { opam_repo_commit; _ }) -> opam_repo_commit
+  | Vendored _ -> None
+  | Opam { opam_repo_commit; _ } -> opam_repo_commit
 
 let fmt_spec ~base ~ocamlformat_source ~selection =
   let open Obuilder_spec in
@@ -46,38 +46,43 @@ let fmt_spec ~base ~ocamlformat_source ~selection =
         ~target:"/home/opam/.opam/download-cache";
     ]
   in
-  match ocamlformat_source with
-  | Error (`Msg msg) ->
-      stage ~from:base
-      @@ [ user_unix ~uid:1000 ~gid:1000; run "echo Error: %s; exit 2" msg ]
-  | Ok ocamlformat_source ->
-      let commit =
-        Option.value ~default:commit
-          (commit_from_ocamlformat_source ocamlformat_source)
-      in
-      let network = [ "host" ] in
-      stage ~from:base
-      @@ [
-           user_unix ~uid:1000 ~gid:1000;
-           run ~network ~cache
-             "cd ~/opam-repository && (git cat-file -e %s || git fetch origin \
-              master) && git reset -q --hard %s && git log --no-decorate -n1 \
-              --oneline && opam update -u"
-             commit commit;
-           run ~network ~cache "opam depext -i dune";
-           (* Necessary in case current compiler < 4.08 *)
-           (* Not necessarily the dune version used by the project *)
-           workdir "/src";
-         ]
-      @ (match ocamlformat_source with
-        | Some src -> install_ocamlformat src
-        | None -> [])
-      @ [
-          copy [ "." ] ~dst:"/src/";
+  let actions =
+    match ocamlformat_source with
+    | Error (`Msg msg) ->
+        [ user_unix ~uid:1000 ~gid:1000; run "echo Error: %s; exit 2" msg ]
+    | Ok None ->
+        (* TODO This is a workaround for https://github.com/ocaml/dune/issues/10578
+           Once [dune build @fmt] allows clean exits even when ocamlformat is not installed,
+           we should remove this case, so that we still have the benefit of running other
+           formatting lints that may be associated with the @fmt alias. *)
+        [
           run
-            "opam exec -- dune build @fmt --ignore-promoted-rules || (echo \
-             \"dune build @fmt failed\"; exit 2)";
+            {| echo "skipping format lint because ocamlformat is not configured" |};
         ]
+    | Ok (Some source) ->
+        let commit =
+          Option.value ~default:commit (commit_from_ocamlformat_source source)
+        in
+        let network = [ "host" ] in
+        install_ocamlformat source
+        @ [
+            user_unix ~uid:1000 ~gid:1000;
+            run ~network ~cache
+              "cd ~/opam-repository && (git cat-file -e %s || git fetch origin \
+               master) && git reset -q --hard %s && git log --no-decorate -n1 \
+               --oneline && opam update -u"
+              commit commit;
+            run ~network ~cache "opam depext -i dune";
+            (* Necessary in case current compiler < 4.08 *)
+            (* Not necessarily the dune version used by the project *)
+            workdir "/src";
+            copy [ "." ] ~dst:"/src/";
+            run
+              "opam exec -- dune build @fmt --ignore-promoted-rules || (echo \
+               \"dune build @fmt failed\"; exit 2)";
+          ]
+  in
+  stage ~from:base actions
 
 let doc_spec ~base ~opam_files ~selection =
   let cache =


### PR DESCRIPTION
Closes #936

This is a workaround for https://github.com/ocaml/dune/issues/10578 . 

The gist is that `dune build @fmt` currently exits with 1 if ocamlformat is not installed. So this change makes the `fmt-lint` job a no-op in case the project is not configured for ocamlformat. 

An alternative approach would be to install ocmalformat unconditionally, but that seemed a bit iffy to me, as it takes extra resources and I thought it may produce failing outcomes that devs weren't expecting? I'm happy to go that route of others think it is preferable tho. 

Once `dune build @fmt` allows clean exits even when ocamlformat is not installed, we should undo this change, so that we still have the benefit of running other formatting lints that may be associated with the `@fmt` alias.