### PR TITLE
FreeBSD: bump distro from 15.0 to 15.1

### DIFF
--- a/lib/variant.ml
+++ b/lib/variant.ml
@@ -40,7 +40,7 @@ type t = {
 [@@deriving yojson, ord, eq]
 
 let macos_distributions = [ "macos-homebrew" ]
-let freebsd_distributions = [ "freebsd-15.0" ]
+let freebsd_distributions = [ "freebsd-15.1" ]
 let windows_distributions = [ "windows-server-mingw-ltsc2025" ]
 let openbsd_distributions = [ "openbsd-78-amd64" ]
 

--- a/service/conf.ml
+++ b/service/conf.ml
@@ -126,10 +126,10 @@ let freebsd_distros =
   List.map
     (fun ocaml_version ->
       {
-        label = "freebsd-15.0";
+        label = "freebsd-15.1";
         builder = Builders.local;
         pool = `FreeBSD_x86_64;
-        distro = "freebsd-15.0";
+        distro = "freebsd-15.1";
         ocaml_version;
         arch = `X86_64;
         opam_version = `V2_5;
@@ -312,7 +312,7 @@ let fetch_platforms ~query_uri ~include_macos ~include_freebsd ~include_windows
     match (conn, distro) with
     | Some conn, "macos-homebrew"
     | Some conn, "openbsd-78-amd64"
-    | Some conn, "freebsd-15.0" ->
+    | Some conn, "freebsd-15.1" ->
         (* FreeBSD and MacOS uses ZFS snapshots rather than docker images. *)
         let docker_image_name =
           Fmt.str "%s-ocaml-%d.%d" distro (OV.major ocaml_version)


### PR DESCRIPTION
Bumps the FreeBSD distro from `freebsd-15.0` to `freebsd-15.1` (the worker now runs FreeBSD 15.1 with base images rebuilt as `freebsd-15.1-ocaml-<ver>`). Builds clean; tests don't assert the FreeBSD version.