### PR TITLE
Refresh for ocaml-version 4.1.3 / current 0.7.5 and fix @fmt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,14 +14,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     m4 \
     pkg-config \
     libcapnp-dev
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 94c943996066236b7203cad4027522be61e33f45 && opam update
-RUN opam pin add -yn current.dev         https://github.com/ocurrent/ocurrent.git#peek-os-param && \
-    opam pin add -yn current_web.dev     https://github.com/ocurrent/ocurrent.git#peek-os-param && \
-    opam pin add -yn current_git.dev     https://github.com/ocurrent/ocurrent.git#peek-os-param && \
-    opam pin add -yn current_github.dev  https://github.com/ocurrent/ocurrent.git#peek-os-param && \
-    opam pin add -yn current_docker.dev  https://github.com/ocurrent/ocurrent.git#peek-os-param && \
-    opam pin add -yn current_slack.dev   https://github.com/ocurrent/ocurrent.git#peek-os-param && \
-    opam pin add -yn current_rpc.dev     https://github.com/ocurrent/ocurrent.git#peek-os-param
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard ceed23f9d33677f323a62325ad42599d14f46b98 && opam update
 COPY --chown=opam --link ocaml-ci.opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -13,7 +13,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libssl-dev \
     m4 \
     pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 94c943996066236b7203cad4027522be61e33f45 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard ceed23f9d33677f323a62325ad42599d14f46b98 && opam update
 COPY --chown=opam --link ocaml-ci-api.opam ocaml-ci-web.opam ocaml-ci.opam /src/
 WORKDIR /src
 ENV OPAMSOLVERTIMEOUT=900

--- a/dune-project
+++ b/dune-project
@@ -14,7 +14,8 @@
  (depends
   (ocaml (>= 4.14))
   dune
-  current_rpc
+  (current_rpc (>= 0.7.5))
+  (solver-service-api (>= dev))
   (capnp (>= 3.4.0))
   (capnp-rpc-lwt (>= 1.2))
   (ppx_deriving (>= 5.1))
@@ -27,11 +28,11 @@
   (ocaml (>= 4.14))
   dune
   ocaml-ci-api
-  current
-  current_docker
+  (current (>= 0.7.5))
+  (current_docker (>= 0.7.5))
   current_ocluster
-  current_rpc
-  obuilder-spec
+  (current_rpc (>= 0.7.5))
+  (obuilder-spec (>= 0.7.0))
   ocluster-api
   solver-service
   solver-service-api
@@ -41,7 +42,7 @@
   (capnp-rpc-unix (>= 1.2))
   (cohttp-lwt-unix (>= 5.1.0))
   (logs (>= 0.7.0))
-  (ocaml-version (>= 4.1.0))
+  (ocaml-version (>= 4.1.3))
   (omigrate (>= 0.3.2))
   (opam-0install (>= 0.4.3))
   (ppx_deriving (>= 5.1))
@@ -58,15 +59,16 @@
   (ocaml (>= 4.14))
   dune
   ocaml-ci-api
-  current_git
-  current_github
-  current_docker
-  current_web
-  current_rpc
+  (current (>= 0.7.5))
+  (current_git (>= 0.7.5))
+  (current_github (>= 0.7.5))
+  (current_docker (>= 0.7.5))
+  (current_web (>= 0.7.5))
+  (current_rpc (>= 0.7.5))
   current_ocluster
   solver-service
   ocluster-api
-  obuilder-spec
+  (obuilder-spec (>= 0.7.0))
   (alcotest (and (>= 1.7.0) :with-test))
   (alcotest-lwt (and (>= 1.7.0) :with-test))
   (ansi (>= 0.6.0))
@@ -79,7 +81,7 @@
   (fmt (>= 0.8.9))
   (logs (>= 0.7.0))
   (mirage-crypto-rng (>= 0.8.7))
-  (ocaml-version (>= 4.1.0))
+  (ocaml-version (>= 4.1.3))
   (opam-0install (>= 0.4.3))
   (ppx_deriving (>= 5.1))
   (ppx_deriving_yojson (>= 3.7))
@@ -94,7 +96,7 @@
   (ocaml (>= 4.14))
   dune
   ocaml-ci-api
-  current_rpc
+  (current_rpc (>= 0.7.5))
   (capnp-rpc-unix (>= 1.2))
   (dockerfile (>= 8.3.6))
   (fmt (>= 0.8.9))

--- a/lib/build_info.ml
+++ b/lib/build_info.ml
@@ -22,7 +22,7 @@ let experimental_variant s =
     | None -> false
     | Some v ->
         Variant.os v = `windows
-        || Astring.String.equal "openbsd-77-amd64" (Variant.distro v)
+        || Astring.String.equal "openbsd-78-amd64" (Variant.distro v)
 
 (** Like [experimental_variant], but takes strings for when a [build_info]
     record is unavailable.
@@ -33,5 +33,5 @@ let experimental_variant_str s =
   Astring.String.(
     is_prefix ~affix:Variant.lower_bound_label s
     || is_prefix ~affix:Variant.opam_label s
-    || is_prefix ~affix:"openbsd-77-amd64" s
+    || is_prefix ~affix:"openbsd-78-amd64" s
     || is_prefix ~affix:"windows" s)

--- a/lib/platform.ml
+++ b/lib/platform.ml
@@ -152,7 +152,9 @@ let peek ~arch ~schedule ~builder ~distro ~ocaml_version ~opam_version =
   match Variant.v ~arch ~distro ~ocaml_version ~opam_version with
   | Error (`Msg m) -> Current.fail m
   | Ok variant ->
-      let os = match Variant.os variant with `windows -> "windows" | _ -> "linux" in
+      let os =
+        match Variant.os variant with `windows -> "windows" | _ -> "linux"
+      in
       let archl = Ocaml_version.to_opam_arch arch in
       let opam_version = Opam_version.to_string opam_version in
       Current.component "peek@,%s %a %s opam-%s" distro Ocaml_version.pp

--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -42,7 +42,7 @@ type t = {
 let macos_distributions = [ "macos-homebrew" ]
 let freebsd_distributions = [ "freebsd-15.0" ]
 let windows_distributions = [ "windows-server-mingw-ltsc2025" ]
-let openbsd_distributions = [ "openbsd-77-amd64" ]
+let openbsd_distributions = [ "openbsd-78-amd64" ]
 
 let os { distro; _ } =
   if List.exists (String.equal distro) macos_distributions then `macOS

--- a/ocaml-ci-api.opam
+++ b/ocaml-ci-api.opam
@@ -10,7 +10,8 @@ bug-reports: "https://github.com/ocurrent/ocaml-ci/issues"
 depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.20"}
-  "current_rpc"
+  "current_rpc" {>= "0.7.5"}
+  "solver-service-api" {>= "dev"}
   "capnp" {>= "3.4.0"}
   "capnp-rpc-lwt" {>= "1.2"}
   "ppx_deriving" {>= "5.1"}

--- a/ocaml-ci-client.opam
+++ b/ocaml-ci-client.opam
@@ -11,7 +11,7 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.20"}
   "ocaml-ci-api"
-  "current_rpc"
+  "current_rpc" {>= "0.7.5"}
   "capnp-rpc-unix" {>= "1.2"}
   "dockerfile" {>= "8.3.6"}
   "fmt" {>= "0.8.9"}

--- a/ocaml-ci-service.opam
+++ b/ocaml-ci-service.opam
@@ -11,15 +11,16 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.20"}
   "ocaml-ci-api"
-  "current_git"
-  "current_github"
-  "current_docker"
-  "current_web"
-  "current_rpc"
+  "current" {>= "0.7.5"}
+  "current_git" {>= "0.7.5"}
+  "current_github" {>= "0.7.5"}
+  "current_docker" {>= "0.7.5"}
+  "current_web" {>= "0.7.5"}
+  "current_rpc" {>= "0.7.5"}
   "current_ocluster"
   "solver-service"
   "ocluster-api"
-  "obuilder-spec"
+  "obuilder-spec" {>= "0.7.0"}
   "alcotest" {>= "1.7.0" & with-test}
   "alcotest-lwt" {>= "1.7.0" & with-test}
   "ansi" {>= "0.6.0"}
@@ -32,7 +33,7 @@ depends: [
   "fmt" {>= "0.8.9"}
   "logs" {>= "0.7.0"}
   "mirage-crypto-rng" {>= "0.8.7"}
-  "ocaml-version" {>= "4.1.0"}
+  "ocaml-version" {>= "4.1.3"}
   "opam-0install" {>= "0.4.3"}
   "ppx_deriving" {>= "5.1"}
   "ppx_deriving_yojson" {>= "3.7"}

--- a/ocaml-ci.opam
+++ b/ocaml-ci.opam
@@ -11,11 +11,11 @@ depends: [
   "ocaml" {>= "4.14"}
   "dune" {>= "3.20"}
   "ocaml-ci-api"
-  "current"
-  "current_docker"
+  "current" {>= "0.7.5"}
+  "current_docker" {>= "0.7.5"}
   "current_ocluster"
-  "current_rpc"
-  "obuilder-spec"
+  "current_rpc" {>= "0.7.5"}
+  "obuilder-spec" {>= "0.7.0"}
   "ocluster-api"
   "solver-service"
   "solver-service-api"
@@ -25,7 +25,7 @@ depends: [
   "capnp-rpc-unix" {>= "1.2"}
   "cohttp-lwt-unix" {>= "5.1.0"}
   "logs" {>= "0.7.0"}
-  "ocaml-version" {>= "4.1.0"}
+  "ocaml-version" {>= "4.1.3"}
   "omigrate" {>= "0.3.2"}
   "opam-0install" {>= "0.4.3"}
   "ppx_deriving" {>= "5.1"}
@@ -52,7 +52,7 @@ build: [
 dev-repo: "git+https://github.com/ocurrent/ocaml-ci.git"
 x-maintenance-intent: ["(latest)"]
 pin-depends: [
-  ["solver-service.dev" "git+https://github.com/ocurrent/solver-service.git#98c04705bdd5511094364ba2549c1192bdd94c1c"]
-  ["solver-service-api.dev" "git+https://github.com/ocurrent/solver-service.git#98c04705bdd5511094364ba2549c1192bdd94c1c"]
-  ["solver-worker.dev" "git+https://github.com/ocurrent/solver-service.git#98c04705bdd5511094364ba2549c1192bdd94c1c"]
+  ["solver-service.dev" "git+https://github.com/ocurrent/solver-service.git#ca9ef7e8a4097ed56ef6e2d9befa7ca0dc5997cb"]
+  ["solver-service-api.dev" "git+https://github.com/ocurrent/solver-service.git#ca9ef7e8a4097ed56ef6e2d9befa7ca0dc5997cb"]
+  ["solver-worker.dev" "git+https://github.com/ocurrent/solver-service.git#ca9ef7e8a4097ed56ef6e2d9befa7ca0dc5997cb"]
 ]

--- a/ocaml-ci.opam.template
+++ b/ocaml-ci.opam.template
@@ -1,5 +1,5 @@
 pin-depends: [
-  ["solver-service.dev" "git+https://github.com/ocurrent/solver-service.git#98c04705bdd5511094364ba2549c1192bdd94c1c"]
-  ["solver-service-api.dev" "git+https://github.com/ocurrent/solver-service.git#98c04705bdd5511094364ba2549c1192bdd94c1c"]
-  ["solver-worker.dev" "git+https://github.com/ocurrent/solver-service.git#98c04705bdd5511094364ba2549c1192bdd94c1c"]
+  ["solver-service.dev" "git+https://github.com/ocurrent/solver-service.git#ca9ef7e8a4097ed56ef6e2d9befa7ca0dc5997cb"]
+  ["solver-service-api.dev" "git+https://github.com/ocurrent/solver-service.git#ca9ef7e8a4097ed56ef6e2d9befa7ca0dc5997cb"]
+  ["solver-worker.dev" "git+https://github.com/ocurrent/solver-service.git#ca9ef7e8a4097ed56ef6e2d9befa7ca0dc5997cb"]
 ]

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -97,7 +97,7 @@ let openbsd_distros =
         label = "openbsd";
         builder = Builders.local;
         pool = `OpenBSD_amd64;
-        distro = "openbsd-77-amd64";
+        distro = "openbsd-78-amd64";
         ocaml_version;
         arch = `X86_64;
         opam_version = `V2_5;
@@ -311,7 +311,7 @@ let fetch_platforms ~query_uri ~include_macos ~include_freebsd ~include_windows
       } =
     match (conn, distro) with
     | Some conn, "macos-homebrew"
-    | Some conn, "openbsd-77-amd64"
+    | Some conn, "openbsd-78-amd64"
     | Some conn, "freebsd-15.0" ->
         (* FreeBSD and MacOS uses ZFS snapshots rather than docker images. *)
         let docker_image_name =

--- a/test/service/test_conf.ml
+++ b/test/service/test_conf.ml
@@ -64,8 +64,8 @@ let test_macos_platforms () =
   in
   let exists =
     [
-      (true, ("macos-homebrew", OVR.v5_4, `Aarch64));
-      (true, ("macos-homebrew", OVR.v5_4, `X86_64));
+      (true, ("macos-homebrew", OVR.v5_5, `Aarch64));
+      (true, ("macos-homebrew", OVR.v5_5, `X86_64));
       (true, ("macos-homebrew", OVR.v4_14, `Aarch64));
       (true, ("macos-homebrew", OVR.v4_14, `X86_64));
     ]


### PR DESCRIPTION
CI on master is red and the Docker image no longer builds; this brings both back to green.

- **ocaml-version 4.1.3** moves `Releases.latest` to 5.5.0, so the default compilers built on every platform are now 4.14.4 + 5.5. Update the macOS conf test to expect 5.5, and require `ocaml-version >= 4.1.3`.
- **Drop the `ocurrent#peek-os-param` pins.** That branch was merged and released as `current*` 0.7.5 (which ships `peek … ?os:string`), now published in opam-repository. The Dockerfile pinned a branch that no longer exists, breaking the image build. Removing the pins lets opam resolve the released 0.7.5, and the deps now require `current* >= 0.7.5` so the `?os` parameter is guaranteed.
- Bump the `Dockerfile` / `Dockerfile.web` opam-repository pin to current master (where 0.7.5 lives).
- **OpenBSD 7.7 -> 7.8**: `openbsd-77-amd64` -> `openbsd-78-amd64`.
- Wrap an over-long line in `lib/platform.ml` that `dune build @fmt` rejects.
