### PR TITLE
monorepo: look for debian-13 compatible worker

### DIFF
--- a/lib/opam_monorepo.ml
+++ b/lib/opam_monorepo.ml
@@ -153,11 +153,11 @@ let selection ~info:(lock_file_path, lock_file) ~platforms ~solve =
     ]
   in
   solve ~root_pkgs ~pinned_pkgs:[] ~platforms >>= fun workers ->
-  (* Choose a linux distro (Debian-12 is the default) to run the build on. *)
+  (* Choose a linux distro (Debian-13 is the default) to run the build on. *)
   let debian_selection =
     List.find_opt
       (fun worker ->
-        String.equal (Variant.distro worker.Selection.variant) "debian-12"
+        String.equal (Variant.distro worker.Selection.variant) "debian-13"
         && Variant.arch worker.Selection.variant == `X86_64)
       workers
   in
@@ -170,7 +170,7 @@ let selection ~info:(lock_file_path, lock_file) ~platforms ~solve =
         { lock_file_path; selection; lock_file_version; switch_type }
   | None ->
       Lwt.return_error
-        (`Msg "No debian-12 solution found for this monorepo build.")
+        (`Msg "No debian-13 solution found for this monorepo build.")
 
 let initialize_switch ~network = function
   | Base -> []


### PR DESCRIPTION
Nowadays debian-13 workers have a much broader diversity of OCaml versions.This leads some monorepo builds (which look for a debian-12 worker) to fail: https://ocaml.ci.dev/github/tarides/opam-monorepo/commit/a91f67c8f1d982b5a7e0e06efe442234b0ab2f18/variant/%28analysis%29#L1257-1257