### PR TITLE
Add ocaml-semver to github-organisations

### DIFF
--- a/deploy-data/github-organisations.txt
+++ b/deploy-data/github-organisations.txt
@@ -103,3 +103,4 @@ koonwen
 lubegasimon
 punchagan
 ahrefs
+ocaml-semver


### PR DESCRIPTION
Thanks for providing such a great CI for OCaml projects!

I would love to enable it for https://github.com/ocaml-semver/ocaml-api-watch !