### PR TITLE
Platform matrix trim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     m4 \
     pkg-config \
     libcapnp-dev
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 4ae3c774e4a07972d8dc71ead3a8294779f6dada && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 94c943996066236b7203cad4027522be61e33f45 && opam update
 COPY --chown=opam --link ocaml-ci.opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -12,7 +12,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libsqlite3-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 4ae3c774e4a07972d8dc71ead3a8294779f6dada && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 94c943996066236b7203cad4027522be61e33f45 && opam update
 COPY --chown=opam --link ocaml-ci.opam ocaml-ci-gitlab.opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 4ae3c774e4a07972d8dc71ead3a8294779f6dada && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 94c943996066236b7203cad4027522be61e33f45 && opam update
 COPY --chown=opam --link ocaml-ci-api.opam ocaml-ci-web.opam ocaml-ci.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/dune-project
+++ b/dune-project
@@ -37,11 +37,11 @@
   solver-service-api
   solver-worker
   (bos (>= 0.2.1))
-  (dockerfile-opam (>= 8.2.1))
+  (dockerfile-opam (>= 8.3.6))
   (capnp-rpc-unix (>= 1.2))
   (cohttp-lwt-unix (>= 5.1.0))
   (logs (>= 0.7.0))
-  (ocaml-version (>= 3.6.1))
+  (ocaml-version (>= 4.1.0))
   (omigrate (>= 0.3.2))
   (opam-0install (>= 0.4.3))
   (ppx_deriving (>= 5.1))
@@ -75,11 +75,11 @@
   (capnp-rpc-unix (>= 1.2))
   (cmdliner (>= 1.1.1))
   (conf-libev (<> :os "win32"))
-  (dockerfile-opam (>= 8.2.1))
+  (dockerfile-opam (>= 8.3.6))
   (fmt (>= 0.8.9))
   (logs (>= 0.7.0))
   (mirage-crypto-rng (>= 0.8.7))
-  (ocaml-version (>= 3.6.1))
+  (ocaml-version (>= 4.1.0))
   (opam-0install (>= 0.4.3))
   (ppx_deriving (>= 5.1))
   (ppx_deriving_yojson (>= 3.7))
@@ -117,7 +117,7 @@
   ocaml-ci-api
   current_rpc
   (capnp-rpc-unix (>= 1.2))
-  (dockerfile (>= 8.2.1))
+  (dockerfile (>= 8.3.6))
   (fmt (>= 0.8.9))
   (logs (>= 0.7.0))
   (timedesc (>= 0.9.0))))

--- a/lib/pipeline.ml
+++ b/lib/pipeline.ml
@@ -73,27 +73,6 @@ let get_job_id x =
   let+ md = Current.Analysis.metadata x in
   match md with Some { Current.Metadata.job_id; _ } -> job_id | None -> None
 
-(* Identifies "selections" on which we don't want to run the CI, e.g., due to
-   platforms unsupported by some required package. *)
-let excluded_selection =
-  let is_debian_12_x86_32 (v : Variant.t) =
-    match (Variant.distro v, Variant.arch v) with
-    | "debian-12", `I386 -> true
-    | _ -> false
-  in
-  let is_conf_capnproto package_name =
-    match Astring.String.cut ~sep:"." package_name with
-    | Some ("conf-capnproto", _) -> true
-    | _ -> false
-  in
-  fun (s : Selection.t) ->
-    (* TODO Remove when (a) we stop building on 32bit Debian 12 or (b) Debian
-       bookworm backports the need fix to capnproto to support large files on 32
-       bit systems.
-
-       See https://github.com/ocurrent/ocaml-ci/issues/931 *)
-    is_debian_12_x86_32 s.variant && List.exists is_conf_capnproto s.packages
-
 let docker_specs ~analysis =
   let+ analysis = Current.state ~hidden:true analysis in
   match analysis with
@@ -110,9 +89,6 @@ let docker_specs ~analysis =
             ~analysis (`Lint `Fmt)
           :: Spec.opam_monorepo builds
       | `Opam_build selections ->
-          let included_selections =
-            List.filter (fun s -> not (excluded_selection s)) selections
-          in
           (* For lower-bound, take only the lowest version of OCaml that has a solution *)
           let selections =
             let lower_bound, other =
@@ -121,7 +97,7 @@ let docker_specs ~analysis =
                   s.Selection.lower_bound
                   && Variant.arch s.Selection.variant == `X86_64
                   && Variant.os s.Selection.variant == `linux)
-                included_selections
+                selections
             in
             take_lowest_bound_selection lower_bound @ other
           in

--- a/ocaml-ci-client.opam
+++ b/ocaml-ci-client.opam
@@ -13,7 +13,7 @@ depends: [
   "ocaml-ci-api"
   "current_rpc"
   "capnp-rpc-unix" {>= "1.2"}
-  "dockerfile" {>= "8.2.1"}
+  "dockerfile" {>= "8.3.6"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "timedesc" {>= "0.9.0"}

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -28,11 +28,11 @@ depends: [
   "capnp-rpc-unix" {>= "1.2"}
   "cmdliner" {>= "1.1.1"}
   "conf-libev" {os != "win32"}
-  "dockerfile-opam" {>= "8.2.1"}
+  "dockerfile-opam" {>= "8.3.6"}
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "mirage-crypto-rng" {>= "0.8.7"}
-  "ocaml-version" {>= "3.6.1"}
+  "ocaml-version" {>= "4.1.0"}
   "opam-0install" {>= "0.4.3"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.7"}

--- a/ocaml-ci.opam
+++ b/ocaml-ci.opam
@@ -21,11 +21,11 @@ depends: [
   "solver-service-api"
   "solver-worker"
   "bos" {>= "0.2.1"}
-  "dockerfile-opam" {>= "8.2.1"}
+  "dockerfile-opam" {>= "8.3.6"}
   "capnp-rpc-unix" {>= "1.2"}
   "cohttp-lwt-unix" {>= "5.1.0"}
   "logs" {>= "0.7.0"}
-  "ocaml-version" {>= "3.6.1"}
+  "ocaml-version" {>= "4.1.0"}
   "omigrate" {>= "0.3.2"}
   "opam-0install" {>= "0.4.3"}
   "ppx_deriving" {>= "5.1"}

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -227,7 +227,9 @@ let platforms ~profile ~include_macos ~include_freebsd ~include_windows
         |> List.append (if include_windows then windows_distros else [])
       in
       (* The first one in this list is used for lint actions *)
-      let ovs = List.rev OV.Releases.significant @ OV.Releases.unreleased_betas in
+      let ovs =
+        List.rev OV.Releases.significant @ OV.Releases.unreleased_betas
+      in
       let releases = List.map make_release ovs in
       let lower_bounds = List.map (make_release ~lower_bound:true) ovs in
       releases @ lower_bounds @ distros

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -195,10 +195,12 @@ let platforms ~profile ~include_macos ~include_freebsd ~include_windows
     let tag = DD.tag_of_distro (distro :> DD.t) in
     let f ov =
       if distro = master_distro then
+        let arches =
+          DD.distro_arches ov (distro :> DD.t)
+          |> List.filter (function `I386 | `Aarch32 -> false | _ -> true)
+        in
         v label tag (OV.with_variant ov (Some "flambda"))
-        :: List.map
-             (fun arch -> v ~arch label tag ov)
-             (DD.distro_arches ov (distro :> DD.t))
+        :: List.map (fun arch -> v ~arch label tag ov) arches
       else [ v label tag ov ]
     in
     List.fold_left (fun l ov -> f ov @ l) [] default_compilers
@@ -225,7 +227,7 @@ let platforms ~profile ~include_macos ~include_freebsd ~include_windows
         |> List.append (if include_windows then windows_distros else [])
       in
       (* The first one in this list is used for lint actions *)
-      let ovs = List.rev OV.Releases.recent @ OV.Releases.unreleased_betas in
+      let ovs = List.rev OV.Releases.significant @ OV.Releases.unreleased_betas in
       let releases = List.map make_release ovs in
       let lower_bounds = List.map (make_release ~lower_bound:true) ovs in
       releases @ lower_bounds @ distros
@@ -236,7 +238,7 @@ let platforms ~profile ~include_macos ~include_freebsd ~include_windows
       [ v (OV.to_string ov) distro ov ]
   | `Minimal ->
       let[@warning "-8"] (latest :: previous :: _) =
-        List.rev OV.Releases.recent
+        List.rev OV.Releases.significant
       in
       List.map make_release [ latest; previous ]
 

--- a/test/service/test_conf.ml
+++ b/test/service/test_conf.ml
@@ -31,14 +31,14 @@ let test_platforms () =
       (true, (to_tag (`Debian `Stable), OVR.latest, `Aarch64));
       (true, (to_tag (`Debian `Stable), OVR.latest, `S390x));
       (true, (to_tag (`Debian `Stable), OVR.latest, `Ppc64le));
-      (true, (to_tag (`Debian `Stable), OVR.latest, `I386));
-      (true, (to_tag (`Debian `Stable), OVR.latest, `Aarch32));
+      (false, (to_tag (`Debian `Stable), OVR.latest, `I386));
+      (false, (to_tag (`Debian `Stable), OVR.latest, `Aarch32));
       (true, (to_tag (`Debian `Stable), OVR.v4_14, `X86_64));
       (true, (to_tag (`Debian `Stable), OVR.v4_14, `Aarch64));
       (true, (to_tag (`Debian `Stable), OVR.v4_14, `S390x));
       (true, (to_tag (`Debian `Stable), OVR.v4_14, `Ppc64le));
-      (true, (to_tag (`Debian `Stable), OVR.v4_14, `I386));
-      (true, (to_tag (`Debian `Stable), OVR.v4_14, `Aarch32));
+      (false, (to_tag (`Debian `Stable), OVR.v4_14, `I386));
+      (false, (to_tag (`Debian `Stable), OVR.v4_14, `Aarch32));
       (true, (to_tag (`Fedora `Latest), OVR.latest, `X86_64));
       (true, (to_tag (`Fedora `Latest), OVR.v4_14, `X86_64));
       (true, (to_tag (`Alpine `Latest), OVR.latest, `X86_64));


### PR DESCRIPTION
- Build only `OV.Releases.significant` rather than `OV.Releases.recent`
- Drop i386 and Aarch32 builds