### PR TITLE
Constrain dream-httpaf version

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -137,6 +137,7 @@
   (capnp-rpc-unix (>= 1.2))
   (crunch (and (>= 3.2.0) :build))
   (dream (= 1.0.0~alpha6))
+  (dream-httpaf (= 1.0.0~alpha3))
   (fmt (>= 0.8.9))
   (logs (>= 0.7.0))
   (lwt (>= 5.7.0))

--- a/ocaml-ci-web.opam
+++ b/ocaml-ci-web.opam
@@ -19,6 +19,7 @@ depends: [
   "capnp-rpc-unix" {>= "1.2"}
   "crunch" {>= "3.2.0" & build}
   "dream" {= "1.0.0~alpha6"}
+  "dream-httpaf" {= "1.0.0~alpha3"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "lwt" {>= "5.7.0"}


### PR DESCRIPTION
OCaml-CI is failing its own CI tests on OCaml 5.3 beta. On 5.3, OCaml-CI installs dream-httpaf version `1.0.0~alpha4` rather than `1.0.0~alpha3` as on other platforms.  With dream-httpaf `1.0.0~alpha4`, dream `1.0.0~alpha6` (already constrained) fails to build.

```
#=== ERROR while compiling dream.1.0.0~alpha6 =================================#
# context     2.3.0 | linux/x86_64 | ocaml-base-compiler.5.3.0~beta1 | file:///home/opam/opam-repository
# path        ~/.opam/5.3~beta1/.opam-switch/build/dream.1.0.0~alpha6
# command     ~/.opam/5.3~beta1/bin/dune build -p dream -j 31
# exit-code   1
# env-file    ~/.opam/log/dream-1-77d9dc.env
# output-file ~/.opam/log/dream-1-77d9dc.out
### output ###
# File "src/http/dune", line 21, characters 2-32:
# 21 |   dream-httpaf.dream-websocketaf
#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# Error: Library "dream-httpaf.dream-websocketaf" not found.
# -> required by library "dream.http" in _build/default/src/http
# -> required by _build/default/META.dream
# -> required by _build/install/default/lib/dream/META
# -> required by _build/default/dream.install
# -> required by alias install
```

The solver is unable to find a solution if the constraint on dream is moved to the current version (alpha8).

Ideally, the constraints would be removed, but this workaround allows OCaml-CI to pass the CI test and unblock the backlog of PRs.