### PR TITLE
Pass os to docker peek so Windows images resolve

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,13 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pkg-config \
     libcapnp-dev
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 94c943996066236b7203cad4027522be61e33f45 && opam update
+RUN opam pin add -yn current.dev         https://github.com/ocurrent/ocurrent.git#peek-os-param && \
+    opam pin add -yn current_web.dev     https://github.com/ocurrent/ocurrent.git#peek-os-param && \
+    opam pin add -yn current_git.dev     https://github.com/ocurrent/ocurrent.git#peek-os-param && \
+    opam pin add -yn current_github.dev  https://github.com/ocurrent/ocurrent.git#peek-os-param && \
+    opam pin add -yn current_docker.dev  https://github.com/ocurrent/ocurrent.git#peek-os-param && \
+    opam pin add -yn current_slack.dev   https://github.com/ocurrent/ocurrent.git#peek-os-param && \
+    opam pin add -yn current_rpc.dev     https://github.com/ocurrent/ocurrent.git#peek-os-param
 COPY --chown=opam --link ocaml-ci.opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/lib/builder.ml
+++ b/lib/builder.ml
@@ -16,9 +16,9 @@ let pull { docker_context; pool = _; build_timeout = _ } ~arch tag =
   in
   Current_docker.Raw.pull ?arch tag ~docker_context
 
-let peek { docker_context; pool = _; build_timeout = _ } ~arch tag =
+let peek { docker_context; pool = _; build_timeout = _ } ~os ~arch tag =
   let arch = Ocaml_version.to_docker_arch arch in
-  Current_docker.Raw.peek ~arch tag ~docker_context
+  Current_docker.Raw.peek ~os ~arch tag ~docker_context
 
 let run { docker_context; pool; build_timeout = _ } ~args img =
   Current_docker.Raw.run img ~docker_context ~pool ~args

--- a/lib/builder.mli
+++ b/lib/builder.mli
@@ -24,11 +24,12 @@ val pull :
 
 val peek :
   t ->
+  os:string ->
   arch:Ocaml_version.arch ->
   string ->
   schedule:Current_cache.Schedule.t ->
   string Current.Primitive.t
-(** Docker [peek] an image for [arch] with a scheduled check. *)
+(** Docker [peek] an image for [os]/[arch] with a scheduled check. *)
 
 val run :
   t ->

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -152,10 +152,11 @@ let peek ~arch ~schedule ~builder ~distro ~ocaml_version ~opam_version =
   match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
+      let os = match Variant.os variant with `windows -> "windows" | _ -> "linux" in
       let archl = Ocaml_version.to_opam_arch arch in
       let opam_version = Opam_version.to_string opam_version in
       Current.component "peek@,%s %a %s opam-%s" distro Ocaml_version.pp
         ocaml_version archl opam_version
       |> let> () = Current.return () in
          let tag = Variant.docker_tag variant in
-         Builder.peek ~schedule ~arch builder @@ "ocaml/opam:" ^ tag
+         Builder.peek ~os ~schedule ~arch builder @@ "ocaml/opam:" ^ tag


### PR DESCRIPTION
Forwards the OS through to `Current_docker.Raw.peek` so the manifest filter matches Windows entries (e.g. `ocaml/opam:windows-server-mingw-ltsc2025-ocaml-5.4`).

Depends on ocurrent/ocurrent#472 — Dockerfile pins to that branch in the meantime; drop the pin once it's released.