### PR TITLE
Move from opam 2.1 to opam 2.2

### DIFF
--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -1,5 +1,5 @@
-(* Use opam-2.1 to lint the packages *)
-let opam_version = `V2_1
+(* Use opam-2.2 to lint the packages *)
+let opam_version = `V2_2
 
 let install_ocamlformat =
   let open Obuilder_spec in

--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -158,6 +158,11 @@ let install_project_deps ~opam_version ~opam_files ~selection =
           "opam update --depexts && opam install --cli=2.1 --depext-only -y %s \
            $DEPS"
           compatible_root_pkgs
+    | `V2_2 ->
+        run ~network ~cache
+          "opam update --depexts && opam install --cli=2.2 --depext-only -y %s \
+           $DEPS"
+          compatible_root_pkgs
   in
   (if Variant.arch variant |> Ocaml_version.arch_is_32bit then
      [ shell [ "/usr/bin/linux32"; "/bin/sh"; "-c" ] ]

--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -203,7 +203,7 @@ let spec ~base ~repo ~config ~variant =
   stage ~from:base
   @@ [ comment "%s" (Variant.to_string variant); user_unix ~uid:1000 ~gid:1000 ]
   @ initialize_switch ~network switch_type
-  @ Opam_build.install_project_deps ~opam_version:`V2_1 ~opam_files:[]
+  @ Opam_build.install_project_deps ~opam_version:`V2_2 ~opam_files:[]
       ~selection
   @ [
       workdir "/src";

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -1,11 +1,17 @@
-type t = [ `V2_0 | `V2_1 ] [@@deriving ord, yojson, eq]
+type t = [ `V2_0 | `V2_1 | `V2_2 ] [@@deriving ord, yojson, eq]
 
-let to_string = function `V2_0 -> "2.0" | `V2_1 -> "2.1"
-let to_string_with_patch = function `V2_0 -> "2.0.10" | `V2_1 -> "2.1.2"
+let to_string = function `V2_0 -> "2.0" | `V2_1 -> "2.1" | `V2_2 -> "2.2"
+
+let to_string_with_patch = function
+  | `V2_0 -> "2.0.10"
+  | `V2_1 -> "2.1.6"
+  | `V2_2 -> "2.0.0"
+
 let pp = Fmt.of_to_string to_string
 let default = `V2_0
 
 let of_string = function
   | "2.0" -> Ok `V2_0
   | "2.1" -> Ok `V2_1
+  | "2.2" -> Ok `V2_2
   | s -> Error (`Msg (s ^ ": invalid opam version"))

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -5,7 +5,7 @@ let to_string = function `V2_0 -> "2.0" | `V2_1 -> "2.1" | `V2_2 -> "2.2"
 let to_string_with_patch = function
   | `V2_0 -> "2.0.10"
   | `V2_1 -> "2.1.6"
-  | `V2_2 -> "2.0.0"
+  | `V2_2 -> "2.2.0"
 
 let pp = Fmt.of_to_string to_string
 let default = `V2_0

--- a/lib/opam_version.mli
+++ b/lib/opam_version.mli
@@ -1,6 +1,6 @@
 (** Opam versions supported. *)
 
-type t = [ `V2_0 | `V2_1 ] [@@deriving ord, yojson, eq]
+type t = [ `V2_0 | `V2_1 | `V2_2 ] [@@deriving ord, yojson, eq]
 
 val pp : t Fmt.t
 val to_string : t -> string

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -178,7 +178,6 @@ module Query = struct
         "opam";
         "list";
         "-s";
-        "--base";
         "--roots";
         "--all-versions";
         "ocaml-base-compiler";

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -100,7 +100,7 @@ let freebsd_distros =
         distro = "freebsd";
         ocaml_version;
         arch = `X86_64;
-        opam_version = `V2_1;
+        opam_version = `V2_2;
         lower_bound = false;
       })
     default_compilers
@@ -116,7 +116,7 @@ let macos_distros =
         distro = "macos-homebrew";
         ocaml_version;
         arch = `X86_64;
-        opam_version = `V2_1;
+        opam_version = `V2_2;
         lower_bound = false;
       })
     default_compilers
@@ -129,7 +129,7 @@ let macos_distros =
           distro = "macos-homebrew";
           ocaml_version;
           arch = `Aarch64;
-          opam_version = `V2_1;
+          opam_version = `V2_2;
           lower_bound = false;
         })
       default_compilers
@@ -302,8 +302,8 @@ let fetch_platforms ~include_macos ~include_freebsd () =
         Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version
           ~host_base ~opam_version ~lower_bound base
   in
-  let v2_1 =
-    platforms ~profile:platforms_profile `V2_1 ~include_macos ~include_freebsd
+  let v2_2 =
+    platforms ~profile:platforms_profile `V2_2 ~include_macos ~include_freebsd
     |> merge_lower_bound_platforms
   in
-  Current.list_seq (List.map v v2_1) |> Current.map List.flatten
+  Current.list_seq (List.map v v2_2) |> Current.map List.flatten


### PR DESCRIPTION
This PR updates OCaml-CI to use opam 2.2.

Until https://github.com/ocurrent/docker-base-images/pull/289 and https://github.com/ocurrent/ocaml-dockerfile/pull/215 are merged this will result in `opam 2.3.0~alpha~dev` being used.  See https://github.com/ocurrent/ocaml-dockerfile/blob/5c2d8e095cb92f7e590e85b991ac93ae8209908a/src-opam/opam.ml#L208-L217 which aliases `opam-2.2` to be the `master` branch.

Closes #952