### PR TITLE
Use builtin-0install solver in Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pkg-config \
     libcapnp-dev
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard ceed23f9d33677f323a62325ad42599d14f46b98 && opam update
+RUN opam option --global solver=builtin-0install
 COPY --chown=opam --link ocaml-ci.opam ocaml-ci-service.opam ocaml-ci-api.opam /src/
 WORKDIR /src
-ENV OPAMSOLVERTIMEOUT=900
 RUN --mount=type=cache,target=/home/opam/.opam/download-cache,sharing=locked,uid=1000,gid=1000 \
     opam install -y --deps-only .
 ADD --chown=opam . .

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -14,9 +14,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     m4 \
     pkg-config
 RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard ceed23f9d33677f323a62325ad42599d14f46b98 && opam update
+RUN opam option --global solver=builtin-0install
 COPY --chown=opam --link ocaml-ci-api.opam ocaml-ci-web.opam ocaml-ci.opam /src/
 WORKDIR /src
-ENV OPAMSOLVERTIMEOUT=900
 RUN --mount=type=cache,target=/home/opam/.opam/download-cache,sharing=locked,uid=1000,gid=1000 \
     opam install -y --deps-only .
 ADD --chown=opam . .


### PR DESCRIPTION
The default opam solver can take over 15 minutes to solve ocaml-ci's dependencies, overrunning `OPAMSOLVERTIMEOUT` and failing the image build. Switch to the builtin 0install solver (`opam option --global solver=builtin-0install`), which solves quickly, and drop the `OPAMSOLVERTIMEOUT=900` workaround in both `Dockerfile` and `Dockerfile.web`.

Running live.