### PR TITLE
web: flush the initial log chunk so short/queued logs render

### DIFF
--- a/web-ui/view/step.ml
+++ b/web-ui/view/step.ml
@@ -264,6 +264,12 @@ module Make (M : Git_forge_intf.Forge) = struct
       (fun response_stream ->
         Dream.write response_stream header >>= fun () ->
         Dream.write response_stream (Ansi.process ansi data) >>= fun () ->
+        (* Flush the initial chunk now: the loop below blocks in
+           [Current_rpc.Job.log] waiting for more output, and for a short log
+           (e.g. a queued job with only its header) the buffered header+chunk
+           would otherwise never be flushed until the job produces more, leaving
+           the page blank while queued. *)
+        Dream.flush response_stream >>= fun () ->
         let rec loop next =
           Current_rpc.Job.log job ~start:next >>= function
           | Ok ("", _) ->
@@ -718,6 +724,12 @@ module Make (M : Git_forge_intf.Forge) = struct
         Dream.write response_stream header >>= fun () ->
         let data' = process_logs data in
         Dream.write response_stream data' >>= fun () ->
+        (* Flush the initial chunk now: the loop below blocks in
+           [Current_rpc.Job.log] waiting for more output, and for a short log
+           (e.g. a queued job with only its header) the buffered header+chunk
+           would otherwise never be flushed until the job produces more, leaving
+           the page blank while queued. *)
+        Dream.flush response_stream >>= fun () ->
         let rec loop next =
           Current_rpc.Job.log job ~start:next >>= function
           | Ok ("", _) ->


### PR DESCRIPTION
## Problem

The step-log viewer renders a **blank log frame** for a job that is queued
(waiting for a worker) whenever its log is short — e.g. a job whose only
output so far is the header lines (`New job:`, `Waiting for worker…`). You see
the page header and an empty log area, and content only appears once the job
starts producing more output.

## Cause

`web-ui/view/step.ml` streams the log with `Dream.stream`: it writes the page
`header` and the initial log `chunk`, then enters a loop that calls
`Current_rpc.Job.log ~start:next` for more data. The only `Dream.flush` is
*inside* that loop, reached only after a fetch returns more data.

For a running job with nothing past the current offset, `Current_rpc.Job.log`
blocks in `wait_for_log_data` until the job writes more. So the initial
`header + chunk` sits unflushed in the response buffer indefinitely. Large logs
happen to overflow the socket buffer and auto-flush (which is why this was
never noticed); short logs (a few hundred bytes) stay buffered → blank frame.

## Fix

Flush the initial chunk explicitly before entering the loop, in both `show`
and `show_raw`. One extra `Dream.flush` per stream.

Verified against a live deployment: queued jobs with only their header now
render immediately instead of showing a blank frame.
