### PR TITLE
index: use GLOB not LIKE in get_full_hash to hit the PK index

### DIFF
--- a/lib/index.ml
+++ b/lib/index.ml
@@ -129,9 +129,15 @@ let db =
          "SELECT variant, job_id FROM ci_build_index WHERE owner = ? AND name \
           = ? AND hash = ?"
      and full_hash =
+       (* GLOB (not LIKE) so the query uses the primary-key index: LIKE is
+          case-insensitive by default, which disables the index and forces a
+          full scan of the owner/name partition of ci_build_index on every
+          call. GLOB is case-sensitive and its prefix pattern compiles to an
+          indexed range seek. Git hashes are lowercase hex, so
+          case-sensitivity is a non-issue. *)
        Sqlite3.prepare db
          "SELECT DISTINCT hash FROM ci_build_index WHERE owner = ? AND name = \
-          ? AND hash LIKE ?"
+          ? AND hash GLOB ?"
      and record_job_summary =
        Sqlite3.prepare db
          "INSERT INTO ci_build_summary (owner, name, hash, gref, build_number, \
@@ -639,7 +645,7 @@ let get_full_hash ~owner ~name short_hash =
   if is_valid_hash short_hash then
     match
       Db.query t.full_hash
-        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "%") ]
+        Sqlite3.Data.[ TEXT owner; TEXT name; TEXT (short_hash ^ "*") ]
     with
     | [] -> Error `Unknown
     | [ Sqlite3.Data.[ TEXT hash ] ] -> Ok hash


### PR DESCRIPTION
`get_full_hash` ran `SELECT DISTINCT hash FROM ci_build_index WHERE owner = ? AND name = ? AND hash LIKE ?`.

SQLite's `LIKE` is **case-insensitive by default**, which disables the index for the `hash` term — so the query seeks to the `owner/name` prefix and then **scans every row under it**. Because `get_full_hash` runs on every commit page and the SQLite call is synchronous on the single Lwt thread, a crawl of the web UI (which drives these lookups via RPC into the engine) saturates a core and makes the engine unresponsive.

`GLOB` is case-sensitive, so its prefix pattern compiles to an **indexed range seek** (`hash>? AND hash<?`). Git hashes are lowercase hex, so case-sensitivity is a non-issue and the prefix / `Ambiguous` semantics are unchanged.

Same root cause and fix as ocurrent/opam-repo-ci#482, where it was profiled with `perf` (96.9% of engine CPU in libsqlite3) and measured on the production index: **968 ms scan → 1 ms seek (~900×)**.