### PR TITLE
Opam vars moved to OCluster

### DIFF
--- a/gitlab/local.ml
+++ b/gitlab/local.ml
@@ -7,16 +7,10 @@ let setup_log default_level =
 
 let main () config mode repo : ('a, [ `Msg of string ]) result =
   let solver = Ocaml_ci.Backend_solver.v None in
-  let conn = match None with
-    | None -> assert false
-    | Some ur ->
-        let vat = Capnp_rpc_unix.client_only_vat () in
-        let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
-        (Current_ocluster.Connection.create sr) in
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine =
     Current.Engine.create ~config
-      (Ocaml_ci_gitlab.Pipeline.local_test ~conn ~solver repo)
+      (Ocaml_ci_gitlab.Pipeline.local_test ~query_uri:None ~solver repo)
   in
   let site =
     Current_web.Site.(v ~has_role:allow_all)

--- a/gitlab/local.ml
+++ b/gitlab/local.ml
@@ -7,10 +7,16 @@ let setup_log default_level =
 
 let main () config mode repo : ('a, [ `Msg of string ]) result =
   let solver = Ocaml_ci.Backend_solver.v None in
+  let conn = match None with
+    | None -> assert false
+    | Some ur ->
+        let vat = Capnp_rpc_unix.client_only_vat () in
+        let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+        (Current_ocluster.Connection.create sr) in
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine =
     Current.Engine.create ~config
-      (Ocaml_ci_gitlab.Pipeline.local_test ~solver repo)
+      (Ocaml_ci_gitlab.Pipeline.local_test ~conn ~solver repo)
   in
   let site =
     Current_web.Site.(v ~has_role:allow_all)

--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -113,6 +113,12 @@ let main () config mode app capnp_public_address capnp_listen_address
   let open Ocaml_ci_gitlab in
   Lwt_main.run
     (let solver = Ocaml_ci.Backend_solver.v solver_uri in
+     let conn = match solver_uri with
+       | None -> assert false
+       | Some ur ->
+           let vat = Capnp_rpc_unix.client_only_vat () in
+           let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+           (Current_ocluster.Connection.create sr) in
      run_capnp capnp_public_address capnp_listen_address
      >>= fun (vat, rpc_engine_resolver) ->
      let ocluster =
@@ -120,7 +126,7 @@ let main () config mode app capnp_public_address capnp_listen_address
      in
      let engine =
        Current.Engine.create ~config
-         (Pipeline.v ?ocluster ~app ~solver ~migrations)
+         (Pipeline.v ?ocluster ~app ~conn ~solver ~migrations)
      in
      rpc_engine_resolver
      |> Option.iter (fun r ->

--- a/gitlab/main.ml
+++ b/gitlab/main.ml
@@ -205,7 +205,8 @@ let submission_query_service =
   @@ Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None
   @@ Arg.info
        ~doc:
-         "The query-solve.cap file which handles building opam variables for various platforms. The cap file could be the same as \
+         "The query-solve.cap file which handles building opam variables for \
+          various platforms. The cap file could be the same as \
           $(b,--submission-service) or omitted to use the local system."
        ~docv:"FILE"
        [ "submission-query-service" ]

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -179,9 +179,9 @@ let gitlab_status_of_state head result =
   | Error (`Msg m) ->
       Gitlab.Api.Status.v ~url `Failure ~description:m ~name:program_name
 
-let local_test ~conn ~solver repo () =
+let local_test ~query_uri ~solver repo () =
   let platforms =
-    Conf.fetch_platforms ~conn ~include_macos:false ~include_freebsd:false ()
+    Conf.fetch_platforms ~query_uri ~include_macos:false ~include_freebsd:false ()
   in
   let src = Git.Local.head_commit repo in
   let src_content = Repo_content.extract src in
@@ -194,9 +194,9 @@ let local_test ~conn ~solver repo () =
      let result = summarise results in
      Current_incr.const (result, None)
 
-let v ?ocluster ~app ~conn ~solver ~migrations () =
+let v ?ocluster ~app ~query_uri ~solver ~migrations () =
   let platforms =
-    Conf.fetch_platforms ~conn ~include_macos:true ~include_freebsd:true () in
+    Conf.fetch_platforms ~query_uri ~include_macos:true ~include_freebsd:true () in
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -181,7 +181,8 @@ let gitlab_status_of_state head result =
 
 let local_test ~query_uri ~solver repo () =
   let platforms =
-    Conf.fetch_platforms ~query_uri ~include_macos:false ~include_freebsd:false ()
+    Conf.fetch_platforms ~query_uri ~include_macos:false ~include_freebsd:false
+      ()
   in
   let src = Git.Local.head_commit repo in
   let src_content = Repo_content.extract src in
@@ -196,7 +197,8 @@ let local_test ~query_uri ~solver repo () =
 
 let v ?ocluster ~app ~query_uri ~solver ~migrations () =
   let platforms =
-    Conf.fetch_platforms ~query_uri ~include_macos:true ~include_freebsd:true () in
+    Conf.fetch_platforms ~query_uri ~include_macos:true ~include_freebsd:true ()
+  in
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in

--- a/gitlab/pipeline.ml
+++ b/gitlab/pipeline.ml
@@ -18,9 +18,6 @@ module Metrics = struct
       "repositories_total"
 end
 
-let platforms =
-  Conf.fetch_platforms ~include_macos:true ~include_freebsd:true ()
-
 let program_name = "ocaml-ci"
 
 (* Link for GitLab statuses. *)
@@ -182,9 +179,9 @@ let gitlab_status_of_state head result =
   | Error (`Msg m) ->
       Gitlab.Api.Status.v ~url `Failure ~description:m ~name:program_name
 
-let local_test ~solver repo () =
+let local_test ~conn ~solver repo () =
   let platforms =
-    Conf.fetch_platforms ~include_macos:false ~include_freebsd:false ()
+    Conf.fetch_platforms ~conn ~include_macos:false ~include_freebsd:false ()
   in
   let src = Git.Local.head_commit repo in
   let src_content = Repo_content.extract src in
@@ -197,7 +194,9 @@ let local_test ~solver repo () =
      let result = summarise results in
      Current_incr.const (result, None)
 
-let v ?ocluster ~app ~solver ~migrations () =
+let v ?ocluster ~app ~conn ~solver ~migrations () =
+  let platforms =
+    Conf.fetch_platforms ~conn ~include_macos:true ~include_freebsd:true () in
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in

--- a/gitlab/pipeline.mli
+++ b/gitlab/pipeline.mli
@@ -1,6 +1,7 @@
 (** Pipeline for testing GitLab hosted repositories. *)
 
 val local_test :
+  conn:Current_ocluster.Connection.t ->
   solver:Ocaml_ci.Backend_solver.t ->
   Current_git.Local.t ->
   unit ->
@@ -11,6 +12,7 @@ val local_test :
 val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_gitlab.Api.t ->
+  conn:Current_ocluster.Connection.t ->
   solver:Ocaml_ci.Backend_solver.t ->
   migrations:string option ->
   unit ->

--- a/gitlab/pipeline.mli
+++ b/gitlab/pipeline.mli
@@ -1,7 +1,7 @@
 (** Pipeline for testing GitLab hosted repositories. *)
 
 val local_test :
-  conn:Current_ocluster.Connection.t ->
+  query_uri:Uri.t option ->
   solver:Ocaml_ci.Backend_solver.t ->
   Current_git.Local.t ->
   unit ->
@@ -12,7 +12,7 @@ val local_test :
 val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_gitlab.Api.t ->
-  conn:Current_ocluster.Connection.t ->
+  query_uri:Uri.t option ->
   solver:Ocaml_ci.Backend_solver.t ->
   migrations:string option ->
   unit ->

--- a/lib/build.mli
+++ b/lib/build.mli
@@ -12,7 +12,7 @@ val v :
     (e.g. GitHub or GitLab). *)
 
 val make_build_spec :
-  base:Platform.base ->
+  base:Current_docker.Raw.Image.t ->
   repo:Repo_id.t ->
   variant:Variant.t ->
   ty:Spec.ty ->

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -16,5 +16,9 @@ let pull { docker_context; pool = _; build_timeout = _ } ~arch tag =
   in
   Current_docker.Raw.pull ?arch tag ~docker_context
 
+let peek { docker_context; pool = _; build_timeout = _ } ~arch tag =
+  let arch = Ocaml_version.to_docker_arch arch in
+  Current_docker.Raw.peek ~arch tag ~docker_context
+
 let run { docker_context; pool; build_timeout = _ } ~args img =
   Current_docker.Raw.run img ~docker_context ~pool ~args

--- a/lib/builder.mli
+++ b/lib/builder.mli
@@ -22,6 +22,14 @@ val pull :
   Current_docker.Raw.Image.t Current.Primitive.t
 (** Docker [pull] an image for [arch] with a scheduled check. *)
 
+val peek :
+  t ->
+  arch:Ocaml_version.arch ->
+  string ->
+  schedule:Current_cache.Schedule.t ->
+  string Current.Primitive.t
+(** Docker [peek] an image for [arch] with a scheduled check. *)
+
 val run :
   t ->
   args:string list ->

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -46,7 +46,8 @@ module Op = struct
   module Value = struct
     type t = {
       ty : Spec.ty;
-      base : Current_docker.Raw.Image.t; (* The image with the OCaml compiler to use. *)
+      base : Current_docker.Raw.Image.t;
+          (* The image with the OCaml compiler to use. *)
       variant : Variant.t; (* Added as a comment in the Dockerfile *)
     }
 
@@ -75,8 +76,8 @@ module Op = struct
       | `Opam_fmt (selection, _) -> "ocamlformat-" ^ selection.Selection.commit
       | `Opam_monorepo _ -> "opam-monorepo-" ^ Variant.to_string variant
     in
-    Fmt.str "%s/%s-%s-%a-%s" owner name (Image.hash base) Variant.pp
-      variant deps
+    Fmt.str "%s/%s-%s-%a-%s" owner name (Image.hash base) Variant.pp variant
+      deps
 
   let run t job { Key.pool; commit; label = _; repo } spec =
     Current.Job.on_cancel job (fun reason ->

--- a/lib/cluster_build.ml
+++ b/lib/cluster_build.ml
@@ -46,14 +46,14 @@ module Op = struct
   module Value = struct
     type t = {
       ty : Spec.ty;
-      base : Platform.base; (* The image with the OCaml compiler to use. *)
+      base : Current_docker.Raw.Image.t; (* The image with the OCaml compiler to use. *)
       variant : Variant.t; (* Added as a comment in the Dockerfile *)
     }
 
     let to_json { base; ty; variant } =
       `Assoc
         [
-          ("base", Platform.to_yojson base);
+          ("base", `String (Image.hash base));
           ("op", Spec.ty_to_yojson ty);
           ("variant", Variant.to_yojson variant);
         ]
@@ -75,7 +75,7 @@ module Op = struct
       | `Opam_fmt (selection, _) -> "ocamlformat-" ^ selection.Selection.commit
       | `Opam_monorepo _ -> "opam-monorepo-" ^ Variant.to_string variant
     in
-    Fmt.str "%s/%s-%s-%a-%s" owner name (Platform.to_string base) Variant.pp
+    Fmt.str "%s/%s-%s-%a-%s" owner name (Image.hash base) Variant.pp
       variant deps
 
   let run t job { Key.pool; commit; label = _; repo } spec =
@@ -88,7 +88,7 @@ module Op = struct
     let { Value.base; variant; ty } = spec in
     let build_spec = Build.make_build_spec ~base ~repo ~variant ~ty in
     Current.Job.write job
-      (Fmt.str "@[<v>Base: %a@,%a@]@." Platform.base_pp base Spec.pp_summary ty);
+      (Fmt.str "@[<v>Base: %a@,%a@]@." Image.pp base Spec.pp_summary ty);
     Current.Job.write job
       (Fmt.str
          "@.To reproduce locally:@.@.%a@.cat > Dockerfile \

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -1,4 +1,3 @@
-open Lwt.Infix
 open Current.Syntax
 module Raw = Current_docker.Raw
 module Worker = Ocaml_ci_api.Worker
@@ -70,7 +69,6 @@ type t = {
 
 let pp f t = Fmt.string f t.label
 let compare a b = compare a.label b.label
-let ( >>!= ) = Lwt_result.bind
 
 let compiler_matches_major_and_minor vars ~version =
   let vars_version =
@@ -84,302 +82,85 @@ let set_compiler_version vars ~version =
   let ocaml_version = Ocaml_version.to_string version in
   { vars with Worker.Vars.ocaml_version }
 
-module Query = struct
-  let id = "opam-vars"
-
-  type t = {
-    conn : Current_ocluster.Connection.t;
-  }
-
-  module Key = struct
-    type t = {
-      docker_context : string option;
-      variant : Variant.t;
-      lower_bound : bool;
-      pool : string;
-    }
-    [@@deriving to_yojson]
-
-    let digest t = Yojson.Safe.to_string (to_yojson t)
-  end
-
-  module Value = struct
-    type t = { image : string; host_image : string } [@@deriving to_yojson]
-
-    let digest t = Yojson.Safe.to_string (to_yojson t)
-  end
-
-  module Outcome = struct
-    type t = { image : string; vars : Worker.Vars.t } [@@deriving yojson]
-
-    let marshal t = Yojson.Safe.to_string (to_yojson t)
-
-    let unmarshal s =
-      match of_yojson (Yojson.Safe.from_string s) with
-      | Ok x -> x
-      | Error e -> failwith e
-  end
-
-  (* This is needed iff the opam used isn't the image default opam. *)
-  (*
-  let prepare_image ~job ~docker_context ~tag variant image =
-    let opam =
-      "opam-" ^ Opam_version.to_string (Variant.opam_version variant)
-    in
-    let prefix =
-      match Variant.os variant with
-      | `macOS -> "~/local"
-      | `linux -> "/usr"
-      | `freeBSD -> "/usr/local"
-    in
-    let ln =
-      match Variant.os variant with
-      | `macOS -> "ln"
-      | `linux | `freeBSD -> "sudo ln"
-    in
-    (* XXX: don't overwrite default config? *)
-    let opamrc = "" in
-    let spec =
-      let open Obuilder_spec in
-      stage ~from:image
-        [
-          run "%s -f %s/bin/%s %s/bin/opam" ln prefix opam prefix;
-          run "opam init --reinit%s -ni" opamrc;
-        ]
-      |> Docker.dockerfile_of_spec ~buildkit:true ~os:`Unix
-    in
-    let cmd =
-      Raw.Cmd.docker ~docker_context [ "build"; "--pull"; "-t"; tag; "-" ]
-    in
-    Current.Process.exec ~stdin:spec ~cancellable:false ~job cmd >>!= fun () ->
-    Lwt_result.ok (Lwt.return tag)
-     *)
-
-  (* This is needed iff the opam used isn't the image default opam. *)
-  let prepare_image2 ~variant =
-    let opam =
-      "opam-" ^ Opam_version.to_string (Variant.opam_version variant)
-    in
-    let prefix =
-      match Variant.os variant with
-      | `macOS -> "~/local"
-      | `linux -> "/usr"
-      | `freeBSD -> "/usr/local"
-    in
-    let ln =
-      match Variant.os variant with
-      | `macOS -> "ln"
-      | `linux | `freeBSD -> "sudo ln"
-    in
-    (* XXX: don't overwrite default config? *)
-    let opamrc = "" in
-    let open Obuilder_spec in
-        [
-          run "%s -f %s/bin/%s %s/bin/opam" ln prefix opam prefix;
-          run "opam init --reinit%s -ni" opamrc;
-        ]
-
-  let opam_template arch =
-    let arch = Option.value ~default:"%{arch}%" arch in
-    Fmt.str
-      {|
-    {
-      "arch": "%s",
-      "os": "%%{os}%%",
-      "os_family": "%%{os-family}%%",
-      "os_distribution": "%%{os-distribution}%%",
-      "os_version": "%%{os-version}%%",
-      "opam_version": "%%{opam-version}%%"
-    }
-  |}
-      arch
-
-  (*
-  let get_vars ~arch ~docker_context image =
-    Raw.Cmd.docker ~docker_context
-      [ "run"; "-i"; image; "opam"; "config"; "expand"; opam_template arch ]
-     *)
-
-(*
-  let get_ocaml_package ~docker_context image =
-    Raw.Cmd.docker ~docker_context
-      [
-        "run";
-        "-i";
-        image;
-        "opam";
-        "list";
-        "-s";
-        "--base";
-        "--roots";
-        "--all-versions";
-        "ocaml-base-compiler";
-        "ocaml-variants";
-        "ocaml-system";
-      ]
-   *)
-
-  let tail ~buffer ~job build_job =
-    let rec aux start =
-      Cluster_api.Job.log build_job start >>= function
-      | Error (`Capnp e) -> Lwt.return @@ Fmt.error_msg "%a" Capnp_rpc.Error.pp e
-      | Ok ("", _) -> Lwt_result.return ()
-      | Ok (data, next) ->
-        Buffer.add_string buffer data;
-        Current.Job.write job data;
-        aux next
-    in aux 0L
-
-  let run_job ~buffer ~job build_job =
-    let on_cancel _ =
-      Cluster_api.Job.cancel build_job >|= function
-      | Ok () -> ()
-      | Error (`Capnp e) -> Current.Job.log job "Cancel failed: %a" Capnp_rpc.Error.pp e
-    in
-    Current.Job.with_handler job ~on_cancel @@ fun () ->
-    let result = Cluster_api.Job.result build_job in
-    tail ~buffer ~job build_job >>!= fun () ->
-    result >>= function
-    | Error (`Capnp e) -> Lwt_result.fail (`Msg (Fmt.to_to_string Capnp_rpc.Error.pp e))
-    | Ok _ as x -> Lwt.return x
-
-  let parse_output job build_job =
-    let buffer = Buffer.create 1024 in
-    Capnp_rpc_lwt.Capability.with_ref build_job (run_job ~buffer ~job) >>!= fun (_ : string) ->
-      match Astring.String.cuts ~sep:"\n@@@OUTPUT\n" (Buffer.contents buffer) with
-      | [_; output; _; output2; _] ->
-        Current.Job.log job "@[<v2>Result:@,%s,%s@]" output output2;
-        Lwt_result.return (Some (output, output2))
-      | [_; rest ] when Astring.String.is_prefix ~affix:"@@@OUTPUT\n" rest -> Lwt_result.return None
-      | _ -> Lwt_result.fail (`Msg "Missing output from command\n")
-
-  let set_personality ~variant =
-    if Variant.arch variant |> Ocaml_version.arch_is_32bit then
-      [Obuilder_spec.shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]]
-    else
-      []
-
-  let run { conn } job { Key.docker_context; variant; lower_bound; pool }
-      { Value.image; host_image } =
-    let open Obuilder_spec in
-    let _ = docker_context in
-    let arch =
-      Variant.arch variant |> fun v ->
-      if Ocaml_version.arch_is_32bit v then Some (Ocaml_version.to_opam_arch v)
-      else None
-    in
-    let spec = Obuilder_spec.stage ~from:host_image (
-      user_unix ~uid:1000 ~gid:1000 ::
-      set_personality ~variant @
-      prepare_image2 ~variant @ [
-        run "echo '@@@OUTPUT' && \
-             opam list -s --color=never --base --roots --all-versions ocaml-base-compiler ocaml-variants ocaml-system && \
-             echo '@@@OUTPUT'";
-        run "echo '@@@OUTPUT' && \
-             opam config expand '%s' && \
-             echo '@@@OUTPUT'" (opam_template arch)
-      ]) in
-    let spec_str = Fmt.to_to_string Obuilder_spec.pp (spec) in
-    let action = Cluster_api.Submission.obuilder_build spec_str in
-    let foo_pool = Current_ocluster.Connection.pool ~job ~pool ~cache_hint:"foo" ~action conn in
-    Current.Job.start_with ~pool:foo_pool job ~level:Current.Level.Mostly_harmless >>=
-    parse_output job >>!= fun s ->
-    let (ocaml_package, vars) = match s with
-      | Some (a, b) -> a, b 
-      | None -> assert false in
-    (*
-    Current.Job.start job ~pool ~level:Current.Level.Mostly_harmless
-    >>= fun () ->
-    let prep_image =
-      Fmt.str "ocurrent/ocaml-ci:%s" (Variant.docker_tag variant)
-    in
-    prepare_image ~job ~docker_context ~tag:prep_image variant host_image
-    >>!= fun host_image ->
-    let cmd = get_ocaml_package ~docker_context host_image in
-    Current.Process.check_output ~cancellable:false ~job cmd
-    >>!= fun ocaml_package ->
-       *)
-    let ocaml_package = String.trim ocaml_package in
-    let ocaml_package_name, ocaml_version =
-      match Astring.String.cut ~sep:"." ocaml_package with
-      | Some (name, version) -> (name, version)
-      | None -> Fmt.failwith "Unexpected opam package name: %s" ocaml_package
-    in
-    (*
-    let cmd = get_vars ~arch ~docker_context host_image in
-    Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vars ->
-       *)
-    let json =
-      match Yojson.Safe.from_string vars with
-      | `Assoc items ->
-          `Assoc
-            (("ocaml_package", `String ocaml_package_name)
-            :: ("ocaml_version", `String ocaml_version)
-            :: ("lower_bound", `Bool lower_bound)
-            :: items)
-      | json ->
-          Fmt.failwith "Unexpected JSON: %a"
-            Yojson.Safe.(pretty_print ~std:true)
-            json
-    in
-    Current.Job.log job "@[<v2>Result:@,%a@]"
-      Yojson.Safe.(pretty_print ~std:true)
-      json;
-    match Worker.Vars.of_yojson json with
-    | Error msg -> Lwt_result.fail (`Msg msg)
-    | Ok vars -> Lwt_result.return { Outcome.vars; image }
-
-  let pp f (key, value) =
-    Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant
-      value.Value.image
-
-  let auto_cancel = false
-  let latched = true
-end
-
 module QC = Current_cache.Generic (Query)
 
-let query schedule conn builder ~variant ~lower_bound ~pool image =
+let query conn ~variant ~lower_bound ~pool image =
   let label = if lower_bound then "opam-vars (lower-bound)" else "opam-vars" in
   Current.component "%s" label
   |> let> image in
-     let docker_context = builder.Builder.docker_context in
-     QC.run ~schedule { conn }
-       { Query.Key.docker_context; variant; lower_bound; pool }
+     QC.run { conn }
+       { Query.Key.variant; lower_bound; pool }
        { Query.Value.image; host_image = image }
 
-let get_docker schedule conn builder variant ~lower_bound tag arch opam_version
-    label pool =
+module QCL = Current_cache.Generic (Query_local)
+
+let query_local builder ~variant ~lower_bound ~host_image image =
+  let label = if lower_bound then "opam-vars (lower-bound)" else "opam-vars" in
+  Current.component "%s" label
+  |> let> host_image and> image in
+     let image = Raw.Image.hash image in
+     let host_image = Raw.Image.hash host_image in
+     let docker_context = builder.Builder.docker_context in
+     let pool = builder.Builder.pool in
+     QCL.run { pool }
+       { Query_local.Key.docker_context; variant; lower_bound }
+       { Query_local.Value.image; host_image }
+
+let get_docker conn builder variant ~lower_bound tag label pool =
   let+ { Query.Outcome.vars; image } =
-    query schedule conn builder ~variant ~lower_bound ~pool:(Pool_name.to_string pool) tag
-  in
-  (* It would be better to run the opam query on the platform itself, but for
-     now we run everything on x86_64 and then assume that the other
-     architectures are the same except for the arch flag. *)
-  let vars =
-    {
-      vars with
-      arch = Ocaml_version.to_opam_arch arch;
-      opam_version = Opam_version.to_string_with_patch opam_version;
-    }
+    query conn ~variant ~lower_bound ~pool:(Pool_name.to_string pool) tag
   in
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base = `Docker base; vars }
 
-let get ~schedule ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
+let get_docker_local builder variant ~lower_bound host_base base label pool =
+  let+ { Query_local.Outcome.vars; image } =
+    query_local builder ~variant ~lower_bound ~host_image:host_base base
+  in
+  let base = Raw.Image.of_hash image in
+  { label; builder; pool; variant; base = `Docker base; vars }
+
+let get ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
     ~opam_version ~lower_bound tag =
   match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
       let upper_bound =
-        get_docker schedule conn builder variant ~lower_bound:false tag arch opam_version label pool
+        get_docker conn builder variant ~lower_bound:false tag label pool
       in
       if lower_bound then
         let lower_bound =
-          get_docker schedule conn builder variant ~lower_bound:true tag arch opam_version label pool
+          get_docker conn builder variant ~lower_bound:true tag label pool
         in
         Current.list_seq [ upper_bound; lower_bound ]
       else Current.list_seq [ upper_bound ]
+
+let get_local ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base
+    ~opam_version ~lower_bound base =
+  match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
+  | Error (`Msg m) -> Current.fail m
+  | Ok variant ->
+      let upper_bound =
+        get_docker_local builder variant ~lower_bound:false host_base base label pool
+      in
+      if lower_bound then
+        let lower_bound =
+          get_docker_local builder variant ~lower_bound:true host_base base label pool
+        in
+        Current.list_seq [ upper_bound; lower_bound ]
+      else Current.list_seq [ upper_bound ]
+
+let pull ~arch ~schedule ~builder ~distro ~ocaml_version ~opam_version =
+  match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
+  | Error (`Msg m) -> Current.fail m
+  | Ok variant ->
+      let archl = Ocaml_version.to_opam_arch arch in
+      let opam_version = Opam_version.to_string opam_version in
+      Current.component "pull@,%s %a %s opam-%s" distro Ocaml_version.pp
+        ocaml_version archl opam_version
+      |> let> () = Current.return () in
+         let tag = Variant.docker_tag variant in
+         Builder.pull ~schedule ~arch builder @@ "ocaml/opam:" ^ tag
 
 let peek ~arch ~schedule ~builder ~distro ~ocaml_version ~opam_version =
   match Variant.v ~arch ~distro ~ocaml_version ~opam_version with

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -98,8 +98,8 @@ let get_docker_local builder variant ~lower_bound host_base base label pool =
   let base = Raw.Image.of_hash image in
   { label; builder; pool; variant; base; vars }
 
-let get ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
-    ~opam_version ~lower_bound tag =
+let get ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version ~opam_version
+    ~lower_bound tag =
   match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
@@ -119,11 +119,13 @@ let get_local ~arch ~label ~builder ~pool ~distro ~ocaml_version ~host_base
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
       let upper_bound =
-        get_docker_local builder variant ~lower_bound:false host_base base label pool
+        get_docker_local builder variant ~lower_bound:false host_base base label
+          pool
       in
       if lower_bound then
         let lower_bound =
-          get_docker_local builder variant ~lower_bound:true host_base base label pool
+          get_docker_local builder variant ~lower_bound:true host_base base
+            label pool
         in
         Current.list_seq [ upper_bound; lower_bound ]
       else Current.list_seq [ upper_bound ]

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -1,14 +1,5 @@
 (** A platform on which we wish to perform test builds. *)
 
-type base =
-  [ `Docker of Current_docker.Raw.Image.t
-  | `MacOS of string
-  | `FreeBSD of string ]
-
-val to_yojson : base -> Yojson.Safe.t
-val to_string : base -> string
-val base_pp : Format.formatter -> base -> unit
-
 module Pool_name : sig
   type t =
     [ `Linux_x86_64
@@ -29,7 +20,7 @@ type t = {
   builder : Builder.t;
   pool : Pool_name.t; (* OCluster pool *)
   variant : Variant.t; (* e.g. "debian-10-ocaml-4.08" *)
-  base : base; (* Base image to use *)
+  base : Current_docker.Raw.Image.t; (* Base image to use *)
   vars : Ocaml_ci_api.Worker.Vars.t;
 }
 

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -48,6 +48,7 @@ val set_compiler_version :
   Ocaml_ci_api.Worker.Vars.t
 
 val get :
+  schedule:Current_cache.Schedule.t ->
   arch:Ocaml_version.arch ->
   label:string ->
   conn:Current_ocluster.Connection.t ->
@@ -55,51 +56,21 @@ val get :
   pool:Pool_name.t ->
   distro:string ->
   ocaml_version:Ocaml_version.t ->
-  host_base:Current_docker.Raw.Image.t Current.t ->
   opam_version:Opam_version.t ->
   lower_bound:bool ->
-  Current_docker.Raw.Image.t Current.t ->
+  string Current.t ->
   t list Current.t
 (** [get ~label ~builder ~variant ~host_base base] creates a [t] by getting the
     opam variables from [host_base] and returning [base] for subsequent builds. *)
 
-val pull :
+val peek :
   arch:Ocaml_version.arch ->
   schedule:Current_cache.Schedule.t ->
   builder:Builder.t ->
   distro:string ->
   ocaml_version:Ocaml_version.t ->
   opam_version:Opam_version.t ->
-  Current_docker.Raw.Image.t Current.t
-(** [pull ~schedule ~builder ~distro ~ocaml_version] pulls
+  string Current.t
+(** [peek ~schedule ~builder ~distro ~ocaml_version] pulls
     "ocaml/opam:\{distro\}-ocaml-\{version\}" on [schedule]. *)
 
-val get_macos :
-  arch:Ocaml_version.arch ->
-  label:string ->
-  builder:Builder.t ->
-  pool:Pool_name.t ->
-  distro:string ->
-  ocaml_version:Ocaml_version.t ->
-  opam_version:Opam_version.t ->
-  lower_bound:bool ->
-  [< `MacOS of string ] Current.t ->
-  t list Current.t
-(** [get_macos ~label ~builder ~variant ~host_base base] creates a [t] by
-    getting the opam variables from [host_base] and returning [base] for
-    subsequent builds. *)
-
-val get_freebsd :
-  arch:Ocaml_version.arch ->
-  label:string ->
-  builder:Builder.t ->
-  pool:Pool_name.t ->
-  distro:string ->
-  ocaml_version:Ocaml_version.t ->
-  opam_version:Opam_version.t ->
-  lower_bound:bool ->
-  [< `FreeBSD of string ] Current.t ->
-  t list Current.t
-(** [get_freebsd ~label ~builder ~variant ~host_base base] creates a [t] by
-    getting the opam variables from [host_base] and returning [base] for
-    subsequent builds. *)

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -50,6 +50,7 @@ val set_compiler_version :
 val get :
   arch:Ocaml_version.arch ->
   label:string ->
+  conn:Current_ocluster.Connection.t ->
   builder:Builder.t ->
   pool:Pool_name.t ->
   distro:string ->

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -48,7 +48,6 @@ val set_compiler_version :
   Ocaml_ci_api.Worker.Vars.t
 
 val get :
-  schedule:Current_cache.Schedule.t ->
   arch:Ocaml_version.arch ->
   label:string ->
   conn:Current_ocluster.Connection.t ->
@@ -62,6 +61,32 @@ val get :
   t list Current.t
 (** [get ~label ~builder ~variant ~host_base base] creates a [t] by getting the
     opam variables from [host_base] and returning [base] for subsequent builds. *)
+
+val get_local :
+  arch:Ocaml_version.arch ->
+  label:string ->
+  builder:Builder.t ->
+  pool:Pool_name.t ->
+  distro:string ->
+  ocaml_version:Ocaml_version.t ->
+  host_base:Current_docker.Raw.Image.t Current.t ->
+  opam_version:Opam_version.t ->
+  lower_bound:bool ->
+  Current_docker.Raw.Image.t Current.t ->
+  t list Current.t
+(** [get ~label ~builder ~variant ~host_base base] creates a [t] by getting the
+    opam variables from [host_base] and returning [base] for subsequent builds. *)
+
+val pull :
+  arch:Ocaml_version.arch ->
+  schedule:Current_cache.Schedule.t ->
+  builder:Builder.t ->
+  distro:string ->
+  ocaml_version:Ocaml_version.t ->
+  opam_version:Opam_version.t ->
+  Current_docker.Raw.Image.t Current.t
+(** [pull ~schedule ~builder ~distro ~ocaml_version] pulls
+    "ocaml/opam:\{distro\}-ocaml-\{version\}" on [schedule]. *)
 
 val peek :
   arch:Ocaml_version.arch ->

--- a/lib/platform.mli
+++ b/lib/platform.mli
@@ -89,4 +89,3 @@ val peek :
   string Current.t
 (** [peek ~schedule ~builder ~distro ~ocaml_version] pulls
     "ocaml/opam:\{distro\}-ocaml-\{version\}" on [schedule]. *)
-

--- a/lib/query.ml
+++ b/lib/query.ml
@@ -2,19 +2,12 @@ open Lwt.Infix
 module Worker = Ocaml_ci_api.Worker
 
 let ( >>!= ) = Lwt_result.bind
-
 let id = "opam-vars"
 
-type t = {
-  conn : Current_ocluster.Connection.t;
-}
+type t = { conn : Current_ocluster.Connection.t }
 
 module Key = struct
-  type t = {
-    variant : Variant.t;
-    lower_bound : bool;
-    pool : string;
-  }
+  type t = { variant : Variant.t; lower_bound : bool; pool : string }
   [@@deriving to_yojson]
 
   let digest t = Yojson.Safe.to_string (to_yojson t)
@@ -39,9 +32,7 @@ end
 
 (* This is needed iff the opam used isn't the image default opam. *)
 let prepare_image ~variant =
-  let opam =
-    "opam-" ^ Opam_version.to_string (Variant.opam_version variant)
-  in
+  let opam = "opam-" ^ Opam_version.to_string (Variant.opam_version variant) in
   let prefix =
     match Variant.os variant with
     | `macOS -> "~/local"
@@ -56,10 +47,10 @@ let prepare_image ~variant =
   (* XXX: don't overwrite default config? *)
   let opamrc = "" in
   let open Obuilder_spec in
-      [
-        run "%s -f %s/bin/%s %s/bin/opam" ln prefix opam prefix;
-        run "opam init --reinit%s -ni" opamrc;
-      ]
+  [
+    run "%s -f %s/bin/%s %s/bin/opam" ln prefix opam prefix;
+    run "opam init --reinit%s -ni" opamrc;
+  ]
 
 let opam_template arch =
   let arch = Option.value ~default:"%{arch}%" arch in
@@ -82,67 +73,76 @@ let tail ~buffer ~job build_job =
     | Error (`Capnp e) -> Lwt.return @@ Fmt.error_msg "%a" Capnp_rpc.Error.pp e
     | Ok ("", _) -> Lwt_result.return ()
     | Ok (data, next) ->
-      Buffer.add_string buffer data;
-      Current.Job.write job data;
-      aux next
-  in aux 0L
+        Buffer.add_string buffer data;
+        Current.Job.write job data;
+        aux next
+  in
+  aux 0L
 
 let run_job ~buffer ~job build_job =
   let on_cancel _ =
     Cluster_api.Job.cancel build_job >|= function
     | Ok () -> ()
-    | Error (`Capnp e) -> Current.Job.log job "Cancel failed: %a" Capnp_rpc.Error.pp e
+    | Error (`Capnp e) ->
+        Current.Job.log job "Cancel failed: %a" Capnp_rpc.Error.pp e
   in
   Current.Job.with_handler job ~on_cancel @@ fun () ->
   let result = Cluster_api.Job.result build_job in
   tail ~buffer ~job build_job >>!= fun () ->
   result >>= function
-  | Error (`Capnp e) -> Lwt_result.fail (`Msg (Fmt.to_to_string Capnp_rpc.Error.pp e))
+  | Error (`Capnp e) ->
+      Lwt_result.fail (`Msg (Fmt.to_to_string Capnp_rpc.Error.pp e))
   | Ok _ as x -> Lwt.return x
 
 let parse_output job build_job =
   let buffer = Buffer.create 1024 in
-  Capnp_rpc_lwt.Capability.with_ref build_job (run_job ~buffer ~job) >>!= fun (_ : string) ->
-    match Astring.String.cuts ~sep:"\n@@@OUTPUT\n" (Buffer.contents buffer) with
-    | [_; output; _; output2; _] ->
+  Capnp_rpc_lwt.Capability.with_ref build_job (run_job ~buffer ~job)
+  >>!= fun (_ : string) ->
+  match Astring.String.cuts ~sep:"\n@@@OUTPUT\n" (Buffer.contents buffer) with
+  | [ _; output; _; output2; _ ] ->
       Current.Job.log job "@[<v2>Result:@,%s,%s@]" output output2;
       Lwt_result.return (Some (output, output2))
-    | [_; rest ] when Astring.String.is_prefix ~affix:"@@@OUTPUT\n" rest -> Lwt_result.return None
-    | _ -> Lwt_result.fail (`Msg "Missing output from command\n")
+  | [ _; rest ] when Astring.String.is_prefix ~affix:"@@@OUTPUT\n" rest ->
+      Lwt_result.return None
+  | _ -> Lwt_result.fail (`Msg "Missing output from command\n")
 
 let set_personality ~variant =
   if Variant.arch variant |> Ocaml_version.arch_is_32bit then
-    [Obuilder_spec.shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]]
-  else
-    []
+    [ Obuilder_spec.shell [ "/usr/bin/linux32"; "/bin/sh"; "-c" ] ]
+  else []
 
-let run { conn } job { Key.variant; lower_bound; pool }
-    { Value.image } =
+let run { conn } job { Key.variant; lower_bound; pool } { Value.image } =
   let open Obuilder_spec in
   let arch =
     Variant.arch variant |> fun v ->
     if Ocaml_version.arch_is_32bit v then Some (Ocaml_version.to_opam_arch v)
     else None
   in
-  let spec = Obuilder_spec.stage ~from:image (
-    user_unix ~uid:1000 ~gid:1000 ::
-    set_personality ~variant @
-    prepare_image ~variant @ [
-      run "echo '@@@OUTPUT' && \
-           opam list -s --color=never --base --roots --all-versions ocaml-base-compiler ocaml-variants ocaml-system && \
-           echo '@@@OUTPUT'";
-      run "echo '@@@OUTPUT' && \
-           opam config expand '%s' && \
-           echo '@@@OUTPUT'" (opam_template arch)
-    ]) in
-  let spec_str = Fmt.to_to_string Obuilder_spec.pp (spec) in
+  let spec =
+    Obuilder_spec.stage ~from:image
+      ((user_unix ~uid:1000 ~gid:1000 :: set_personality ~variant)
+      @ prepare_image ~variant
+      @ [
+          run
+            "echo '@@@OUTPUT' && opam list -s --color=never --base --roots \
+             --all-versions ocaml-base-compiler ocaml-variants ocaml-system && \
+             echo '@@@OUTPUT'";
+          run "echo '@@@OUTPUT' && opam config expand '%s' && echo '@@@OUTPUT'"
+            (opam_template arch);
+        ])
+  in
+  let spec_str = Fmt.to_to_string Obuilder_spec.pp spec in
   let action = Cluster_api.Submission.obuilder_build spec_str in
-  let pool = Current_ocluster.Connection.pool ~job ~pool ~cache_hint:("opam-vars-" ^ image) ~action conn in
-  Current.Job.start_with ~pool job ~level:Current.Level.Mostly_harmless >>=
-  parse_output job >>!= fun s ->
-  let (ocaml_package, vars) = match s with
-    | Some (a, b) -> a, b 
-    | None -> assert false in
+  let pool =
+    Current_ocluster.Connection.pool ~job ~pool
+      ~cache_hint:("opam-vars-" ^ image) ~action conn
+  in
+  Current.Job.start_with ~pool job ~level:Current.Level.Mostly_harmless
+  >>= parse_output job
+  >>!= fun s ->
+  let ocaml_package, vars =
+    match s with Some (a, b) -> (a, b) | None -> assert false
+  in
   let ocaml_package = String.trim ocaml_package in
   let ocaml_package_name, ocaml_version =
     match Astring.String.cut ~sep:"." ocaml_package with
@@ -170,8 +170,7 @@ let run { conn } job { Key.variant; lower_bound; pool }
   | Ok vars -> Lwt_result.return { Outcome.vars; image }
 
 let pp f (key, value) =
-  Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant
-    value.Value.image
+  Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant value.Value.image
 
 let auto_cancel = false
 let latched = true

--- a/lib/query.ml
+++ b/lib/query.ml
@@ -1,0 +1,177 @@
+open Lwt.Infix
+module Worker = Ocaml_ci_api.Worker
+
+let ( >>!= ) = Lwt_result.bind
+
+let id = "opam-vars"
+
+type t = {
+  conn : Current_ocluster.Connection.t;
+}
+
+module Key = struct
+  type t = {
+    variant : Variant.t;
+    lower_bound : bool;
+    pool : string;
+  }
+  [@@deriving to_yojson]
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Value = struct
+  type t = { image : string; host_image : string } [@@deriving to_yojson]
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Outcome = struct
+  type t = { image : string; vars : Worker.Vars.t } [@@deriving yojson]
+
+  let marshal t = Yojson.Safe.to_string (to_yojson t)
+
+  let unmarshal s =
+    match of_yojson (Yojson.Safe.from_string s) with
+    | Ok x -> x
+    | Error e -> failwith e
+end
+
+(* This is needed iff the opam used isn't the image default opam. *)
+let prepare_image ~variant =
+  let opam =
+    "opam-" ^ Opam_version.to_string (Variant.opam_version variant)
+  in
+  let prefix =
+    match Variant.os variant with
+    | `macOS -> "~/local"
+    | `linux -> "/usr"
+    | `freeBSD -> "/usr/local"
+  in
+  let ln =
+    match Variant.os variant with
+    | `macOS -> "ln"
+    | `linux | `freeBSD -> "sudo ln"
+  in
+  (* XXX: don't overwrite default config? *)
+  let opamrc = "" in
+  let open Obuilder_spec in
+      [
+        run "%s -f %s/bin/%s %s/bin/opam" ln prefix opam prefix;
+        run "opam init --reinit%s -ni" opamrc;
+      ]
+
+let opam_template arch =
+  let arch = Option.value ~default:"%{arch}%" arch in
+  Fmt.str
+    {|
+  {
+    "arch": "%s",
+    "os": "%%{os}%%",
+    "os_family": "%%{os-family}%%",
+    "os_distribution": "%%{os-distribution}%%",
+    "os_version": "%%{os-version}%%",
+    "opam_version": "%%{opam-version}%%"
+  }
+|}
+    arch
+
+let tail ~buffer ~job build_job =
+  let rec aux start =
+    Cluster_api.Job.log build_job start >>= function
+    | Error (`Capnp e) -> Lwt.return @@ Fmt.error_msg "%a" Capnp_rpc.Error.pp e
+    | Ok ("", _) -> Lwt_result.return ()
+    | Ok (data, next) ->
+      Buffer.add_string buffer data;
+      Current.Job.write job data;
+      aux next
+  in aux 0L
+
+let run_job ~buffer ~job build_job =
+  let on_cancel _ =
+    Cluster_api.Job.cancel build_job >|= function
+    | Ok () -> ()
+    | Error (`Capnp e) -> Current.Job.log job "Cancel failed: %a" Capnp_rpc.Error.pp e
+  in
+  Current.Job.with_handler job ~on_cancel @@ fun () ->
+  let result = Cluster_api.Job.result build_job in
+  tail ~buffer ~job build_job >>!= fun () ->
+  result >>= function
+  | Error (`Capnp e) -> Lwt_result.fail (`Msg (Fmt.to_to_string Capnp_rpc.Error.pp e))
+  | Ok _ as x -> Lwt.return x
+
+let parse_output job build_job =
+  let buffer = Buffer.create 1024 in
+  Capnp_rpc_lwt.Capability.with_ref build_job (run_job ~buffer ~job) >>!= fun (_ : string) ->
+    match Astring.String.cuts ~sep:"\n@@@OUTPUT\n" (Buffer.contents buffer) with
+    | [_; output; _; output2; _] ->
+      Current.Job.log job "@[<v2>Result:@,%s,%s@]" output output2;
+      Lwt_result.return (Some (output, output2))
+    | [_; rest ] when Astring.String.is_prefix ~affix:"@@@OUTPUT\n" rest -> Lwt_result.return None
+    | _ -> Lwt_result.fail (`Msg "Missing output from command\n")
+
+let set_personality ~variant =
+  if Variant.arch variant |> Ocaml_version.arch_is_32bit then
+    [Obuilder_spec.shell ["/usr/bin/linux32"; "/bin/sh"; "-c"]]
+  else
+    []
+
+let run { conn } job { Key.variant; lower_bound; pool }
+    { Value.image; host_image } =
+  let open Obuilder_spec in
+  let arch =
+    Variant.arch variant |> fun v ->
+    if Ocaml_version.arch_is_32bit v then Some (Ocaml_version.to_opam_arch v)
+    else None
+  in
+  let spec = Obuilder_spec.stage ~from:host_image (
+    user_unix ~uid:1000 ~gid:1000 ::
+    set_personality ~variant @
+    prepare_image ~variant @ [
+      run "echo '@@@OUTPUT' && \
+           opam list -s --color=never --base --roots --all-versions ocaml-base-compiler ocaml-variants ocaml-system && \
+           echo '@@@OUTPUT'";
+      run "echo '@@@OUTPUT' && \
+           opam config expand '%s' && \
+           echo '@@@OUTPUT'" (opam_template arch)
+    ]) in
+  let spec_str = Fmt.to_to_string Obuilder_spec.pp (spec) in
+  let action = Cluster_api.Submission.obuilder_build spec_str in
+  let foo_pool = Current_ocluster.Connection.pool ~job ~pool ~cache_hint:"foo" ~action conn in
+  Current.Job.start_with ~pool:foo_pool job ~level:Current.Level.Mostly_harmless >>=
+  parse_output job >>!= fun s ->
+  let (ocaml_package, vars) = match s with
+    | Some (a, b) -> a, b 
+    | None -> assert false in
+  let ocaml_package = String.trim ocaml_package in
+  let ocaml_package_name, ocaml_version =
+    match Astring.String.cut ~sep:"." ocaml_package with
+    | Some (name, version) -> (name, version)
+    | None -> Fmt.failwith "Unexpected opam package name: %s" ocaml_package
+  in
+  let json =
+    match Yojson.Safe.from_string vars with
+    | `Assoc items ->
+        `Assoc
+          (("ocaml_package", `String ocaml_package_name)
+          :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
+          :: items)
+    | json ->
+        Fmt.failwith "Unexpected JSON: %a"
+          Yojson.Safe.(pretty_print ~std:true)
+          json
+  in
+  Current.Job.log job "@[<v2>Result:@,%a@]"
+    Yojson.Safe.(pretty_print ~std:true)
+    json;
+  match Worker.Vars.of_yojson json with
+  | Error msg -> Lwt_result.fail (`Msg msg)
+  | Ok vars -> Lwt_result.return { Outcome.vars; image }
+
+let pp f (key, value) =
+  Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant
+    value.Value.image
+
+let auto_cancel = false
+let latched = true

--- a/lib/query_local.ml
+++ b/lib/query_local.ml
@@ -1,0 +1,158 @@
+open Lwt.Infix
+module Raw = Current_docker.Raw
+module Worker = Ocaml_ci_api.Worker
+
+let ( >>!= ) = Lwt_result.bind
+
+let id = "opam-vars-local"
+
+type t = { pool : unit Current.Pool.t }
+
+module Key = struct
+  type t = {
+    docker_context : string option;
+    variant : Variant.t;
+    lower_bound : bool;
+  }
+  [@@deriving to_yojson]
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Value = struct
+  type t = { image : string; host_image : string } [@@deriving to_yojson]
+
+  let digest t = Yojson.Safe.to_string (to_yojson t)
+end
+
+module Outcome = struct
+  type t = { image : string; vars : Worker.Vars.t } [@@deriving yojson]
+
+  let marshal t = Yojson.Safe.to_string (to_yojson t)
+
+  let unmarshal s =
+    match of_yojson (Yojson.Safe.from_string s) with
+    | Ok x -> x
+    | Error e -> failwith e
+end
+
+(* This is needed iff the opam used isn't the image default opam. *)
+let prepare_image ~job ~docker_context ~tag variant image =
+  let opam =
+    "opam-" ^ Opam_version.to_string (Variant.opam_version variant)
+  in
+  let prefix =
+    match Variant.os variant with
+    | `macOS -> "~/local"
+    | `linux -> "/usr"
+    | `freeBSD -> "/usr/local"
+  in
+  let ln =
+    match Variant.os variant with
+    | `macOS -> "ln"
+    | `linux | `freeBSD -> "sudo ln"
+  in
+  (* XXX: don't overwrite default config? *)
+  let opamrc = "" in
+  let spec =
+    let open Obuilder_spec in
+    stage ~from:image
+      [
+        run "%s -f %s/bin/%s %s/bin/opam" ln prefix opam prefix;
+        run "opam init --reinit%s -ni" opamrc;
+      ]
+    |> Docker.dockerfile_of_spec ~buildkit:true ~os:`Unix
+  in
+  let cmd =
+    Raw.Cmd.docker ~docker_context [ "build"; "--pull"; "-t"; tag; "-" ]
+  in
+  Current.Process.exec ~stdin:spec ~cancellable:false ~job cmd >>!= fun () ->
+  Lwt_result.ok (Lwt.return tag)
+
+let opam_template arch =
+  let arch = Option.value ~default:"%{arch}%" arch in
+  Fmt.str
+    {|
+  {
+    "arch": "%s",
+    "os": "%%{os}%%",
+    "os_family": "%%{os-family}%%",
+    "os_distribution": "%%{os-distribution}%%",
+    "os_version": "%%{os-version}%%",
+    "opam_version": "%%{opam-version}%%"
+  }
+|}
+    arch
+
+let get_vars ~arch ~docker_context image =
+  Raw.Cmd.docker ~docker_context
+    [ "run"; "-i"; image; "opam"; "config"; "expand"; opam_template arch ]
+
+let get_ocaml_package ~docker_context image =
+  Raw.Cmd.docker ~docker_context
+    [
+      "run";
+      "-i";
+      image;
+      "opam";
+      "list";
+      "-s";
+      "--base";
+      "--roots";
+      "--all-versions";
+      "ocaml-base-compiler";
+      "ocaml-variants";
+      "ocaml-system";
+    ]
+
+let run { pool } job { Key.docker_context; variant; lower_bound }
+    { Value.image; host_image } =
+  Current.Job.start job ~pool ~level:Current.Level.Mostly_harmless
+  >>= fun () ->
+  let prep_image =
+    Fmt.str "ocurrent/ocaml-ci:%s" (Variant.docker_tag variant)
+  in
+  prepare_image ~job ~docker_context ~tag:prep_image variant host_image
+  >>!= fun host_image ->
+  let cmd = get_ocaml_package ~docker_context host_image in
+  Current.Process.check_output ~cancellable:false ~job cmd
+  >>!= fun ocaml_package ->
+  let ocaml_package = String.trim ocaml_package in
+  let ocaml_package_name, ocaml_version =
+    match Astring.String.cut ~sep:"." ocaml_package with
+    | Some (name, version) -> (name, version)
+    | None -> Fmt.failwith "Unexpected opam package name: %s" ocaml_package
+  in
+  let arch =
+    Variant.arch variant |> fun v ->
+    if Ocaml_version.arch_is_32bit v then Some (Ocaml_version.to_opam_arch v)
+    else None
+  in
+  let cmd = get_vars ~arch ~docker_context host_image in
+  Current.Process.check_output ~cancellable:false ~job cmd >>!= fun vars ->
+  let json =
+    match Yojson.Safe.from_string vars with
+    | `Assoc items ->
+        `Assoc
+          (("ocaml_package", `String ocaml_package_name)
+          :: ("ocaml_version", `String ocaml_version)
+          :: ("lower_bound", `Bool lower_bound)
+          :: items)
+    | json ->
+        Fmt.failwith "Unexpected JSON: %a"
+          Yojson.Safe.(pretty_print ~std:true)
+          json
+  in
+  Current.Job.log job "@[<v2>Result:@,%a@]"
+    Yojson.Safe.(pretty_print ~std:true)
+    json;
+  match Worker.Vars.of_yojson json with
+  | Error msg -> Lwt_result.fail (`Msg msg)
+  | Ok vars -> Lwt_result.return { Outcome.vars; image }
+
+let pp f (key, value) =
+  Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant
+    value.Value.image
+
+let auto_cancel = false
+let latched = true

--- a/lib/query_local.ml
+++ b/lib/query_local.ml
@@ -3,7 +3,6 @@ module Raw = Current_docker.Raw
 module Worker = Ocaml_ci_api.Worker
 
 let ( >>!= ) = Lwt_result.bind
-
 let id = "opam-vars-local"
 
 type t = { pool : unit Current.Pool.t }
@@ -38,9 +37,7 @@ end
 
 (* This is needed iff the opam used isn't the image default opam. *)
 let prepare_image ~job ~docker_context ~tag variant image =
-  let opam =
-    "opam-" ^ Opam_version.to_string (Variant.opam_version variant)
-  in
+  let opam = "opam-" ^ Opam_version.to_string (Variant.opam_version variant) in
   let prefix =
     match Variant.os variant with
     | `macOS -> "~/local"
@@ -107,8 +104,7 @@ let get_ocaml_package ~docker_context image =
 
 let run { pool } job { Key.docker_context; variant; lower_bound }
     { Value.image; host_image } =
-  Current.Job.start job ~pool ~level:Current.Level.Mostly_harmless
-  >>= fun () ->
+  Current.Job.start job ~pool ~level:Current.Level.Mostly_harmless >>= fun () ->
   let prep_image =
     Fmt.str "ocurrent/ocaml-ci:%s" (Variant.docker_tag variant)
   in
@@ -151,8 +147,7 @@ let run { pool } job { Key.docker_context; variant; lower_bound }
   | Ok vars -> Lwt_result.return { Outcome.vars; image }
 
 let pp f (key, value) =
-  Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant
-    value.Value.image
+  Fmt.pf f "opam vars of %a@,(%s)" Variant.pp key.Key.variant value.Value.image
 
 let auto_cancel = false
 let latched = true

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -247,7 +247,7 @@ let merge_lower_bound_platforms platforms =
   in
   upper_bound @ lower_bound
 
-let fetch_platforms ~include_macos ~include_freebsd () =
+let fetch_platforms ~conn ~include_macos ~include_freebsd () =
   let open Ocaml_ci in
   let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
   let v
@@ -299,7 +299,7 @@ let fetch_platforms ~include_macos ~include_freebsd () =
               Platform.pull ~arch:`X86_64 ~schedule ~builder ~distro
                 ~ocaml_version ~opam_version
         in
-        Platform.get ~arch ~label ~builder ~pool ~distro ~ocaml_version
+        Platform.get ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
           ~host_base ~opam_version ~lower_bound base
   in
   let v2_1 =

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -249,10 +249,14 @@ let merge_lower_bound_platforms platforms =
 
 let fetch_platforms ~query_uri ~include_macos ~include_freebsd () =
   let open Ocaml_ci in
-  let conn = Option.map (fun ur ->
-      let vat = Capnp_rpc_unix.client_only_vat () in
-      let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
-      (Current_ocluster.Connection.create sr)) query_uri in
+  let conn =
+    Option.map
+      (fun ur ->
+        let vat = Capnp_rpc_unix.client_only_vat () in
+        let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+        Current_ocluster.Connection.create sr)
+      query_uri
+  in
   let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
   let v
       {
@@ -265,9 +269,8 @@ let fetch_platforms ~query_uri ~include_macos ~include_freebsd () =
         opam_version;
         lower_bound;
       } =
-    match conn, distro with
-    | Some conn, "macos-homebrew"
-    | Some conn, "freebsd" ->
+    match (conn, distro) with
+    | Some conn, "macos-homebrew" | Some conn, "freebsd" ->
         (* FreeBSD and MacOS uses ZFS snapshots rather than docker images. *)
         let docker_image_name =
           Fmt.str "%s-ocaml-%d.%d" distro (OV.major ocaml_version)

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -247,8 +247,12 @@ let merge_lower_bound_platforms platforms =
   in
   upper_bound @ lower_bound
 
-let fetch_platforms ~conn ~include_macos ~include_freebsd () =
+let fetch_platforms ~query_uri ~include_macos ~include_freebsd () =
   let open Ocaml_ci in
+  let conn = Option.map (fun ur ->
+      let vat = Capnp_rpc_unix.client_only_vat () in
+      let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+      (Current_ocluster.Connection.create sr)) query_uri in
   let schedule = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) () in
   let v
       {
@@ -261,9 +265,9 @@ let fetch_platforms ~conn ~include_macos ~include_freebsd () =
         opam_version;
         lower_bound;
       } =
-    match distro with
-    | "macos-homebrew"
-    | "freebsd" ->
+    match conn, distro with
+    | Some conn, "macos-homebrew"
+    | Some conn, "freebsd" ->
         (* FreeBSD and MacOS uses ZFS snapshots rather than docker images. *)
         let docker_image_name =
           Fmt.str "%s-ocaml-%d.%d" distro (OV.major ocaml_version)
@@ -273,16 +277,31 @@ let fetch_platforms ~conn ~include_macos ~include_freebsd () =
           Fmt.str "%s %s" docker_image_name (OV.string_of_arch arch)
         in
         let base = Current.return ~label docker_image_name in
-        Platform.get ~schedule ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
+        Platform.get ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
           ~opam_version ~lower_bound base
-    | _ ->
-        (* All Linux distros *)
+    | Some conn, _ ->
+        (* All Linux distros via Ocluster *)
         let base =
           Platform.peek ~arch ~schedule ~builder ~distro ~ocaml_version
             ~opam_version
         in
-        Platform.get ~schedule ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
+        Platform.get ~arch ~label ~conn ~builder ~pool ~distro ~ocaml_version
           ~opam_version ~lower_bound base
+    | None, _ ->
+        (* All Linux distros via local opam vars *)
+        let base =
+          Platform.pull ~arch ~schedule ~builder ~distro ~ocaml_version
+            ~opam_version
+        in
+        let host_base =
+          match arch with
+          | `X86_64 -> base
+          | _ ->
+              Platform.pull ~arch:`X86_64 ~schedule ~builder ~distro
+                ~ocaml_version ~opam_version
+        in
+        Platform.get_local ~arch ~label ~builder ~pool ~distro ~ocaml_version
+          ~host_base ~opam_version ~lower_bound base
   in
   let v2_1 =
     platforms ~profile:platforms_profile `V2_1 ~include_macos ~include_freebsd

--- a/service/local.ml
+++ b/service/local.ml
@@ -12,7 +12,8 @@ let main () config mode repo solve_uri : ('a, [ `Msg of string ]) result =
   let solver = Ocaml_ci.Backend_solver.v solve_uri in
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine =
-    Current.Engine.create ~config (Pipeline.local_test ~solver ~query_uri:None repo)
+    Current.Engine.create ~config
+      (Pipeline.local_test ~solver ~query_uri:None repo)
   in
   let site =
     Current_web.Site.(v ~has_role:allow_all)

--- a/service/local.ml
+++ b/service/local.ml
@@ -10,15 +10,9 @@ let setup_log style_renderer default_level =
 let main () config mode repo solve_uri : ('a, [ `Msg of string ]) result =
   let open Ocaml_ci_service in
   let solver = Ocaml_ci.Backend_solver.v solve_uri in
-  let conn = match solve_uri with
-    | None -> assert false
-    | Some ur ->
-        let vat = Capnp_rpc_unix.client_only_vat () in
-        let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
-        (Current_ocluster.Connection.create sr) in
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine =
-    Current.Engine.create ~config (Pipeline.local_test ~conn ~solver repo)
+    Current.Engine.create ~config (Pipeline.local_test ~solver ~query_uri:None repo)
   in
   let site =
     Current_web.Site.(v ~has_role:allow_all)

--- a/service/local.ml
+++ b/service/local.ml
@@ -10,9 +10,15 @@ let setup_log style_renderer default_level =
 let main () config mode repo solve_uri : ('a, [ `Msg of string ]) result =
   let open Ocaml_ci_service in
   let solver = Ocaml_ci.Backend_solver.v solve_uri in
+  let conn = match solve_uri with
+    | None -> assert false
+    | Some ur ->
+        let vat = Capnp_rpc_unix.client_only_vat () in
+        let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+        (Current_ocluster.Connection.create sr) in
   let repo = Current_git.Local.v (Fpath.v repo) in
   let engine =
-    Current.Engine.create ~config (Pipeline.local_test ~solver repo)
+    Current.Engine.create ~config (Pipeline.local_test ~conn ~solver repo)
   in
   let site =
     Current_web.Site.(v ~has_role:allow_all)

--- a/service/main.ml
+++ b/service/main.ml
@@ -111,16 +111,10 @@ let run_capnp capnp_public_address capnp_listen_address =
       Lwt.return (vat, Some rpc_engine_resolver)
 
 let main () config mode app capnp_public_address capnp_listen_address
-    github_auth submission_uri solve_uri migrations :
+    github_auth submission_uri solve_uri query_uri migrations :
     ('a, [ `Msg of string ]) result =
   Lwt_main.run
     (let solver = Backend_solver.v solve_uri in
-     let conn = match solve_uri with
-       | None -> assert false
-       | Some ur ->
-           let vat = Capnp_rpc_unix.client_only_vat () in
-           let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
-           (Current_ocluster.Connection.create sr) in
      run_capnp capnp_public_address capnp_listen_address
      >>= fun (vat, rpc_engine_resolver) ->
      let ocluster =
@@ -128,7 +122,7 @@ let main () config mode app capnp_public_address capnp_listen_address
      in
      let engine =
        Current.Engine.create ~config
-         (Pipeline.v ?ocluster ~app ~conn ~solver ~migrations)
+         (Pipeline.v ?ocluster ~app ~solver ~query_uri ~migrations)
      in
      rpc_engine_resolver
      |> Option.iter (fun r ->
@@ -209,6 +203,16 @@ let submission_solver_service =
        ~docv:"FILE"
        [ "submission-solver-service" ]
 
+let submission_query_service =
+  Arg.value
+  @@ Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None
+  @@ Arg.info
+       ~doc:
+         "The query-solve.cap file which handles building opam variables for various platforms. The cap file could be the same as \
+          $(b,--submission-service) or omitted to use the local system."
+       ~docv:"FILE"
+       [ "submission-query-service" ]
+
 let cmd =
   let doc = "Build OCaml projects on GitHub" in
   let info = Cmd.info "ocaml-ci-service" ~doc ~envs:Conf.cmdliner_envs in
@@ -225,6 +229,7 @@ let cmd =
         $ Current_github.Auth.cmdliner
         $ submission_service
         $ submission_solver_service
+        $ submission_query_service
         $ migrations))
 
 let () = exit @@ Cmd.eval cmd

--- a/service/main.ml
+++ b/service/main.ml
@@ -115,6 +115,12 @@ let main () config mode app capnp_public_address capnp_listen_address
     ('a, [ `Msg of string ]) result =
   Lwt_main.run
     (let solver = Backend_solver.v solve_uri in
+     let conn = match solve_uri with
+       | None -> assert false
+       | Some ur ->
+           let vat = Capnp_rpc_unix.client_only_vat () in
+           let sr = Capnp_rpc_unix.Vat.import_exn vat ur in
+           (Current_ocluster.Connection.create sr) in
      run_capnp capnp_public_address capnp_listen_address
      >>= fun (vat, rpc_engine_resolver) ->
      let ocluster =
@@ -122,7 +128,7 @@ let main () config mode app capnp_public_address capnp_listen_address
      in
      let engine =
        Current.Engine.create ~config
-         (Pipeline.v ?ocluster ~app ~solver ~migrations)
+         (Pipeline.v ?ocluster ~app ~conn ~solver ~migrations)
      in
      rpc_engine_resolver
      |> Option.iter (fun r ->

--- a/service/main.ml
+++ b/service/main.ml
@@ -208,7 +208,8 @@ let submission_query_service =
   @@ Arg.opt Arg.(some Capnp_rpc_unix.sturdy_uri) None
   @@ Arg.info
        ~doc:
-         "The query-solve.cap file which handles building opam variables for various platforms. The cap file could be the same as \
+         "The query-solve.cap file which handles building opam variables for \
+          various platforms. The cap file could be the same as \
           $(b,--submission-service) or omitted to use the local system."
        ~docv:"FILE"
        [ "submission-query-service" ]

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -109,9 +109,9 @@ let set_active_refs ~repo refs default_ref =
   Index.set_active_refs ~repo refs (ref_from_commit default);
   xs
 
-let local_test ~conn ~solver repo () =
+let local_test ~query_uri ~solver repo () =
   let platforms =
-    Conf.fetch_platforms ~conn ~include_macos:false ~include_freebsd:false ()
+    Conf.fetch_platforms ~query_uri ~include_macos:false ~include_freebsd:false ()
   in
   let src = Git.Local.head_commit repo in
   let src_content = Repo_content.extract src in
@@ -124,12 +124,12 @@ let local_test ~conn ~solver repo () =
      let result = results |> summarise in
      Current_incr.const (result, None)
 
-let v ?ocluster ~app ~conn ~solver ~migrations () =
+let v ?ocluster ~app ~solver ~query_uri ~migrations () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
   in
   let platforms =
-    Conf.fetch_platforms ~conn ~include_macos:true ~include_freebsd:true ()
+    Conf.fetch_platforms ~query_uri ~include_macos:true ~include_freebsd:true ()
   in
   let migrations =
     match migrations with

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -111,7 +111,8 @@ let set_active_refs ~repo refs default_ref =
 
 let local_test ~query_uri ~solver repo () =
   let platforms =
-    Conf.fetch_platforms ~query_uri ~include_macos:false ~include_freebsd:false ()
+    Conf.fetch_platforms ~query_uri ~include_macos:false ~include_freebsd:false
+      ()
   in
   let src = Git.Local.head_commit repo in
   let src_content = Repo_content.extract src in

--- a/service/pipeline.ml
+++ b/service/pipeline.ml
@@ -5,9 +5,6 @@ module Git = Current_git
 module Github = Current_github
 module Docker = Current_docker.Default
 
-let platforms =
-  Conf.fetch_platforms ~include_macos:true ~include_freebsd:true ()
-
 (* Link for GitHub statuses. *)
 let url ~owner ~name ~hash ~gref =
   Uri.of_string
@@ -112,9 +109,9 @@ let set_active_refs ~repo refs default_ref =
   Index.set_active_refs ~repo refs (ref_from_commit default);
   xs
 
-let local_test ~solver repo () =
+let local_test ~conn ~solver repo () =
   let platforms =
-    Conf.fetch_platforms ~include_macos:false ~include_freebsd:false ()
+    Conf.fetch_platforms ~conn ~include_macos:false ~include_freebsd:false ()
   in
   let src = Git.Local.head_commit repo in
   let src_content = Repo_content.extract src in
@@ -127,9 +124,12 @@ let local_test ~solver repo () =
      let result = results |> summarise in
      Current_incr.const (result, None)
 
-let v ?ocluster ~app ~solver ~migrations () =
+let v ?ocluster ~app ~conn ~solver ~migrations () =
   let ocluster =
     Option.map (Cluster_build.config ~timeout:(Duration.of_hour 1)) ocluster
+  in
+  let platforms =
+    Conf.fetch_platforms ~conn ~include_macos:true ~include_freebsd:true ()
   in
   let migrations =
     match migrations with

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,7 +1,7 @@
 (** Pipeline for testing GitHub hosted repositories. *)
 
 val local_test :
-  conn:Current_ocluster.Connection.t ->
+  query_uri:Uri.t option ->
   solver:Ocaml_ci.Backend_solver.t ->
   Current_git.Local.t ->
   unit ->
@@ -12,8 +12,8 @@ val local_test :
 val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_github.App.t ->
-  conn:Current_ocluster.Connection.t ->
   solver:Ocaml_ci.Backend_solver.t ->
+  query_uri:Uri.t option ->
   migrations:string option ->
   unit ->
   unit Current.t

--- a/service/pipeline.mli
+++ b/service/pipeline.mli
@@ -1,6 +1,7 @@
 (** Pipeline for testing GitHub hosted repositories. *)
 
 val local_test :
+  conn:Current_ocluster.Connection.t ->
   solver:Ocaml_ci.Backend_solver.t ->
   Current_git.Local.t ->
   unit ->
@@ -11,6 +12,7 @@ val local_test :
 val v :
   ?ocluster:Cluster_api.Raw.Client.Submission.t Capnp_rpc_lwt.Sturdy_ref.t ->
   app:Current_github.App.t ->
+  conn:Current_ocluster.Connection.t ->
   solver:Ocaml_ci.Backend_solver.t ->
   migrations:string option ->
   unit ->

--- a/stack.yml.in
+++ b/stack.yml.in
@@ -10,7 +10,7 @@ secrets:
     external: true
   ocaml-ci-oauth:
     external: true
-  ocaml-ci-submission.cap:
+  ocaml-ci-submission-cap:
     external: true
   ocaml-ci-webhook-secret:
     external: true
@@ -20,7 +20,7 @@ secrets:
     external: true
   ocaml-ci-gitlab-webhook-secret:
     external: true
-  ocaml-ci-solver.cap:
+  ocaml-ci-solver-cap:
     external: true
 
 services:
@@ -36,8 +36,8 @@ services:
       --confirm above-average
       --confirm-auto-release 120
       --capnp-public-address=tcp:ocaml.ci.dev:8102 --capnp-listen-address=tcp:0.0.0.0:9000
-      --submission-service /run/secrets/ocaml-ci-submission.cap
-      --submission-solver-service /run/secrets/ocaml-ci-solver.cap 
+      --submission-service /run/secrets/ocaml-ci-submission-cap
+      --submission-solver-service /run/secrets/ocaml-ci-solver-cap 
       --migration-path /migrations
       --verbosity info
       --github-account-allowlist GITHUB_ORGANISATIONS
@@ -55,8 +55,8 @@ services:
     secrets:
       - 'ocaml-ci-oauth'
       - 'ocaml-ci-github-key'
-      - 'ocaml-ci-submission.cap'
-      - 'ocaml-ci-solver.cap'
+      - 'ocaml-ci-submission-cap'
+      - 'ocaml-ci-solver-cap'
       - 'ocaml-ci-webhook-secret'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'
@@ -69,8 +69,8 @@ services:
       --gitlab-oauth /run/secrets/ocaml-ci-gitlab-oauth
       --gitlab-token-file /run/secrets/ocaml-ci-gitlab-token
       --gitlab-webhook-secret-file /run/secrets/ocaml-ci-gitlab-webhook-secret
-      --submission-service /run/secrets/ocaml-ci-submission.cap
-      --submission-solver-service /run/secrets/ocaml-ci-solver.cap
+      --submission-service /run/secrets/ocaml-ci-submission-cap
+      --submission-solver-service /run/secrets/ocaml-ci-solver-cap
       --capnp-public-address=tcp:ocaml.ci.dev:8202
       --capnp-listen-address=tcp:0.0.0.0:9000
       --migration-path /migrations
@@ -89,8 +89,8 @@ services:
     secrets:
       - 'ocaml-ci-gitlab-oauth'
       - 'ocaml-ci-gitlab-token'
-      - 'ocaml-ci-submission.cap'
-      - 'ocaml-ci-solver.cap'
+      - 'ocaml-ci-submission-cap'
+      - 'ocaml-ci-solver-cap'
       - 'ocaml-ci-gitlab-webhook-secret'
     sysctls:
       - 'net.ipv4.tcp_keepalive_time=60'


### PR DESCRIPTION
This PR moves the opam-vars process from the local machine to OCluster while leaving the ability to use the original local process for testing.

Solving using OCluster is enabled with the new command-line option `--submission-query-service`, which takes a `.cap` file. The `.cap` can be the same as that used for the solver service or for submitting builds.

Closes https://github.com/ocurrent/ocaml-ci/issues/947