### PR TITLE
Add solo5 to github-organisations.txt

### DIFF
--- a/deploy-data/github-organisations.txt
+++ b/deploy-data/github-organisations.txt
@@ -113,3 +113,4 @@ umd-cmsc330
 mbarbin
 johnwhitington
 dra27
+solo5


### PR DESCRIPTION
It would be great if you could allow the solo5 organization to use ocaml-ci. Thanks a lot.