### PR TITLE
Update opam command line for opam 2.2

### DIFF
--- a/lib/query.ml
+++ b/lib/query.ml
@@ -124,9 +124,9 @@ let run { conn } job { Key.variant; lower_bound; pool } { Value.image } =
       @ prepare_image ~variant
       @ [
           run
-            "echo '@@@OUTPUT' && opam list -s --color=never --base --roots \
-             --all-versions ocaml-base-compiler ocaml-variants ocaml-system && \
-             echo '@@@OUTPUT'";
+            "echo '@@@OUTPUT' && opam list -s --color=never --installed \
+             ocaml-base-compiler ocaml-variants ocaml-system --column package \
+             && echo '@@@OUTPUT'";
           run "echo '@@@OUTPUT' && opam config expand '%s' && echo '@@@OUTPUT'"
             (opam_template arch);
         ])

--- a/lib/query_local.ml
+++ b/lib/query_local.ml
@@ -94,12 +94,13 @@ let get_ocaml_package ~docker_context image =
       "opam";
       "list";
       "-s";
-      "--base";
-      "--roots";
-      "--all-versions";
+      "--color=never";
+      "--installed";
       "ocaml-base-compiler";
       "ocaml-variants";
       "ocaml-system";
+      "--column";
+      "package";
     ]
 
 let run { pool } job { Key.docker_context; variant; lower_bound }

--- a/stack.yml.in
+++ b/stack.yml.in
@@ -38,6 +38,7 @@ services:
       --capnp-public-address=tcp:ocaml.ci.dev:8102 --capnp-listen-address=tcp:0.0.0.0:9000
       --submission-service /run/secrets/ocaml-ci-submission-cap
       --submission-solver-service /run/secrets/ocaml-ci-solver-cap 
+      --submission-query-service /run/secrets/ocaml-ci-submission-cap
       --migration-path /migrations
       --verbosity info
       --github-account-allowlist GITHUB_ORGANISATIONS


### PR DESCRIPTION
See https://github.com/ocaml/opam/issues/6136.

This is the proper fix for the workaround on `live-engine`.