### PR TITLE
Remove opam 2.0 support

### DIFF
--- a/lib/opam_build.ml
+++ b/lib/opam_build.ml
@@ -182,9 +182,6 @@ let install_project_deps ~opam_version ~opam_files ~selection =
   let non_root_pkgs = String.concat " " non_root_pkgs in
   let opam_depext =
     match opam_version with
-    | `V2_0 ->
-        run ~network ~cache "opam depext --update -y %s $DEPS"
-          compatible_root_pkgs
     | `V2_1 ->
         run ~network ~cache
           "opam update --depexts && opam install --cli=2.1 --depext-only -y %s \

--- a/lib/opam_version.ml
+++ b/lib/opam_version.ml
@@ -1,27 +1,15 @@
-type t = [ `V2_0 | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ]
-[@@deriving ord, yojson, eq]
+type t = [ `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ] [@@deriving ord, yojson, eq]
 
 let to_string = function
-  | `V2_0 -> "2.0"
   | `V2_1 -> "2.1"
   | `V2_2 -> "2.2"
   | `V2_3 -> "2.3"
   | `V2_4 -> "2.4"
   | `V2_5 -> "2.5"
 
-let to_string_with_patch = function
-  | `V2_0 -> "2.0.10"
-  | `V2_1 -> "2.1.6"
-  | `V2_2 -> "2.2.1"
-  | `V2_3 -> "2.3.0"
-  | `V2_4 -> "2.4.1"
-  | `V2_5 -> "2.5.0"
-
 let pp = Fmt.of_to_string to_string
-let default = `V2_0
 
 let of_string = function
-  | "2.0" -> Ok `V2_0
   | "2.1" -> Ok `V2_1
   | "2.2" -> Ok `V2_2
   | "2.3" -> Ok `V2_3

--- a/lib/opam_version.mli
+++ b/lib/opam_version.mli
@@ -1,10 +1,7 @@
 (** Opam versions supported. *)
 
-type t = [ `V2_0 | `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ]
-[@@deriving ord, yojson, eq]
+type t = [ `V2_1 | `V2_2 | `V2_3 | `V2_4 | `V2_5 ] [@@deriving ord, yojson, eq]
 
 val pp : t Fmt.t
 val to_string : t -> string
-val to_string_with_patch : t -> string
-val default : t
 val of_string : string -> (t, [ `Msg of string ]) result

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -81,9 +81,7 @@ let pp f t =
     (match t.arch with
     | `X86_64 -> ""
     | a -> "_" ^ Ocaml_version.to_opam_arch a)
-    (match t.opam_version with
-    | `V2_0 -> ""
-    | v -> "_opam-" ^ Opam_version.to_string v)
+    ("_opam-" ^ Opam_version.to_string t.opam_version)
 
 let to_string = Fmt.str "%a" pp
 let err_variant id = failwith ("internal error: unknown variant " ^ id)
@@ -101,7 +99,7 @@ let opam_version_of_string v =
 let of_string s =
   let s, opam_version =
     match Astring.String.cut ~rev:true ~sep:"_opam-" s with
-    | None -> (s, Opam_version.default)
+    | None -> err_opam_version s
     | Some (s, v) -> (s, opam_version_of_string v)
   in
   let id, arch =

--- a/test/service/test_variant.ml
+++ b/test/service/test_variant.ml
@@ -11,11 +11,7 @@ let test_error s =
 
 let test_simple () =
   List.iter test_one
-    [
-      "debian-11-4.13_x86_32_opam-2.1";
-      "debian-11-4.13_opam-2.1";
-      "debian-11-4.13_x86_32";
-    ]
+    [ "debian-11-4.13_x86_32_opam-2.1"; "debian-11-4.13_opam-2.1" ]
 
 let test_errors () =
   List.iter test_error


### PR DESCRIPTION
The service config pins V2_5 for every build platform and lint.ml
uses V2_2; nothing constructs V2_0, so the V2_0 cases in Variant.pp,
the opam_build depext match, and Opam_version.of_string were never
executed.

Variant.pp also drops the V2_0-as-empty-suffix special case, so all
variants now print with an explicit _opam-X.X suffix. That in turn
makes two more pieces of API redundant:

- Opam_version.default -- referenced only by Variant.of_string as a
  fallback for un-suffixed variant strings. Now that nothing emits
  un-suffixed strings, of_string rejects them outright.
- Opam_version.to_string_with_patch -- declared in the .mli, called
  nowhere.

Prepares for ocurrent/docker-base-images#342 and upstream
ocurrent/ocaml-dockerfile#262 to remove the opam-2.0 base images.
Deploy-safe in any order: V2_5 platforms pull the same _opam-2.5 tag
before and after, and V2_0 was already unused.