### PR TITLE
Use Current.Pool to limit concurrent operations

### DIFF
--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -87,9 +87,7 @@ let set_compiler_version vars ~version =
 module Query = struct
   let id = "opam-vars"
 
-  type t = {
-    pool : unit Current.Pool.t;
-  }
+  type t = { pool : unit Current.Pool.t }
 
   module Key = struct
     type t = {
@@ -190,7 +188,8 @@ module Query = struct
 
   let run { pool } job { Key.docker_context; variant; lower_bound }
       { Value.image; host_image } =
-    Current.Job.start job ~pool ~level:Current.Level.Mostly_harmless >>= fun () ->
+    Current.Job.start job ~pool ~level:Current.Level.Mostly_harmless
+    >>= fun () ->
     let prep_image =
       Fmt.str "ocurrent/ocaml-ci:%s" (Variant.docker_tag variant)
     in


### PR DESCRIPTION
The `platforms` function uses `Builders.local` in all cases.  `Builders.v` looks redundant (the project builds without it).  A pool is defined for `Builders.local.pool` but it isn't passed through to the `Query` Module.  This PR addresses this so the number of concurrent build jobs is limited.  This aims to address https://github.com/ocurrent/ocaml-ci/issues/947