### PR TITLE
Revert PR #993 now Dune 3.17.1 has been released

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -71,26 +71,6 @@ let pin_opam_files ~network ?work_dir groups =
         |> run ~network "%s";
       ]
 
-let create_dune_project_files ~network ?dune_work_dir groups =
-  if groups = [] then []
-  else
-    let open Obuilder_spec in
-    [
-      groups
-      |> List.map (fun (dir, _, _) ->
-             let dir =
-               Option.map
-                 (fun work_dir -> Fpath.( // ) work_dir dir)
-                 dune_work_dir
-               |> Option.value ~default:dir
-             in
-             Printf.sprintf "echo '(lang dune 3.0)' > %s"
-               (Filename.quote
-                  (Fpath.to_string (Fpath.( // ) dir (Fpath.v "dune-project")))))
-      |> String.concat " && \n"
-      |> run ~network "%s";
-    ]
-
 (* Get the packages directly in "." *)
 let rec get_root_opam_packages = function
   | [] -> []
@@ -170,11 +150,6 @@ let install_project_deps ~opam_version ~opam_files ~selection =
     | `linux -> None
     | `freeBSD -> None
   in
-  let dune_work_dir =
-    match Variant.os selection.Selection.variant with
-    | `macOS | `linux | `freeBSD | `openBSD -> work_dir
-    | `windows -> Some (Fpath.v "/cygdrive/c/Users/opam/src")
-  in
   (* XXX: don't overwrite default config? *)
   let opamrc = "" in
   let opam_version_str = Opam_version.to_string opam_version in
@@ -226,7 +201,6 @@ let install_project_deps ~opam_version ~opam_files ~selection =
         commit commit;
     ]
   @ pin_opam_files ~network ?work_dir groups
-  @ create_dune_project_files ~network ?dune_work_dir groups
   @ [
       env "DEPS" non_root_pkgs;
       env "CI" "true";

--- a/test/service/test_spec.ml
+++ b/test/service/test_spec.ml
@@ -15,8 +15,6 @@ let expected_macos_spec =
  (copy (src bondi.opam) (dst ./src/./))
  (run (network host)
       (shell "opam pin add -yn bondi.dev './src/./'"))
- (run (network host)
-      (shell "echo '(lang dune 3.0)' > './src/./dune-project'"))
  (env DEPS "base-bigarray.base base-threads.base base-unix.base dune.3.6.0 menhir.20220210 menhirLib.20220210 menhirSdk.20220210 ocaml.4.14.0 ocaml-base-compiler.4.14.0 ocaml-config.2 ocaml-options-vanilla.1")
  (env CI true)
  (env OCAMLCI true)
@@ -52,8 +50,6 @@ let expected_linux_spec =
  (copy (src bondi.opam) (dst ./))
  (run (network host)
       (shell "opam pin add -yn bondi.dev './'"))
- (run (network host)
-      (shell "echo '(lang dune 3.0)' > './dune-project'"))
  (env DEPS "base-bigarray.base base-threads.base base-unix.base dune.3.6.0 menhir.20220210 menhirLib.20220210 menhirSdk.20220210 ocaml.4.14.0 ocaml-base-compiler.4.14.0 ocaml-config.2 ocaml-options-vanilla.1")
  (env CI true)
  (env OCAMLCI true)
@@ -61,40 +57,6 @@ let expected_linux_spec =
       (network host)
       (shell "opam update --depexts && opam install --cli=2.1 --depext-only -y bondi.dev $DEPS"))
  (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
-      (network host)
-      (shell "opam install $DEPS"))
- (copy (src .) (dst /src))
- (run (shell "opam exec -- dune build @install @check @runtest && rm -rf _build"))
-)
-|}
-
-(* Expected obuilder spec for windows server 2022 build of bondi. *)
-let expected_windows_spec =
-  {|
-((from windows-server-2022-amd64-ocaml-4.14)
- (comment windows-server-2022-4.14.0_opam-2.3)
- (user (uid 1000) (gid 1000)) (env CLICOLOR_FORCE 1)
- (env OPAMCOLOR always)
- (workdir /src)
- (run (shell "sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam"))
- (run (shell "opam init --reinit -ni"))
- (run (shell "uname -rs && opam exec -- ocaml -version && opam --version"))
- (workdir /src)
- (run (shell "sudo chown opam /src"))
- (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
-      (network host) (shell "cd ~/opam-repository && (git cat-file -e f207d3f018d642d1fcddb2c118e7fa8e65f4e366 || git fetch origin master) && git reset -q --hard f207d3f018d642d1fcddb2c118e7fa8e65f4e366 && git log --no-decorate -n1 --oneline && opam update -u"))
- (copy (src bondi.opam) (dst ./))
- (run (network host) (shell "opam pin add -yn bondi.dev './'"))
- (run (network host)
-      (shell "echo '(lang dune 3.0)' > './dune-project'"))
- (env DEPS "arch-x86_64.1 base-bigarray.base base-threads.base base-unix.base conf-mingw-w64-gcc-x86_64.1 dune.3.17.0 flexdll.0.43 host-arch-x86_64.1 host-system-mingw.1 menhir.20240715 menhirCST.20240715 menhirLib.20240715 menhirSdk.20240715 mingw-w64-shims.0.2.0 ocaml.4.14.2 ocaml-base-compiler.4.14.2 ocaml-config.3 ocaml-env-mingw64.1 ocaml-options-vanilla.1 system-mingw.1")
- (env CI true)
- (env OCAMLCI true)
- (run (cache (opam-archives (target /home/opam/.opam/download-cache)))
-      (network host)
-      (shell "opam update --depexts && opam install --cli=2.3 --depext-only -y bondi.dev $DEPS"))
- (run (cache
-      (opam-archives (target /home/opam/.opam/download-cache)))
       (network host)
       (shell "opam install $DEPS"))
  (copy (src .) (dst /src))
@@ -183,56 +145,8 @@ let test_linux_spec () =
   in
   Alcotest.(check sexp) "validate" expected actual
 
-let test_windows_spec () =
-  let open Ocaml_ci in
-  let expected = Sexplib__Pre_sexp.of_string expected_windows_spec in
-  let variant =
-    Variant.v ~arch:`X86_64 ~distro:"windows-server-2022"
-      ~ocaml_version:Ocaml_version.Releases.v4_14_0 ~opam_version:`V2_3
-    |> Result.get_ok
-  in
-  let actual =
-    Opam_build.spec ~base:"windows-server-2022-amd64-ocaml-4.14"
-      ~opam_version:`V2_3 ~opam_files:[ "bondi.opam" ]
-      ~selection:
-        Selection.
-          {
-            variant;
-            packages =
-              [
-                "bondi.dev";
-                "arch-x86_64.1";
-                "base-bigarray.base";
-                "base-threads.base";
-                "base-unix.base";
-                "conf-mingw-w64-gcc-x86_64.1";
-                "dune.3.17.0";
-                "flexdll.0.43";
-                "host-arch-x86_64.1";
-                "host-system-mingw.1";
-                "menhir.20240715";
-                "menhirCST.20240715";
-                "menhirLib.20240715";
-                "menhirSdk.20240715";
-                "mingw-w64-shims.0.2.0";
-                "ocaml.4.14.2";
-                "ocaml-base-compiler.4.14.2";
-                "ocaml-config.3";
-                "ocaml-env-mingw64.1";
-                "ocaml-options-vanilla.1";
-                "system-mingw.1";
-              ];
-            only_packages = [];
-            commit = "f207d3f018d642d1fcddb2c118e7fa8e65f4e366";
-            lower_bound = false;
-          }
-    |> Obuilder_spec.sexp_of_t
-  in
-  Alcotest.(check sexp) "validate" expected actual
-
 let tests =
   [
     Alcotest.test_case "macos" `Quick test_macos_spec;
     Alcotest.test_case "linux" `Quick test_linux_spec;
-    Alcotest.test_case "windows" `Quick test_windows_spec;
   ]


### PR DESCRIPTION
This reverts commit 265d71208c8f5482d562a3afeae1ab735c2aa984, reversing changes made to cc9bac43c99dedc42a48b4dc1982157f87a98132.  This is possible now Dune 3.17.1 has been released.

Closes https://github.com/ocurrent/ocaml-ci/issues/994